### PR TITLE
Phase H: top-flight European leagues (Bundesliga / La Liga / Serie A / Ligue 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ plugin.py         ← orchestrator: refresh + apply + show_status + scheduler
 sources/          ← per-sport adapters (drop-in extensible)
   base.py         ← GameRow + SportSource interface
   ncaaf.py        ← NCAA Football via CFBD
-  soccer.py       ← EPL/EFL Championship/UCL via Football-Data.org + Odds API
+  soccer.py       ← EPL/Championship/UCL/Bundesliga/La Liga/Serie A/Ligue 1 via Football-Data.org + Odds API
   __init__.py
   ↓ produce
 List[GameRow]     ← {sport_prefix, home, away, rank_home, rank_away, start_time, spread, extra}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ first in any IPTV client.
 |---|---|---|
 | NCAA Football | [CollegeFootballData.com](https://collegefootballdata.com/) | Yes (1k req/day) |
 | NCAA Men's Basketball | [CollegeBasketballData.com](https://collegebasketballdata.com/) (same key as CFBD) | Yes |
-| EPL / EFL Championship / UCL | [Football-Data.org](https://www.football-data.org/) | Yes (10 req/min, 12 free comps) |
+| EPL / EFL Championship / UCL / Bundesliga / La Liga / Serie A / Ligue 1 | [Football-Data.org](https://www.football-data.org/) | Yes (10 req/min, 12 free comps) |
 | NHL (regular + Stanley Cup Playoffs) | [api-web.nhle.com](https://api-web.nhle.com/) (official, undocumented) | Yes (no key required) |
 | Spreads (any sport above) | [The Odds API](https://the-odds-api.com/) | Yes (500 req/mo) |
 

--- a/plugin.json
+++ b/plugin.json
@@ -49,6 +49,34 @@
       "help_text": "Knockout/group stage. Position-as-rank doesn't apply cleanly so favorites + odds carry the signal."
     },
     {
+      "id": "enable_bundesliga",
+      "type": "boolean",
+      "label": "Bundesliga (Germany, top flight)",
+      "default": false,
+      "help_text": "18 teams, 34 matchdays. Top 4 → UCL, 5-6 → Europa/Conference, 16 → relegation playoff, 17-18 → direct relegation. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_la_liga",
+      "type": "boolean",
+      "label": "La Liga (Spain, top flight)",
+      "default": false,
+      "help_text": "20 teams, 38 matchdays. Top 4 → UCL, 5-7 → Europa/Conference, bottom 3 → relegation. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_serie_a",
+      "type": "boolean",
+      "label": "Serie A (Italy, top flight)",
+      "default": false,
+      "help_text": "20 teams, 38 matchdays. Top 4 → UCL, 5-7 → Europa/Conference, bottom 3 → relegation. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_ligue_1",
+      "type": "boolean",
+      "label": "Ligue 1 (France, top flight)",
+      "default": false,
+      "help_text": "18 teams, 34 matchdays. Top 3 → UCL (4th = UCL playoff), 5 → Europa, bottom 3 → relegation. Requires Football-Data.org key."
+    },
+    {
       "id": "enable_nhl",
       "type": "boolean",
       "label": "NHL (regular season + Stanley Cup Playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -324,6 +324,17 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("championship"))
     if settings.get("enable_ucl", False) and fd_key:
         sources.append(_make_soccer("ucl"))
+    # Phase H: top-flight European leagues. Same FD.org key as EPL etc.;
+    # _make_soccer routes each to SoccerSource because their LEAGUE_CONTEXTS
+    # entries default to format="league".
+    if settings.get("enable_bundesliga", False) and fd_key:
+        sources.append(_make_soccer("bundesliga"))
+    if settings.get("enable_la_liga", False) and fd_key:
+        sources.append(_make_soccer("la_liga"))
+    if settings.get("enable_serie_a", False) and fd_key:
+        sources.append(_make_soccer("serie_a"))
+    if settings.get("enable_ligue_1", False) and fd_key:
+        sources.append(_make_soccer("ligue_1"))
 
     # NHL — no API key required (api-web.nhle.com is free). Pair the
     # regular and playoff sources together: the playoff source borrows

--- a/scoring.py
+++ b/scoring.py
@@ -198,6 +198,58 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R16 → QF → SF → Final → Champion",
     ),
+    # Phase H: top-flight European leagues. Slot semantics differ by league:
+    #   - UCL slots: Bundesliga 4, La Liga 4, Serie A 4, Ligue 1 3 (one
+    #     fewer; FL1's 4th place enters UEL/UECL playoff).
+    #   - Bundesliga: 16th plays relegation playoff vs Bundesliga 2's 3rd;
+    #     17-18 directly relegated. We use cutoff=15 (i.e. position > 15
+    #     == positions 16/17/18) to fire the relegation band for all three.
+    #   - La Liga / Serie A (20 teams): bottom 3 (18-20) relegated.
+    #   - Ligue 1 (18 teams): 16-18 relegated (same shape as BL1).
+    # Cross-sport weights mirror EPL's slot-by-slot importance because the
+    # consequences (UCL prize money, relegation revenue hit) are roughly
+    # comparable across the Big Five. Tuning each weight per-league
+    # would be premature without season-replay data.
+    "BL1": LeagueContext(
+        code="BL1", matchdays_total=34,
+        thresholds=[
+            (1,  "title",             5.0),
+            (4,  "UCL",               4.0),
+            (6,  "Europa/Conference", 2.0),
+            (15, "relegation",        5.0),
+        ],
+        boundary_summary="Top 4 → UCL · 5-6 → Europa · bottom 3 → relegation",
+    ),
+    "PD": LeagueContext(
+        code="PD", matchdays_total=38,
+        thresholds=[
+            (1,  "title",             5.0),
+            (4,  "UCL",               4.0),
+            (7,  "Europa/Conference", 2.0),
+            (17, "relegation",        5.0),
+        ],
+        boundary_summary="Top 4 → UCL · 5-7 → Europa · bottom 3 → relegation",
+    ),
+    "SA": LeagueContext(
+        code="SA", matchdays_total=38,
+        thresholds=[
+            (1,  "title",             5.0),
+            (4,  "UCL",               4.0),
+            (7,  "Europa/Conference", 2.0),
+            (17, "relegation",        5.0),
+        ],
+        boundary_summary="Top 4 → UCL · 5-7 → Europa · bottom 3 → relegation",
+    ),
+    "FL1": LeagueContext(
+        code="FL1", matchdays_total=34,
+        thresholds=[
+            (1,  "title",             5.0),
+            (3,  "UCL",               4.0),
+            (5,  "Europa/Conference", 2.0),
+            (15, "relegation",        5.0),
+        ],
+        boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
+    ),
     # Phase D.2 / D.3: NCAA football and men's basketball. Format is
     # "win_count" — threshold cutoffs are MINIMUM win counts rather than
     # position cutoffs (the SoccerSource interpretation). The points-

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -147,6 +147,45 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         use_position_as_rank=False,  # group/knockout standings don't map cleanly
         # total_matchdays=0 — knockout, not a fixed-length season
     ),
+    # Phase H: top-flight European league competitions. All available on
+    # Football-Data.org's free tier (verified 2026-05-25). Each is a
+    # standard round-robin league; SoccerSource handles them with no
+    # subclass needed. Threshold structures live in scoring.LEAGUE_CONTEXTS
+    # because they encode the same competition's slot semantics (UCL
+    # qualification, relegation lines) which are scoring concerns, not
+    # adapter concerns.
+    "bundesliga": SoccerCompetitionConfig(
+        fd_code="BL1",
+        sport_prefix="BL1",
+        sport_label="Bundesliga",
+        odds_sport_key="soccer_germany_bundesliga",
+        rank_cap=18,
+        total_matchdays=34,
+    ),
+    "la_liga": SoccerCompetitionConfig(
+        fd_code="PD",
+        sport_prefix="LaLiga",
+        sport_label="La Liga",
+        odds_sport_key="soccer_spain_la_liga",
+        rank_cap=20,
+        total_matchdays=38,
+    ),
+    "serie_a": SoccerCompetitionConfig(
+        fd_code="SA",
+        sport_prefix="SerieA",
+        sport_label="Serie A",
+        odds_sport_key="soccer_italy_serie_a",
+        rank_cap=20,
+        total_matchdays=38,
+    ),
+    "ligue_1": SoccerCompetitionConfig(
+        fd_code="FL1",
+        sport_prefix="Ligue1",
+        sport_label="Ligue 1",
+        odds_sport_key="soccer_france_ligue_one",
+        rank_cap=18,
+        total_matchdays=34,
+    ),
 }
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -261,7 +261,9 @@ class TestNcaamSpreadsShape:
 
 class TestSoccerCompetitions:
     def test_known_keys(self):
-        for k in ("epl", "championship", "ucl"):
+        # Phase H added bundesliga / la_liga / serie_a / ligue_1 to the catalog.
+        for k in ("epl", "championship", "ucl",
+                  "bundesliga", "la_liga", "serie_a", "ligue_1"):
             assert k in SOCCER_COMPETITIONS
 
     def test_epl_config(self):
@@ -288,11 +290,69 @@ class TestSoccerCompetitions:
 
     def test_unknown_competition_rejected(self):
         try:
-            SoccerSource("bundesliga", fd_api_key="x")
+            SoccerSource("not_a_real_league", fd_api_key="x")
         except ValueError:
             pass
         else:
             raise AssertionError("expected ValueError")
+
+    # ---------- Phase H: top-flight European leagues ----------
+
+    def test_bundesliga_matchdays(self):
+        # 18 teams → 34 matchdays. Off-by-one silently misleads "Matchday X of Y".
+        assert SOCCER_COMPETITIONS["bundesliga"].total_matchdays == 34
+        assert SOCCER_COMPETITIONS["bundesliga"].rank_cap == 18
+        assert SOCCER_COMPETITIONS["bundesliga"].fd_code == "BL1"
+
+    def test_la_liga_matchdays(self):
+        # 20 teams → 38 matchdays (same shape as EPL).
+        assert SOCCER_COMPETITIONS["la_liga"].total_matchdays == 38
+        assert SOCCER_COMPETITIONS["la_liga"].rank_cap == 20
+        assert SOCCER_COMPETITIONS["la_liga"].fd_code == "PD"
+
+    def test_serie_a_matchdays(self):
+        assert SOCCER_COMPETITIONS["serie_a"].total_matchdays == 38
+        assert SOCCER_COMPETITIONS["serie_a"].rank_cap == 20
+        assert SOCCER_COMPETITIONS["serie_a"].fd_code == "SA"
+
+    def test_ligue_1_matchdays(self):
+        # 18 teams → 34 matchdays (same as Bundesliga).
+        assert SOCCER_COMPETITIONS["ligue_1"].total_matchdays == 34
+        assert SOCCER_COMPETITIONS["ligue_1"].rank_cap == 18
+        assert SOCCER_COMPETITIONS["ligue_1"].fd_code == "FL1"
+
+    def test_top_flight_leagues_use_position_as_rank(self):
+        # All Big-Five leagues have a real points table — position-as-rank applies.
+        for k in ("bundesliga", "la_liga", "serie_a", "ligue_1"):
+            assert SOCCER_COMPETITIONS[k].use_position_as_rank is True
+
+    def test_top_flight_route_to_league_format_not_knockout(self):
+        # _make_soccer factory in plugin.py picks SoccerSource (not
+        # KnockoutSoccerSource) when LEAGUE_CONTEXTS[fd_code].format == "league".
+        # Verify the LEAGUE_CONTEXTS entries reflect that.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        for code in ("BL1", "PD", "SA", "FL1"):
+            assert LEAGUE_CONTEXTS[code].format == "league", \
+                f"{code} should route through SoccerSource (format=league)"
+
+    def test_top_flight_thresholds_include_title_ucl_relegation(self):
+        # Every Big-Five entry must have title + UCL + relegation bands so
+        # importance leverage covers the most stakeholder-relevant outcomes.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        for code in ("BL1", "PD", "SA", "FL1"):
+            labels = {label for _cut, label, _w in LEAGUE_CONTEXTS[code].thresholds}
+            assert "title" in labels, f"{code} missing title band"
+            assert "UCL" in labels, f"{code} missing UCL band"
+            assert "relegation" in labels, f"{code} missing relegation band"
+
+    def test_ligue_1_ucl_cutoff_is_three_not_four(self):
+        # FL1 only awards 3 direct UCL slots (4th plays UCL playoff round).
+        # Reflect that in the cutoff so importance for "did we make UCL"
+        # leverages the right boundary.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ucl_cutoffs = [cut for cut, label, _w in LEAGUE_CONTEXTS["FL1"].thresholds
+                       if label == "UCL"]
+        assert ucl_cutoffs == [3]
 
 
 class TestPreviousSeasonStartYear:


### PR DESCRIPTION
## Summary

- 4 new soccer competitions: BL1 (Bundesliga), PD (La Liga), SA (Serie A), FL1 (Ligue 1).
- Zero new adapter code — all 4 plug into the existing `SoccerSource` machinery via the `COMPETITIONS` catalog. Same FD.org key as EPL.
- Threshold tuning is league-specific: Ligue 1 awards only 3 direct UCL slots so its UCL cutoff is 3, not 4. Bundesliga / Ligue 1 (18 teams) use `cutoff > 15` for relegation; La Liga / Serie A (20 teams) use `cutoff > 17`.

## Live verification

Standings reproduce final 2024-25 reality:
- **BL1**: Bayern 89, BVB 73; relegated Heidenheim (26), St. Pauli (26).
- **PD**: Barcelona 94, Real Madrid 86; relegated Girona (41), Real Oviedo (29).
- **SA**: Inter 87, Napoli 76; relegated Verona (21), Pisa (18).
- **FL1**: PSG 76, Lens 70; relegated Nantes (23), Metz (17).

## Test plan

- [x] 267/267 unit tests pass (was 259; +8 new).
- [x] Updated `test_unknown_competition_rejected` (the old sentinel "bundesliga" is now a valid key).
- [x] Live verified each of the 4 standings endpoints returns 200 on the free tier with the existing FD.org key.
- [x] Each league's `format="league"` so `_make_soccer` routes through SoccerSource, not KnockoutSoccerSource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)