### PR TITLE
Phase M: NCAA Baseball (D1 regular season)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ first in any IPTV client.
 | NCAA Men's Basketball | [CollegeBasketballData.com](https://collegebasketballdata.com/) (same key as CFBD) | Yes |
 | EPL / EFL Championship / UCL / Bundesliga / La Liga / Serie A / Ligue 1 / FIFA World Cup / UEFA EURO | [Football-Data.org](https://www.football-data.org/) | Yes (10 req/min, 12 free comps) |
 | NHL (regular + Stanley Cup Playoffs) | [api-web.nhle.com](https://api-web.nhle.com/) (official, undocumented) | Yes (no key required) |
+| NCAA Baseball (D1 regular season) | [site.api.espn.com](https://site.api.espn.com/) (unofficial) + D1Baseball.com poll | Yes (no key required) |
 | Spreads (any sport above) | [The Odds API](https://the-odds-api.com/) | Yes (500 req/mo) |
 
 Adding a sport is a new file in `sources/` implementing the `SportSource`

--- a/plugin.json
+++ b/plugin.json
@@ -98,6 +98,13 @@
       "help_text": "Regular season uses standings points (95+ bubble, 100+ playoff-secured, 110+ division pace, 125+ Presidents' Trophy). Playoffs are best-of-7 each round. No API key required — official api-web.nhle.com."
     },
     {
+      "id": "enable_ncaa_baseball",
+      "type": "boolean",
+      "label": "NCAA Baseball (D1)",
+      "default": false,
+      "help_text": "D1 baseball regular season. ESPN unofficial API + D1Baseball.com Top 25 poll. Bands: 30+ wins tournament bubble, 35+ at-large lock, 40+ top regional seed, 45+ national seed, 50+ #1 overall contention. CWS postseason bracket not yet modeled (favorites + rank signal still surface postseason matchups). No API key required."
+    },
+    {
       "id": "_section_keys",
       "type": "info",
       "label": "API Keys",

--- a/plugin.py
+++ b/plugin.py
@@ -292,7 +292,7 @@ def _build_weights(settings: Dict[str, Any]):
 
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
-        KnockoutSoccerSource, NcaafSource, NcaamSource,
+        KnockoutSoccerSource, NcaaBaseballSource, NcaafSource, NcaamSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
     )
     from .sources.soccer import COMPETITIONS
@@ -364,6 +364,13 @@ def _build_sources(settings: Dict[str, Any]):
             # source — it can still run on the default prior.
             logger.warning("[nhl] could not seed playoff strengths: %s", exc)
         sources.append(nhl_po)
+
+    # Phase M: NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
+    # poll, no key needed. Win-count thresholds (30 / 35 / 40 / 45 / 50) drive
+    # the importance signal. CWS postseason bracket isn't modeled yet — postseason
+    # games still surface via favorite + rank-pair signal.
+    if settings.get("enable_ncaa_baseball", False):
+        sources.append(NcaaBaseballSource())
     return sources
 
 

--- a/scoring.py
+++ b/scoring.py
@@ -297,6 +297,24 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R16 → QF → SF → Final → Champion (UEFA EURO)",
     ),
+    # Phase M: NCAA Division I baseball regular season. Win-count
+    # thresholds tuned against historical NCAA Tournament selection
+    # criteria — ~35 wins is the rough at-large cutoff, 45+ wins puts
+    # a team in national-seed (top 16) contention. Seasons run Feb-June
+    # with ~55 regular-season games + conference tournament; matchdays_total
+    # is approximate because non-conference scheduling varies by team.
+    # CWS postseason bracket is not modeled in V1 (filed as follow-up).
+    "BSB": LeagueContext(
+        code="BSB", matchdays_total=55, format="win_count",
+        thresholds=[
+            (30, "tournament_bubble", 1.0),  # bid uncertainty
+            (35, "at_large_lock",     2.0),  # likely tournament bid
+            (40, "regional_top_seed", 3.0),  # top regional seed contender
+            (45, "national_seed",     4.0),  # top-16 / national seed
+            (50, "overall_one_seed",  5.0),  # #1 overall seed conversation
+        ],
+        boundary_summary="30+ wins → tournament bubble · 35+ → at-large lock · 45+ → national seed",
+    ),
     # Phase D.2 / D.3: NCAA football and men's basketball. Format is
     # "win_count" — threshold cutoffs are MINIMUM win counts rather than
     # position cutoffs (the SoccerSource interpretation). The points-

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -1,5 +1,6 @@
 """Per-sport data sources. Each source produces a list of GameRow."""
 from .base import GameRow, SportSource
+from .ncaa_baseball import NcaaBaseballSource
 from .ncaaf import NcaafSource
 from .ncaam import NcaamSource
 from .nhl import NhlPlayoffSource, NhlRegularSource
@@ -11,7 +12,7 @@ from .soccer import (
 
 __all__ = [
     "GameRow", "SportSource",
-    "NcaafSource", "NcaamSource",
+    "NcaaBaseballSource", "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",
     "SoccerSource", "KnockoutSoccerSource", "SOCCER_COMPETITIONS",
 ]

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -1,0 +1,301 @@
+"""NCAA Baseball source — ESPN's unofficial `site.api.espn.com` API.
+
+No API key required. ESPN's API is undocumented but stable enough for
+a homelab TV-guide curator. If it ever 404s, `fetch_upcoming` and
+`_fetch_full_season_games` return [] and the affected sport silently
+drops out of the guide for that refresh cycle — graceful-degrade is
+already the contract.
+
+API endpoints used:
+  - /apis/site/v2/sports/baseball/college-baseball/scoreboard
+    - Daily / date-range scoreboard. `dates=YYYYMMDD` or
+      `dates=YYYYMMDD-YYYYMMDD` for ranges. Returns competitions[]
+      with competitors[] (2 teams), score, status. Used by both
+      fetch_upcoming and _fetch_full_season_games.
+  - /apis/site/v2/sports/baseball/college-baseball/rankings
+    - D1Baseball.com Top 25 (the canonical D1 poll). Used to populate
+      rank_home / rank_away on GameRow records so the rank-pair signal
+      fires for marquee matchups.
+
+Team name canonicalization: ESPN returns `team.location` ("UCLA") and
+`team.name` ("Bruins"). We use `team.location` because that's what
+typically appears in EPG titles ("UCLA at Texas") rather than the
+mascot ("Bruins at Longhorns"). The school name is the stable join
+key for matching.
+
+CWS bracket is NOT modeled in V1 — the double-elimination structure
+(regional / super-regional / CWS bracket / CWS Finals) is a new tie
+shape neither AggregateLegSource nor BestOfNSeriesSource handles.
+Importance during the postseason falls back to favorite + rank-pair
+signals; structural CWS-progression leverage is filed as follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base import GameRow
+from .points_based import PointsBasedSportSource
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_baseball")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/baseball/college-baseball"
+
+# D1 baseball season runs Feb through June (CWS finals typically third
+# week of June). We sweep month by month so a single huge range doesn't
+# risk pagination cutoffs from ESPN's API.
+SEASON_START_MONTH = 2   # February
+SEASON_END_MONTH = 6     # June (CWS finals)
+
+# Default per-team scoring rate priors for teams the simulator hasn't
+# seen yet (transfers, early-season cold starts). D1 baseball averages
+# ~6 runs/team/game over the full season.
+_DEFAULT_RUNS_FOR = 6.0
+_DEFAULT_RUNS_AGAINST = 6.0
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Dict[str, Any]]:
+    """ESPN unofficial API wrapper. Returns the parsed JSON or None on
+    any error (4xx / 5xx / connection failure / JSON decode). Logs at
+    WARNING so silent degradation is observable in the dispatcharr log
+    when the API misbehaves.
+    """
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[ncaa_baseball] %s → %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[ncaa_baseball] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """ESPN returns both `team.location` (school: 'UCLA') and `team.name`
+    (mascot: 'Bruins'). EPG provider titles use the school name. Fall
+    back to nickname / abbreviation if location is missing on some
+    edge-case competitor entries (occasionally happens for non-D1
+    opponents in early-season scrimmages).
+    """
+    loc = (team_obj.get("location") or "").strip()
+    if loc:
+        return loc
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert one ESPN scoreboard event into the canonical PointsBased
+    game record. Returns None if the event isn't a two-team competition
+    we can score (cancellations, postponements with no competitors, etc.).
+    """
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = _team_canonical_name(home.get("team") or {})
+    away_team = _team_canonical_name(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    elif state == "in":
+        # In-progress games are unstable scores. Treat as SCHEDULED so
+        # the simulator doesn't seed wins/losses from mid-game state.
+        status = "SCHEDULED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    # If "FINISHED" but scores are missing, demote to SCHEDULED — the
+    # importance simulator must not seed a 0-0 result.
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    return {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "extra": {},
+    }
+
+
+class NcaaBaseballSource(PointsBasedSportSource):
+    """NCAA Division I baseball regular-season importance.
+
+    Win-count threshold bands tuned against historical NCAA Tournament
+    selection criteria. The 64-team field invites roughly the top D1
+    teams by a blend of RPI/wins/strength-of-schedule; 35+ wins is the
+    rough at-large cutoff line, and 45+ wins put a team in national-seed
+    contention.
+    """
+
+    league_context_code = "BSB"
+    _DEFAULT_POINTS_FOR = _DEFAULT_RUNS_FOR
+    _DEFAULT_POINTS_AGAINST = _DEFAULT_RUNS_AGAINST
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        super().__init__()
+        # NCAA baseball seasons are named by their calendar year (the
+        # 2026 season starts Feb 2026, ends June 2026). Default to the
+        # current calendar year; pre-February treat as last season.
+        now = datetime.now(timezone.utc)
+        self.season_year = (
+            season_year
+            if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAABSB"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Baseball"
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Hit the scoreboard endpoint per-day covering today through
+        `days_ahead` days. Populate rank_home/rank_away from the
+        D1Baseball.com Top 25 so the rank-pair signal fires for marquee
+        matchups. Per-day rather than range because ESPN's range
+        endpoint silently caps at 25 events (see _fetch_full_season_games
+        comment).
+        """
+        rankings = self._fetch_rankings()
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                home = rec["home"]
+                away = rec["away"]
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=home,
+                    away=away,
+                    rank_home=rankings.get(home),
+                    rank_away=rankings.get(away),
+                    start_time=start,
+                    extra={
+                        "espn_event_id": eid,
+                        "fd_competition_code": self.league_context_code,
+                    },
+                ))
+        return out
+
+    # ---------- _fetch_full_season_games (importance side) ----------
+
+    def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
+        """Walk the season day-by-day via the single-date scoreboard
+        endpoint. Dedupe by event id. Returns the canonical shape
+        PointsBasedSportSource expects.
+
+        DO NOT use the `dates=YYYYMMDD-YYYYMMDD` range syntax — empirically
+        ESPN's scoreboard endpoint silently caps range responses at 25
+        events regardless of the `limit` parameter. Single-day queries
+        (`dates=YYYYMMDD`) return ALL games for that day (~70-100 during
+        peak season). Per-day iteration is ~110 calls Feb-now, ~10s total
+        for a refresh.
+        """
+        seen: Dict[Any, Dict[str, Any]] = {}
+        season_start = datetime(self.season_year, SEASON_START_MONTH, 1, tzinfo=timezone.utc).date()
+        # Stop at min(current date + 7 lookahead, season end). Pre-season
+        # we still walk into the season's first week to catch opening day.
+        now = datetime.now(timezone.utc).date()
+        # End of season is the last day of SEASON_END_MONTH.
+        season_end_first = datetime(self.season_year, SEASON_END_MONTH, 1, tzinfo=timezone.utc).date()
+        season_end = (season_end_first + timedelta(days=31)).replace(day=1) - timedelta(days=1)
+        end = min(now + timedelta(days=7), season_end)
+        if end < season_start:
+            # Off-season / pre-season — no games yet.
+            return []
+        day = season_start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec["id"] in seen:
+                        continue
+                    seen[rec["id"]] = rec
+            day += timedelta(days=1)
+        return list(seen.values())
+
+    # ---------- Rankings (D1Baseball.com poll) ----------
+
+    def _fetch_rankings(self) -> Dict[str, int]:
+        """Return {canonical_team_name: ranking_number} for the D1Baseball
+        Top 25. ESPN exposes one poll; if it's missing or empty we
+        gracefully return {} and the rank-pair signal sits out the
+        refresh cycle.
+        """
+        data = _http_get(f"{ESPN_BASE}/rankings")
+        if not data:
+            return {}
+        ranks_by_team: Dict[str, int] = {}
+        polls = data.get("rankings") or []
+        if not polls:
+            return ranks_by_team
+        # Prefer the D1Baseball poll; if multiple polls appear later
+        # we'd want to make this selectable, but for now there's just one.
+        poll = polls[0]
+        for r in poll.get("ranks") or []:
+            team_obj = r.get("team") or {}
+            name = _team_canonical_name(team_obj)
+            try:
+                rank = int(r.get("current") or 0)
+            except (TypeError, ValueError):
+                continue
+            if name and rank > 0:
+                ranks_by_team[name] = rank
+        return ranks_by_team

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2242,3 +2242,160 @@ class TestPointsBasedSourceCountField:
         from dispatcharr_ranked_matchups.sources.ncaaf import NcaafSource
         # CFBD source inherits PointsBasedSportSource without overriding.
         assert NcaafSource._count_field == "wins"
+
+
+# =====================================================================
+# Phase M: NCAA Baseball
+# =====================================================================
+
+class TestNcaaBaseballSource:
+    """Phase M: D1 baseball via ESPN unofficial API + D1Baseball.com poll.
+    Tests cover the canonical-game-record extraction (the tricky part is
+    homeAway / completed / score parsing), team-name canonicalization
+    (location > nickname), and the LEAGUE_CONTEXTS bands.
+    """
+
+    @staticmethod
+    def _make_source():
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballSource
+        # Pin season_year so test isn't dependent on calendar.
+        return NcaaBaseballSource(season_year=2026)
+
+    @staticmethod
+    def _competitor(team_loc, team_name, score, home_away="home", winner=None):
+        return {
+            "homeAway": home_away,
+            "score": str(score) if score is not None else None,
+            "winner": winner,
+            "team": {"location": team_loc, "name": team_name, "abbreviation": team_loc[:4].upper()},
+        }
+
+    @staticmethod
+    def _event(eid, date, hp, ap, completed=True, state="post"):
+        return {
+            "id": eid,
+            "date": date,
+            "competitions": [{
+                "status": {"type": {"completed": completed, "state": state}},
+                "competitors": [
+                    TestNcaaBaseballSource._competitor("UCLA", "Bruins", hp, "home", hp > ap if hp is not None else None),
+                    TestNcaaBaseballSource._competitor("Texas", "Longhorns", ap, "away", ap > hp if ap is not None else None),
+                ],
+            }],
+        }
+
+    # ---------- supports_importance + identity ----------
+
+    def test_supports_importance(self):
+        src = self._make_source()
+        assert src.supports_importance is True
+
+    def test_sport_prefix_label(self):
+        src = self._make_source()
+        assert src.sport_prefix == "NCAABSB"
+        assert src.sport_label == "NCAA Baseball"
+
+    def test_count_field_is_wins(self):
+        # Inherits the PointsBasedSportSource default — D1 baseball has
+        # no OT/SO bonus point complication like NHL.
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballSource
+        assert NcaaBaseballSource._count_field == "wins"
+
+    # ---------- _extract_game_record ----------
+
+    def test_extract_finished_game(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _extract_game_record
+        evt = self._event("1001", "2026-04-01T19:00Z", hp=7, ap=3)
+        rec = _extract_game_record(evt)
+        assert rec is not None
+        assert rec["id"] == "1001"
+        assert rec["home"] == "UCLA"  # location (school), not "Bruins" (mascot)
+        assert rec["away"] == "Texas"
+        assert rec["home_points"] == 7
+        assert rec["away_points"] == 3
+        assert rec["status"] == "FINISHED"
+
+    def test_extract_in_progress_demotes_to_scheduled(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _extract_game_record
+        evt = self._event("1002", "2026-04-01T19:00Z", hp=4, ap=2,
+                          completed=False, state="in")
+        rec = _extract_game_record(evt)
+        # In-progress score is unstable — must not seed wins/losses.
+        assert rec is not None
+        assert rec["status"] == "SCHEDULED"
+        assert rec["home_points"] is None
+        assert rec["away_points"] is None
+
+    def test_extract_pregame_scheduled(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _extract_game_record
+        evt = {
+            "id": "1003",
+            "date": "2026-05-25T22:00Z",
+            "competitions": [{
+                "status": {"type": {"completed": False, "state": "pre"}},
+                "competitors": [
+                    self._competitor("UCLA", "Bruins", None, "home"),
+                    self._competitor("Texas", "Longhorns", None, "away"),
+                ],
+            }],
+        }
+        rec = _extract_game_record(evt)
+        assert rec is not None
+        assert rec["status"] == "SCHEDULED"
+
+    def test_extract_finished_with_missing_score_demotes(self):
+        # Defensive: if ESPN reports completed but no score (data hiccup),
+        # demote to SCHEDULED rather than recording a 0-0 W/L into state.
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _extract_game_record
+        evt = self._event("1004", "2026-04-01T19:00Z", hp=None, ap=None)
+        rec = _extract_game_record(evt)
+        assert rec is not None
+        assert rec["status"] == "SCHEDULED"
+
+    def test_extract_missing_competitor_returns_none(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _extract_game_record
+        # Only 1 competitor (corrupt event)
+        evt = {
+            "id": "1005",
+            "date": "2026-04-01T19:00Z",
+            "competitions": [{
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [self._competitor("UCLA", "Bruins", 7, "home")],
+            }],
+        }
+        rec = _extract_game_record(evt)
+        assert rec is None
+
+    def test_team_canonical_name_prefers_location_over_mascot(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _team_canonical_name
+        # EPG provider titles use the school name ("UCLA at Texas")
+        # not the mascot ("Bruins at Longhorns") — pick location.
+        assert _team_canonical_name({"location": "UCLA", "name": "Bruins"}) == "UCLA"
+
+    def test_team_canonical_name_falls_back_to_nickname(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import _team_canonical_name
+        # Edge case: non-D1 opponent in early-season scrimmage missing location.
+        assert _team_canonical_name({"location": "", "name": "Wildcats"}) == "Wildcats"
+        assert _team_canonical_name({"name": "Wildcats"}) == "Wildcats"
+
+    # ---------- LEAGUE_CONTEXTS ----------
+
+    def test_bsb_in_league_contexts(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS["BSB"]
+        assert ctx.format == "win_count"
+        labels = {label for _cut, label, _w in ctx.thresholds}
+        assert "tournament_bubble" in labels
+        assert "at_large_lock" in labels
+        assert "regional_top_seed" in labels
+        assert "national_seed" in labels
+        assert "overall_one_seed" in labels
+
+    def test_bsb_thresholds_strictly_monotonic(self):
+        # Each band's cutoff must be strictly greater than the prior so
+        # the cascade fires cleanly. A team with 50 wins satisfies every
+        # lower-cutoff band.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        cuts = [cut for cut, _label, _w in LEAGUE_CONTEXTS["BSB"].thresholds]
+        for i in range(len(cuts) - 1):
+            assert cuts[i] < cuts[i + 1], f"BSB band cutoffs must be monotonic: {cuts}"


### PR DESCRIPTION
## Summary

- New `NcaaBaseballSource` (PointsBasedSportSource subclass) via ESPN unofficial API + D1Baseball Top 25 poll. No API key required.
- Win-count thresholds at 30 / 35 / 40 / 45 / 50 — tuned against historical NCAA Tournament selection criteria.
- CWS postseason bracket NOT modeled (double-elimination is a new structural shape filed as #22).

## ESPN API quirk caught in live verify

ESPN's scoreboard endpoint silently caps `dates=YYYYMMDD-YYYYMMDD` (range) responses at 25 events regardless of `limit=`. Single-date queries return all games for that day. Fix: per-day iteration in both `fetch_upcoming` and `_fetch_full_season_games`. Per-day sweep Feb 1 to today (~110 days) costs ~18s.

## Live verification

2026 D1 baseball season as of 2026-05-25:
- 5367 games fetched, 5366 finished, 324 teams.
- Standings reproduce reality (with my data being more current than the once-weekly D1Baseball poll):

```
#1  UCLA            51W- 6L  (poll: 48-6)
#3  Georgia Tech    48W- 9L  (poll: 45-9)
#4  Georgia         46W-12L  (poll: 43-12)
    Jacksonville St 46W-13L  (no rank — quietly elite season)
#2  North Carolina  45W-11L  (poll: 43-10-1)
```

## Test plan

- [x] 287/287 unit tests pass (was 275; +12 new for game-record extraction, in-progress demotion, missing-score defense, team-name canonicalization, LEAGUE_CONTEXTS structure, threshold monotonicity).
- [x] Live verified standings reproduce reality (5367 games / 324 teams in 18s).
- [x] Found and fixed the ESPN range-cap bug during live verify.
- [x] Filed CWS bracket follow-up (#22) — same double-elimination pattern Phase N (Softball) will reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)