### PR TITLE
Phase I: international soccer (FIFA World Cup + UEFA EURO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ first in any IPTV client.
 |---|---|---|
 | NCAA Football | [CollegeFootballData.com](https://collegefootballdata.com/) | Yes (1k req/day) |
 | NCAA Men's Basketball | [CollegeBasketballData.com](https://collegebasketballdata.com/) (same key as CFBD) | Yes |
-| EPL / EFL Championship / UCL / Bundesliga / La Liga / Serie A / Ligue 1 | [Football-Data.org](https://www.football-data.org/) | Yes (10 req/min, 12 free comps) |
+| EPL / EFL Championship / UCL / Bundesliga / La Liga / Serie A / Ligue 1 / FIFA World Cup / UEFA EURO | [Football-Data.org](https://www.football-data.org/) | Yes (10 req/min, 12 free comps) |
 | NHL (regular + Stanley Cup Playoffs) | [api-web.nhle.com](https://api-web.nhle.com/) (official, undocumented) | Yes (no key required) |
 | Spreads (any sport above) | [The Odds API](https://the-odds-api.com/) | Yes (500 req/mo) |
 

--- a/plugin.json
+++ b/plugin.json
@@ -77,6 +77,20 @@
       "help_text": "18 teams, 34 matchdays. Top 3 → UCL (4th = UCL playoff), 5 → Europa, bottom 3 → relegation. Requires Football-Data.org key."
     },
     {
+      "id": "enable_world_cup",
+      "type": "boolean",
+      "label": "FIFA World Cup",
+      "default": false,
+      "help_text": "Quadrennial international tournament. Pure knockout in V1 — group-stage importance not yet modeled (filed as follow-up). LAST_32 (new 48-team format) → R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_euros",
+      "type": "boolean",
+      "label": "UEFA European Championship (EURO)",
+      "default": false,
+      "help_text": "UEFA's quadrennial national-team tournament. Pure knockout in V1 — group-stage importance not yet modeled. R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
+    },
+    {
       "id": "enable_nhl",
       "type": "boolean",
       "label": "NHL (regular season + Stanley Cup Playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -335,6 +335,14 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("serie_a"))
     if settings.get("enable_ligue_1", False) and fd_key:
         sources.append(_make_soccer("ligue_1"))
+    # Phase I: international tournaments. _make_soccer dispatches to
+    # KnockoutSoccerSource via the format="knockout" route. Group-stage
+    # importance isn't modeled in V1; group games still surface via
+    # fetch_upcoming with favorite + closeness signal only.
+    if settings.get("enable_world_cup", False) and fd_key:
+        sources.append(_make_soccer("world_cup"))
+    if settings.get("enable_euros", False) and fd_key:
+        sources.append(_make_soccer("euros"))
 
     # NHL — no API key required (api-web.nhle.com is free). Pair the
     # regular and playoff sources together: the playoff source borrows

--- a/scoring.py
+++ b/scoring.py
@@ -153,6 +153,11 @@ class LeagueContext:
 KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # UEFA cup soccer (UCL / UEL / UECL):
     "PLAYOFFS":        0,  # UCL play-off round (pos 9-24 entrants)
+    # International tournaments (Phase I) use LAST_32 as the entry-level
+    # knockout round in the new 48-team World Cup 2026 format. Same depth
+    # as PLAYOFFS because both are "before LAST_16"; no competition uses
+    # both stages, so they don't collide in the bracket cascade.
+    "LAST_32":         0,
     "LAST_16":         1,
     "QUARTER_FINALS":  2,
     "SEMI_FINALS":     3,
@@ -249,6 +254,48 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (15, "relegation",        5.0),
         ],
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
+    ),
+    # Phase I: international tournaments.
+    #
+    # World Cup 2026 onward uses the 48-team format: 12 groups of 4, top
+    # 2 + best 8 third-place advance to a LAST_32 round. Pre-2026 World
+    # Cups used 32 teams entering at LAST_16. The LEAGUE_CONTEXTS entry
+    # below describes the post-2026 bracket; if you point this at an
+    # older WC season FD.org will publish no LAST_32 matches and the
+    # bracket source will treat LAST_16 as the entry round automatically.
+    #
+    # Weights ramp aggressively for international finals because they're
+    # the highest-viewership soccer matches by an order of magnitude.
+    # WC Final / Winner outweigh UCL equivalents (5.0 / 10.0) because
+    # the WC happens once every 4 years vs UCL every year, concentrating
+    # consequence.
+    #
+    # NB: GROUP_STAGE importance isn't modeled in V1 — the bracket
+    # source only tracks knockout-round eligibility. Group-stage
+    # "survive and advance" games still pick up favorite + closeness
+    # signal but importance reads 0. Filed as follow-up.
+    "WC": LeagueContext(
+        code="WC", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("LAST_32",        "last_32",       0.5),
+            ("LAST_16",        "round_of_16",   1.5),
+            ("QUARTER_FINALS", "quarterfinal",  3.0),
+            ("SEMI_FINALS",    "semifinal",     5.0),
+            ("FINAL",          "final",         8.0),
+            ("WINNER",         "winner",       15.0),
+        ],
+        boundary_summary="R32 → R16 → QF → SF → Final → Champion (FIFA World Cup)",
+    ),
+    "EC": LeagueContext(
+        code="EC", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("LAST_16",        "round_of_16",   1.0),
+            ("QUARTER_FINALS", "quarterfinal",  2.5),
+            ("SEMI_FINALS",    "semifinal",     4.0),
+            ("FINAL",          "final",         6.0),
+            ("WINNER",         "winner",       10.0),
+        ],
+        boundary_summary="R16 → QF → SF → Final → Champion (UEFA EURO)",
     ),
     # Phase D.2 / D.3: NCAA football and men's basketball. Format is
     # "win_count" — threshold cutoffs are MINIMUM win counts rather than

--- a/sources/bracket.py
+++ b/sources/bracket.py
@@ -448,9 +448,19 @@ class AggregateLegSource(BracketSportSource):
     """
 
     def _new_tie_record(self, tie_meta: Dict[str, Any]) -> Dict[str, Any]:
+        # Capture the number of games published for this tie so completeness
+        # can be data-driven instead of guessing from stage name. UEFA cup
+        # ties run 2 legs except the FINAL (1 leg). International tournaments
+        # (WC, EURO) run 1 leg per round including non-finals. Single source
+        # of truth: count the games FD.org publishes for the tie. DO NOT
+        # branch on `stage == KO_STAGES[-1]` — that misclassifies single-leg
+        # non-finals (WC LAST_16, EURO QF, etc.) as incomplete forever and
+        # the round_reached cascade never fires.
+        games_in_tie = len(tie_meta.get("games") or [])
         return {
             "stage": tie_meta.get("stage"),
             "teams": tie_meta.get("teams"),
+            "legs_in_tie": games_in_tie if games_in_tie else 2,
             "leg1": None,
             "leg2": None,
             "winner": None,
@@ -474,10 +484,10 @@ class AggregateLegSource(BracketSportSource):
 
         legs = [tie["leg1"], tie["leg2"]]
         legs_present = [L for L in legs if L is not None]
-        is_final_stage = tie["stage"] == self.KO_STAGES[-1] if self.KO_STAGES else False
+        legs_in_tie = tie.get("legs_in_tie", 2)
         complete = (
-            (is_final_stage and tie["leg1"] is not None)
-            or (tie["leg1"] is not None and tie["leg2"] is not None)
+            (legs_in_tie == 1 and tie["leg1"] is not None)
+            or (legs_in_tie >= 2 and tie["leg1"] is not None and tie["leg2"] is not None)
         )
         if not complete:
             return

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -186,6 +186,23 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         rank_cap=18,
         total_matchdays=34,
     ),
+    # Phase I: international tournaments. Both pure knockout (group stage
+    # not modeled in importance — see Phase I follow-up). LEAGUE_CONTEXTS
+    # routes them to KnockoutSoccerSource via format="knockout".
+    "world_cup": SoccerCompetitionConfig(
+        fd_code="WC",
+        sport_prefix="WC",
+        sport_label="FIFA World Cup",
+        odds_sport_key="soccer_fifa_world_cup",
+        use_position_as_rank=False,  # tournament, not a league table
+    ),
+    "euros": SoccerCompetitionConfig(
+        fd_code="EC",
+        sport_prefix="EURO",
+        sport_label="UEFA European Championship",
+        odds_sport_key="soccer_uefa_european_championship",
+        use_position_as_rank=False,
+    ),
 }
 
 
@@ -863,7 +880,22 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
     strengths, sport_prefix/label, and __init__.
     """
 
-    KO_STAGES = ("PLAYOFFS", "LAST_16", "QUARTER_FINALS", "SEMI_FINALS", "FINAL")
+    # Stage tuple ordered by depth (earlier rounds first). PLAYOFFS and
+    # LAST_32 are both at depth 0 — UEFA cup competitions use PLAYOFFS as
+    # the entry round (pos 9-24 face the league phase's top 8); the new
+    # 48-team FIFA World Cup uses LAST_32. The ordering matters only for
+    # feeds_from inference (each tie looks back through earlier stages);
+    # since no single competition uses both PLAYOFFS and LAST_32, they
+    # don't collide. EURO and FIFA pre-2026 tournaments simply have
+    # neither stage populated — _build_bracket skips empty stages.
+    KO_STAGES = (
+        "PLAYOFFS",
+        "LAST_32",
+        "LAST_16",
+        "QUARTER_FINALS",
+        "SEMI_FINALS",
+        "FINAL",
+    )
 
     def _league_context_code(self) -> str:
         return self.config.fd_code
@@ -885,9 +917,23 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
         outcome lives in `score.penalties` — we apply the +1 here so the
         downstream aggregate computation in AggregateLegSource doesn't
         need to know about shootout semantics).
+
+        Matchday normalization: FD.org's `matchday` is competition-relative.
+        For UEFA cup two-leg ties it doubles as the leg index (1 = leg 1,
+        2 = leg 2 — works directly). For international tournaments (WC,
+        EURO) it's the overall tournament-day counter (e.g., matchday=7
+        for the EURO 2024 final), which DOES NOT map to a leg index. We
+        normalize per-tie here: matchday becomes the 1-indexed leg position
+        within the tie, ordered chronologically. DO NOT pass FD's matchday
+        through unchanged for single-leg-per-round competitions — the
+        AggregateLegSource records the score into `leg2` instead of
+        `leg1` and the tie never marks itself complete.
         """
+        from collections import defaultdict
         matches = self._fetch_all_season_matches()
-        out: List[Dict[str, Any]] = []
+        # Pre-group matches by (stage, frozenset of teams) so we can assign
+        # leg indices per tie based on chronological order within the group.
+        ties: Dict[Tuple[str, frozenset], List[Dict[str, Any]]] = defaultdict(list)
         for m in matches:
             stage = m.get("stage")
             if stage not in self.KO_STAGES:
@@ -896,36 +942,46 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
             away = (m.get("awayTeam") or {}).get("name")
             if not home or not away:
                 continue
-            score = m.get("score") or {}
-            full_time = score.get("fullTime") or {}
-            home_goals = full_time.get("home")
-            away_goals = full_time.get("away")
-            duration = score.get("duration")
-            penalties = score.get("penalties") or {}
-            if (
-                duration == "PENALTY_SHOOTOUT"
-                and home_goals is not None
-                and away_goals is not None
-            ):
-                pen_home = penalties.get("home")
-                pen_away = penalties.get("away")
-                if pen_home is not None and pen_away is not None:
-                    if pen_home > pen_away:
-                        home_goals = (home_goals or 0) + 1
-                    elif pen_away > pen_home:
-                        away_goals = (away_goals or 0) + 1
-            out.append({
-                "game_id": m.get("id"),
-                "stage": stage,
-                "matchday": m.get("matchday") or 1,
-                "home": home,
-                "away": away,
-                "home_goals": home_goals,
-                "away_goals": away_goals,
-                "status": m.get("status"),
-                "start_time": parse_iso_utc(m.get("utcDate")),
-                "extra": {"fd_id": m.get("id")},
-            })
+            ties[(stage, frozenset({home, away}))].append(m)
+
+        out: List[Dict[str, Any]] = []
+        for (stage, _pair), tie_matches in ties.items():
+            # Sort by FD's utcDate so leg 1 is chronologically first.
+            tie_matches.sort(key=lambda x: x.get("utcDate") or "")
+            for leg_idx, m in enumerate(tie_matches, start=1):
+                home = (m.get("homeTeam") or {}).get("name")
+                away = (m.get("awayTeam") or {}).get("name")
+                score = m.get("score") or {}
+                full_time = score.get("fullTime") or {}
+                home_goals = full_time.get("home")
+                away_goals = full_time.get("away")
+                duration = score.get("duration")
+                penalties = score.get("penalties") or {}
+                if (
+                    duration == "PENALTY_SHOOTOUT"
+                    and home_goals is not None
+                    and away_goals is not None
+                ):
+                    pen_home = penalties.get("home")
+                    pen_away = penalties.get("away")
+                    if pen_home is not None and pen_away is not None:
+                        if pen_home > pen_away:
+                            home_goals = (home_goals or 0) + 1
+                        elif pen_away > pen_home:
+                            away_goals = (away_goals or 0) + 1
+                out.append({
+                    "game_id": m.get("id"),
+                    "stage": stage,
+                    "matchday": leg_idx,
+                    "home": home,
+                    "away": away,
+                    "home_goals": home_goals,
+                    "away_goals": away_goals,
+                    "status": m.get("status"),
+                    "start_time": parse_iso_utc(m.get("utcDate")),
+                    "extra": {"fd_id": m.get("id"),
+                              "fd_matchday": m.get("matchday")},
+                })
         return out
 
     # ---------- soccer-specific sampling: regulation + ET + penalty ----------

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -354,6 +354,69 @@ class TestSoccerCompetitions:
                        if label == "UCL"]
         assert ucl_cutoffs == [3]
 
+    # ---------- Phase I: international tournaments ----------
+
+    def test_world_cup_in_competitions(self):
+        cfg = SOCCER_COMPETITIONS["world_cup"]
+        assert cfg.fd_code == "WC"
+        assert cfg.use_position_as_rank is False  # tournament, not league table
+        assert cfg.total_matchdays == 0  # no fixed-length season
+
+    def test_euros_in_competitions(self):
+        cfg = SOCCER_COMPETITIONS["euros"]
+        assert cfg.fd_code == "EC"
+        assert cfg.use_position_as_rank is False
+        assert cfg.total_matchdays == 0
+
+    def test_world_cup_routes_to_knockout(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["WC"].format == "knockout"
+        wc_labels = {label for _cut, label, _w in LEAGUE_CONTEXTS["WC"].thresholds}
+        # WC 2026's 48-team format adds LAST_32 as the entry knockout round.
+        assert "last_32" in wc_labels
+        assert "winner" in wc_labels
+
+    def test_euros_routes_to_knockout_without_last_32(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["EC"].format == "knockout"
+        ec_labels = {label for _cut, label, _w in LEAGUE_CONTEXTS["EC"].thresholds}
+        # EURO is 24-team, enters at LAST_16 — no LAST_32 band.
+        assert "last_32" not in ec_labels
+        assert "round_of_16" in ec_labels
+        assert "winner" in ec_labels
+
+    def test_world_cup_winner_outweighs_ucl_winner(self):
+        # WC is once-every-4-years vs UCL annual; winner consequence
+        # weight reflects the rarity premium.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        wc_winner_w = next(
+            w for _c, label, w in LEAGUE_CONTEXTS["WC"].thresholds if label == "winner"
+        )
+        ucl_winner_w = next(
+            w for _c, label, w in LEAGUE_CONTEXTS["CL"].thresholds if label == "winner"
+        )
+        assert wc_winner_w > ucl_winner_w, \
+            f"WC winner weight {wc_winner_w} should exceed UCL winner {ucl_winner_w}"
+
+    def test_last_32_in_knockout_depth(self):
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert "LAST_32" in KNOCKOUT_ROUND_DEPTH
+        # Entry-level (same depth as PLAYOFFS — both are pre-LAST_16).
+        assert KNOCKOUT_ROUND_DEPTH["LAST_32"] == 0
+        # Strictly shallower than LAST_16.
+        assert KNOCKOUT_ROUND_DEPTH["LAST_32"] < KNOCKOUT_ROUND_DEPTH["LAST_16"]
+
+    def test_knockout_source_includes_last_32_in_ko_stages(self):
+        # KnockoutSoccerSource.KO_STAGES must list LAST_32 between PLAYOFFS
+        # and LAST_16 so feeds_from inference can resolve WC LAST_16 ties
+        # back to their LAST_32 feeders.
+        from dispatcharr_ranked_matchups.sources.soccer import KnockoutSoccerSource
+        stages = KnockoutSoccerSource.KO_STAGES
+        idx_p = stages.index("PLAYOFFS")
+        idx_32 = stages.index("LAST_32")
+        idx_16 = stages.index("LAST_16")
+        assert idx_p < idx_32 < idx_16
+
 
 class TestPreviousSeasonStartYear:
     """B.2 / TUNING_REPORT finding #2: the seed-year derivation must pin
@@ -1080,9 +1143,13 @@ class TestKnockoutSoccerSource:
 
     def test_record_game_into_tie_two_leg_aggregate(self):
         src = self._make_source([])
+        # Phase I introduced data-driven leg counting: tie records carry
+        # `legs_in_tie` to support single-leg non-finals (international
+        # tournaments). Two-leg ties set it to 2.
         tie = {
             "stage": "SEMI_FINALS",
             "teams": frozenset({"A", "B"}),
+            "legs_in_tie": 2,
             "leg1": None, "leg2": None,
             "winner": None, "loser": None,
         }
@@ -1098,9 +1165,12 @@ class TestKnockoutSoccerSource:
 
     def test_record_game_into_tie_single_leg_final(self):
         src = self._make_source([])
+        # Single-leg tie: explicitly set legs_in_tie=1 to opt out of the
+        # default two-leg-aggregate completeness check.
         tie = {
             "stage": "FINAL",
             "teams": frozenset({"A", "C"}),
+            "legs_in_tie": 1,
             "leg1": None, "leg2": None,
             "winner": None, "loser": None,
         }
@@ -1109,6 +1179,22 @@ class TestKnockoutSoccerSource:
         # Single-leg tie completes after one record.
         assert tie["winner"] == "A"
         assert tie["loser"] == "C"
+
+    def test_record_game_into_tie_single_leg_non_final_for_international(self):
+        # Phase I: international tournaments (WC, EURO) use single-leg
+        # knockouts for ALL rounds, not just the final. Verify a SEMI_FINALS
+        # tie with legs_in_tie=1 completes after one record.
+        src = self._make_source([])
+        tie = {
+            "stage": "SEMI_FINALS",
+            "teams": frozenset({"Spain", "France"}),
+            "legs_in_tie": 1,
+            "leg1": None, "leg2": None,
+            "winner": None, "loser": None,
+        }
+        src._record_game_into_tie(tie, "Spain", "France", 2, 1, game_index=1)
+        assert tie["winner"] == "Spain"
+        assert tie["loser"] == "France"
 
     # ---------- _advance_round_reached ----------
 


### PR DESCRIPTION
## Summary

- 2 new soccer tournaments wired via `KnockoutSoccerSource`: World Cup (`world_cup`) + EURO (`euros`). Both reuse the existing knockout machinery — no new source classes.
- 2 bracket-machinery bug fixes surfaced by live verification:
  - **legs_in_tie data-driven completeness**: pre-fix, `AggregateLegSource` branched on stage name (FINAL = 1 leg, others = 2 legs). International tournaments are 1 leg per round including non-finals — the old logic never marked SF/QF/R16 ties complete and `round_reached` stayed empty.
  - **Matchday normalization**: FD.org's `matchday` is the overall tournament-day counter for international tournaments (e.g., `matchday=7` for the EURO 2024 final), not a leg index. Pre-fix the value was treated as a leg index, dropping the result into `leg2` with no `leg1`.
- LAST_32 added to `KNOCKOUT_ROUND_DEPTH` + `KnockoutSoccerSource.KO_STAGES` for the new 48-team WC 2026 entry round.

## Live verification

EURO 2024 (FINISHED, FD.org free tier) reproduces reality exactly:

```
EURO 2024: 15 games applied, 16 teams in round_reached
  champion: ['Spain']
  finalist (final loser): ['England']
  semifinalists (SF losers): ['France', 'Netherlands']
  quarterfinalists (QF losers): ['Germany', 'Portugal', 'Switzerland', 'Turkey']
  round-of-16 (R16 losers): ['Austria', 'Belgium', 'Denmark', 'Georgia',
                              'Italy', 'Romania', 'Slovakia', 'Slovenia']
```

WC 2026 bracket structure parses correctly (16 LAST_32 + 8 LAST_16 + 4 QF + 2 SF + 1 FINAL = 31 ties); matches read as `None vs None` until group stage finishes June 27.

## Limitations

- **Group-stage importance**: not modeled in V1. Group games surface via favorite + closeness signals only; `importance` reads 0. Filed as #20.
- **WC 2026 pre-tournament**: bracket is empty until group-stage results populate team names into LAST_32 matches. Tournament-time refreshes will fill the bracket in.

## Test plan

- [x] 275/275 unit tests pass (was 267; +8 new for WC/EC routing, LAST_32 stage, single-leg-non-final completeness).
- [x] One existing test updated to set `legs_in_tie=1` for single-leg-FINAL fixture (caught by the same data-driven logic).
- [x] Live verified EURO 2024 final standings reproduce reality.
- [x] Live verified WC 2026 bracket structure parses (31 ties across 5 stages).
- [x] FD.org free-tier access confirmed for both competitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)