### PR TITLE
Phase K: WNBA (regular + playoffs)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -119,6 +119,13 @@
       "help_text": "MLS games surface with favorite + closeness scoring only in V1 — no standings-based importance yet (conference structure and the mixed-format MLS Cup bracket are follow-ups). Uses ESPN's unofficial site.api.espn.com for the schedule. The Odds API key enables closeness via the soccer_usa_mls market; without it, MLS games appear but with no closeness signal."
     },
     {
+      "id": "enable_wnba",
+      "type": "boolean",
+      "label": "WNBA (regular season + playoffs)",
+      "default": false,
+      "help_text": "Regular season uses win count (20+ bubble, 25+ playoff-secured, 30+ top-seed pace, 35+ elite) over the 40-game season. Playoffs have mixed series lengths: R1 best-of-3, Semifinals best-of-5, Finals best-of-5 in 2024 / best-of-7 in 2025+. No API key required — uses ESPN's unofficial site.api.espn.com."
+    },
+    {
       "id": "enable_ncaa_baseball",
       "type": "boolean",
       "label": "NCAA Baseball (D1)",

--- a/plugin.py
+++ b/plugin.py
@@ -295,6 +295,7 @@ def _build_sources(settings: Dict[str, Any]):
         KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
         MlsSource,
         NbaPlayoffSource, NbaRegularSource,
+        WnbaPlayoffSource, WnbaRegularSource,
         NcaaBaseballSource, NcaaSoccerSource,
         NcaafSource, NcaamSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
@@ -409,6 +410,20 @@ def _build_sources(settings: Dict[str, Any]):
     # it MLS games surface but with no closeness signal.
     if settings.get("enable_mls", False):
         sources.append(MlsSource(odds_api_key=odds_key or ""))
+
+    # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
+    # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1
+    # best-of-3, SF best-of-5, FINALS best-of-5 in 2024 / best-of-7
+    # in 2025+.
+    if settings.get("enable_wnba", False):
+        wnba_reg = WnbaRegularSource()
+        sources.append(wnba_reg)
+        wnba_po = WnbaPlayoffSource()
+        try:
+            wnba_po.set_regular_season_strengths(wnba_reg.estimate_strengths())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[wnba] could not seed playoff strengths: %s", exc)
+        sources.append(wnba_po)
 
     # Phase M: NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
     # poll, no key needed. Win-count thresholds (30 / 35 / 40 / 45 / 50) drive

--- a/scoring.py
+++ b/scoring.py
@@ -184,8 +184,14 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # depth label across NHL and NBA doesn't cause cross-contamination.
     "CSF":             1,  # Conference Semifinals (4 series)
     "CF":              2,  # Conference Finals (2 series)
-    "FINALS":          3,  # NBA Finals (1 series)
+    "FINALS":          3,  # NBA Finals (1 series) / WNBA Finals (1 series)
     "FINALS_WINNER":   4,  # NBA Champion
+    # WNBA playoffs (Phase K): 3 rounds, mixed series lengths.
+    # R1 (depth 0) and FINALS (depth 3) reuse the labels already in
+    # this table — terminal_outcomes reads per-league bands so no
+    # cross-contamination. SF needs its own depth between R1 and FINALS.
+    "SF":              1,  # WNBA Semifinals (between R1 and FINALS)
+    "WNBA_WINNER":     4,  # WNBA Champion (same synthetic depth as FINALS_WINNER)
 }
 
 
@@ -485,6 +491,35 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             ("FINALS_WINNER",  "finals_winner",    10.0),
         ],
         boundary_summary="R1 → Conf Semis → Conf Finals → NBA Finals → Champion",
+    ),
+    # Phase K: WNBA regular season. 40-game season; 8 of 12-13 teams
+    # make playoffs (since 2022's expansion). The playoff bubble has
+    # historically settled around 19-21 wins; top seed pace is ~28-32
+    # in the current era. Thresholds are tighter than NBA's because
+    # the season is shorter — equal "strength" of a 25-win WNBA team
+    # ≈ 50-win NBA team relative to the league.
+    "WNBA": LeagueContext(
+        code="WNBA", matchdays_total=40, format="win_count",
+        thresholds=[
+            (20, "playoff_bubble",   1.5),  # 8th seed line
+            (25, "playoff_secured",  2.5),  # comfortable in
+            (30, "top_seed_pace",    4.0),  # top-2 seed pace
+            (35, "elite",            5.0),  # historic
+        ],
+        boundary_summary="20+ wins → bubble · 25+ → comfortable · 30+ → top seed · 35+ → elite",
+    ),
+    # Phase K: WNBA playoffs. Three rounds with variable series
+    # lengths (R1=3, SF=5, FINALS=5 in 2024 or 7 in 2025+). Weights
+    # mirror NBA's playoff ramp; bracket structure differs (no
+    # conference reseeding, fewer total games).
+    "WNBA_PO": LeagueContext(
+        code="WNBA_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("SF",           "wnba_semis",     1.0),
+            ("FINALS",       "wnba_finals",    5.0),
+            ("WNBA_WINNER",  "wnba_winner",   10.0),
+        ],
+        boundary_summary="R1 → Semis → WNBA Finals → Champion",
     ),
 }
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -3,6 +3,7 @@ from .base import GameRow, SportSource
 from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .nba import NbaPlayoffSource, NbaRegularSource
+from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaa_baseball import NcaaBaseballSource
 from .ncaa_soccer import NcaaSoccerSource
 from .ncaaf import NcaafSource
@@ -19,6 +20,7 @@ __all__ = [
     "MlbRegularSource", "MlbPlayoffSource",
     "MlsSource",
     "NbaRegularSource", "NbaPlayoffSource",
+    "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaaBaseballSource", "NcaaSoccerSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",

--- a/sources/wnba.py
+++ b/sources/wnba.py
@@ -1,0 +1,463 @@
+"""WNBA source — ESPN's unofficial `site.api.espn.com` API. No key required.
+
+Two source classes mirroring the NBA pattern (Phase G), with WNBA-specific
+adjustments:
+
+  - `WnbaRegularSource(PointsBasedSportSource)`: 40-game regular season,
+    raw wins as the threshold field. LEAGUE_CONTEXTS["WNBA"] thresholds
+    at 20 (playoff bubble — 8 of 13 teams make playoffs) / 25
+    (comfortable) / 30 (top-seed pace) / 35 (elite).
+  - `WnbaPlayoffSource(BestOfNSeriesSource)`: variable series lengths
+    via `_series_length_for_stage` — R1 best-of-3, Semifinals best-of-5,
+    Finals best-of-5 (≤2024) or best-of-7 (≥2025 when the WNBA expanded
+    the championship series). The stage labels are R1 / SF / FINALS;
+    cross-conference seeding (no East/West split in the playoffs since
+    2022's reseed format).
+
+API quirks captured here:
+  - `season.type`: 2 = regular season, 3 = postseason. Same as NBA.
+  - All-Star Tournament games are tagged `competition.type.abbreviation
+    == "ALLSTAR"` and filtered out. Same trap as NBA.
+  - Headline format differs from NBA: WNBA has no East/West discriminator.
+    Patterns: "First Round - Game N" (R1), "WNBA Semifinals - Game N"
+    (SF), "WNBA Finals - Game N" (FINALS).
+  - Team-name canonicalization: `team.displayName` ("New York Liberty",
+    "Minnesota Lynx").
+
+The plugin opts into WNBA via `enable_wnba` in `plugin.json`. Off by
+default.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base import GameRow
+from .bracket import BestOfNSeriesSource
+from .points_based import PointsBasedSportSource
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.wnba")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/basketball/wnba"
+
+# WNBA averages ~82 points per team per game in the modern (post-2020)
+# era. Used as the prior for teams the simulator hasn't seen yet
+# (expansion teams, early-season imports).
+_DEFAULT_POINTS_FOR = 82.0
+_DEFAULT_POINTS_AGAINST = 82.0
+
+# WNBA season runs mid-May through mid-October (regular), with playoffs
+# in late-September through mid-October (mid-October through November
+# for the new 2025+ Finals format). Window: May 1 - Nov 30.
+SEASON_START_MONTH = 5   # May
+SEASON_END_MONTH = 11    # November (covers expanded 2025+ playoff window)
+
+# 2025+ WNBA Finals are best-of-7; 2024 and earlier were best-of-5.
+# Series lengths per stage:
+_WNBA_SERIES_LENGTHS_MODERN: Dict[str, int] = {
+    "R1": 3,        # best-of-3 since 2022
+    "SF": 5,        # best-of-5 since 2022
+    "FINALS": 7,    # best-of-7 from 2025
+}
+_WNBA_SERIES_LENGTHS_LEGACY: Dict[str, int] = {
+    "R1": 3,
+    "SF": 5,
+    "FINALS": 5,    # best-of-5 in 2024 and earlier
+}
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Dict[str, Any]]:
+    """ESPN unofficial API wrapper. Returns parsed JSON or None on
+    any error. Logs at WARNING."""
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[wnba] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[wnba] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """ESPN's WNBA displayName is the full City+Mascot form, which is
+    what EPG providers use."""
+    name = (team_obj.get("displayName") or "").strip()
+    if name:
+        return name
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _default_season_year() -> int:
+    """WNBA seasons are named by the calendar year. Use current year
+    in-season; pre-May treat as last season (postseason / off-season)."""
+    now = datetime.now(timezone.utc)
+    return now.year if now.month >= SEASON_START_MONTH else now.year - 1
+
+
+# Headline parser. WNBA exposes playoff stage in `competition.notes[0].
+# headline`. Unlike NBA, there's no East/West prefix — the league
+# uses cross-conference reseeding since 2022.
+_HEADLINE_RE = re.compile(
+    r"^(?:(?P<round>First\s+Round)|WNBA\s+(?P<wnba>Semifinals|Finals))\s*-\s*Game\s+(?P<game>\d+)",
+    re.IGNORECASE,
+)
+
+_ROUND_TO_STAGE: Dict[str, str] = {
+    "first round": "R1",
+    "semifinals":  "SF",
+    "finals":      "FINALS",
+}
+
+
+def _parse_stage_from_headline(headline: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return {"stage": str, "matchday": int} on match, or None."""
+    if not headline:
+        return None
+    m = _HEADLINE_RE.search(headline)
+    if not m:
+        return None
+    try:
+        matchday = int(m.group("game"))
+    except (TypeError, ValueError):
+        return None
+    if m.group("wnba"):
+        round_key = m.group("wnba").lower().strip()
+    else:
+        round_key = (m.group("round") or "").lower().strip()
+    round_key = re.sub(r"\s+", " ", round_key)
+    stage = _ROUND_TO_STAGE.get(round_key)
+    if stage is None:
+        return None
+    return {"stage": stage, "matchday": matchday}
+
+
+def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert one ESPN scoreboard event into the canonical record.
+    Returns None for unscoreable events (cancellations, postponements
+    with no competitors) AND for non-bracket exhibition games like
+    the WNBA All-Star Game (tagged `competition.type.abbreviation
+    == "ALLSTAR"`).
+    """
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    comp_type_abbrev = ((comp.get("type") or {}).get("abbreviation") or "").upper()
+    if comp_type_abbrev == "ALLSTAR":
+        return None
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = _team_canonical_name(home.get("team") or {})
+    away_team = _team_canonical_name(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    elif state == "in":
+        status = "SCHEDULED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    return {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "season_type": ((event.get("season") or {}).get("type")),
+        "notes": comp.get("notes") or [],
+    }
+
+
+# =====================================================================
+# WnbaRegularSource
+# =====================================================================
+
+
+class WnbaRegularSource(PointsBasedSportSource):
+    """WNBA regular-season importance via PointsBasedSportSource.
+
+    Uses raw `wins` count (no OT bonus). 40-game season; 8 teams make
+    playoffs out of 12-13. Thresholds reflect that cut-line shape: 20
+    wins is roughly the 8th seed line, 30 wins is top-seed pace.
+    """
+
+    league_context_code = "WNBA"
+    _count_field = "wins"
+    _DEFAULT_POINTS_FOR = _DEFAULT_POINTS_FOR
+    _DEFAULT_POINTS_AGAINST = _DEFAULT_POINTS_AGAINST
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        super().__init__()
+        self.season_year = season_year or _default_season_year()
+
+    @property
+    def sport_prefix(self) -> str:
+        return "WNBA"
+
+    @property
+    def sport_label(self) -> str:
+        return "WNBA"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Per-day scoreboard sweep for the next N days. Regular-season
+        games only (filter via season.type==2)."""
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None or rec.get("season_type") != 2:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "wnba_game_id": eid,
+                        "fd_competition_code": self.league_context_code,
+                    },
+                ))
+        return out
+
+    def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
+        """Walk every day of the regular season window. WNBA's regular
+        season is mid-May through mid-September; this covers May
+        through end of September with daily iteration. ESPN's range
+        endpoint silently caps at 25 events; daily queries return
+        everything for that day."""
+        seen: Dict[Any, Dict[str, Any]] = {}
+        season_start = datetime(self.season_year, SEASON_START_MONTH, 1,
+                                tzinfo=timezone.utc).date()
+        # Regular season ends ~September 19; pad to Sept 30.
+        regular_end = datetime(self.season_year, 9, 30, tzinfo=timezone.utc).date()
+        now = datetime.now(timezone.utc).date()
+        end = min(now + timedelta(days=7), regular_end)
+        if end < season_start:
+            return []
+        day = season_start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 2:
+                        continue
+                    if rec["id"] in seen:
+                        continue
+                    seen[rec["id"]] = {
+                        k: v for k, v in rec.items()
+                        if k not in ("season_type", "notes")
+                    }
+            day += timedelta(days=1)
+        return list(seen.values())
+
+
+# =====================================================================
+# WnbaPlayoffSource
+# =====================================================================
+
+
+class WnbaPlayoffSource(BestOfNSeriesSource):
+    """WNBA playoffs with per-stage variable series lengths.
+
+    Series lengths (since 2022 reseeding format):
+      - R1 (First Round):    best-of-3
+      - SF (Semifinals):     best-of-5
+      - FINALS:              best-of-5 in 2024 and earlier, best-of-7
+                             from 2025. Series length picked from the
+                             instance's season_year.
+    """
+
+    KO_STAGES = ("R1", "SF", "FINALS")
+    SERIES_LENGTH = 7   # uniform fallback; per-stage map below overrides
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        self.season_year = season_year or _default_season_year()
+        # 2025+ uses best-of-7 Finals; 2024 and earlier are best-of-5.
+        self._stage_lengths = (
+            _WNBA_SERIES_LENGTHS_MODERN
+            if self.season_year >= 2025
+            else _WNBA_SERIES_LENGTHS_LEGACY
+        )
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "WNBA"
+
+    @property
+    def sport_label(self) -> str:
+        return "WNBA Playoffs"
+
+    def _league_context_code(self) -> str:
+        return "WNBA_PO"
+
+    def _series_length_for_stage(self, stage: str) -> int:
+        return self._stage_lengths.get(stage, self.SERIES_LENGTH)
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        if stage == "FINALS":
+            return "WNBA_WINNER"
+        return None
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Next-N-day playoff schedule (season.type==3 filter)."""
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None or rec.get("season_type") != 3:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "wnba_game_id": eid,
+                        "fd_competition_code": self._league_context_code(),
+                    },
+                ))
+        return out
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]]
+    ) -> None:
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_POINTS_FOR,
+            "pa_per_game": _DEFAULT_POINTS_AGAINST,
+        }
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Pull the postseason schedule via per-day scoreboard and parse
+        the ESPN headline for stage routing. Window: Sept 1 - Oct 31 of
+        season_year (covers all historical WNBA playoff windows including
+        the expanded 2025+ Finals which can stretch into late October).
+        """
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        out: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        start = datetime(self.season_year, 9, 1, tzinfo=timezone.utc).date()
+        # WNBA Finals can stretch to Nov 1 in the new best-of-7 format.
+        end = datetime(self.season_year, 11, 15, tzinfo=timezone.utc).date()
+        day = start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 3:
+                        continue
+                    if rec["id"] in seen_ids:
+                        continue
+                    headline = None
+                    notes = rec.get("notes") or []
+                    if notes:
+                        headline = (notes[0] or {}).get("headline")
+                    parsed = _parse_stage_from_headline(headline)
+                    if parsed is None:
+                        continue
+                    seen_ids.add(rec["id"])
+                    out.append({
+                        "game_id": rec["id"],
+                        "stage": parsed["stage"],
+                        "matchday": parsed["matchday"],
+                        "home": rec["home"],
+                        "away": rec["away"],
+                        "home_goals": rec["home_points"],
+                        "away_goals": rec["away_points"],
+                        "status": rec["status"],
+                        "start_time": rec["start_time"],
+                        "extra": {"headline": headline},
+                    })
+            day += timedelta(days=1)
+        self._bracket_games_cache = out
+        return out

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -3554,3 +3554,237 @@ class TestMlsFetchUpcomingShape:
 
         assert len(games) == 1
         assert games[0].closeness is None  # no odds, no closeness
+
+
+# =====================================================================
+# Phase K: WNBA
+# =====================================================================
+
+class TestWnbaHeadlineParser:
+    """WNBA headline regex differs from NBA — no East/West prefix on R1
+    ("First Round"), WNBA name appears explicitly on Semifinals and
+    Finals ("WNBA Semifinals", "WNBA Finals")."""
+
+    @staticmethod
+    def _parse(headline):
+        from dispatcharr_ranked_matchups.sources.wnba import _parse_stage_from_headline
+        return _parse_stage_from_headline(headline)
+
+    def test_first_round(self):
+        assert self._parse("First Round - Game 1") == {"stage": "R1", "matchday": 1}
+
+    def test_first_round_game_3(self):
+        # Best-of-3 R1 can go to game 3.
+        assert self._parse("First Round - Game 3") == {"stage": "R1", "matchday": 3}
+
+    def test_semifinals(self):
+        assert self._parse("WNBA Semifinals - Game 5") == {"stage": "SF", "matchday": 5}
+
+    def test_finals_game_one(self):
+        assert self._parse("WNBA Finals - Game 1") == {"stage": "FINALS", "matchday": 1}
+
+    def test_finals_game_seven(self):
+        # 2025+ Finals can go to game 7.
+        assert self._parse("WNBA Finals - Game 7") == {"stage": "FINALS", "matchday": 7}
+
+    def test_no_headline_returns_none(self):
+        assert self._parse(None) is None
+        assert self._parse("") is None
+
+    def test_unrecognized_returns_none(self):
+        assert self._parse("Preseason - Exhibition") is None
+        assert self._parse("Commissioner's Cup") is None
+
+    def test_case_insensitive(self):
+        assert self._parse("first round - game 2") == {"stage": "R1", "matchday": 2}
+        assert self._parse("wnba finals - game 1") == {"stage": "FINALS", "matchday": 1}
+
+
+class TestWnbaAllStarFilter:
+    """Same All-Star filter pattern as NBA — WNBA also runs an
+    All-Star Game tagged competition.type.abbreviation=ALLSTAR."""
+
+    @staticmethod
+    def _extract(event):
+        from dispatcharr_ranked_matchups.sources.wnba import _extract_game_record
+        return _extract_game_record(event)
+
+    def test_all_star_game_filtered(self):
+        event = {
+            "id": "401705500",
+            "date": "2025-07-19T23:00Z",
+            "season": {"year": 2025, "type": 2, "slug": "regular-season"},
+            "competitions": [{
+                "type": {"id": "4", "abbreviation": "ALLSTAR"},
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "score": "120",
+                     "team": {"displayName": "Team Caitlin"}},
+                    {"homeAway": "away", "score": "115",
+                     "team": {"displayName": "Team Aliyah"}},
+                ],
+            }],
+        }
+        assert self._extract(event) is None
+
+    def test_regular_season_game_passes(self):
+        event = {
+            "id": "401705501",
+            "date": "2025-06-15T23:00Z",
+            "season": {"year": 2025, "type": 2, "slug": "regular-season"},
+            "competitions": [{
+                "type": {"id": "1", "abbreviation": "STD"},
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "score": "82",
+                     "team": {"displayName": "New York Liberty"}},
+                    {"homeAway": "away", "score": "78",
+                     "team": {"displayName": "Connecticut Sun"}},
+                ],
+            }],
+        }
+        rec = self._extract(event)
+        assert rec is not None
+        assert rec["home"] == "New York Liberty"
+        assert rec["season_type"] == 2
+
+
+class TestWnbaRegularSource:
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.wnba import WnbaRegularSource
+        return WnbaRegularSource(season_year=2024)
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "WNBA"
+        assert src.sport_label == "WNBA"
+        assert src.league_context_code == "WNBA"
+        assert src._count_field == "wins"
+
+    def test_supports_importance(self):
+        assert self._make().supports_importance is True
+
+    def test_outcome_labels(self):
+        labels = self._make().outcome_labels
+        assert "playoff_bubble" in labels
+        assert "playoff_secured" in labels
+        assert "top_seed_pace" in labels
+        assert "elite" in labels
+
+    def test_thresholds_monotonic(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS["WNBA"]
+        cuts = [t[0] for t in ctx.thresholds]
+        for i in range(len(cuts) - 1):
+            assert cuts[i] < cuts[i + 1]
+
+    def test_terminal_outcomes_by_win_count(self):
+        src = self._make()
+        state = {
+            "_applied": frozenset(),
+            "_teams": {
+                "Cellar":   {"wins":  8, "losses": 32, "pf": 0, "pa": 0, "games_played": 40},
+                "Bubble":   {"wins": 22, "losses": 18, "pf": 0, "pa": 0, "games_played": 40},
+                "Comfy":    {"wins": 26, "losses": 14, "pf": 0, "pa": 0, "games_played": 40},
+                "Top":      {"wins": 32, "losses":  8, "pf": 0, "pa": 0, "games_played": 40},
+                "Historic": {"wins": 38, "losses":  2, "pf": 0, "pa": 0, "games_played": 40},
+            },
+        }
+        outcomes = src.terminal_outcomes(state)
+        assert outcomes["Cellar"] == []
+        assert set(outcomes["Bubble"]) == {"playoff_bubble"}
+        assert set(outcomes["Comfy"]) == {"playoff_bubble", "playoff_secured"}
+        assert set(outcomes["Top"]) == {"playoff_bubble", "playoff_secured", "top_seed_pace"}
+        assert set(outcomes["Historic"]) == {
+            "playoff_bubble", "playoff_secured", "top_seed_pace", "elite",
+        }
+
+
+class TestWnbaPlayoffSource:
+
+    @staticmethod
+    def _make_source(season_year=2024, bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.wnba import WnbaPlayoffSource
+        src = WnbaPlayoffSource(season_year=season_year)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make_source()
+        assert src.sport_prefix == "WNBA"
+        assert "Playoffs" in src.sport_label
+        assert src._league_context_code() == "WNBA_PO"
+
+    def test_supports_importance(self):
+        assert self._make_source().supports_importance is True
+
+    def test_ko_stages(self):
+        assert self._make_source().KO_STAGES == ("R1", "SF", "FINALS")
+
+    def test_series_lengths_2024(self):
+        src = self._make_source(season_year=2024)
+        assert src._series_length_for_stage("R1") == 3
+        assert src._series_length_for_stage("SF") == 5
+        assert src._series_length_for_stage("FINALS") == 5  # legacy
+
+    def test_series_lengths_2025(self):
+        src = self._make_source(season_year=2025)
+        assert src._series_length_for_stage("R1") == 3
+        assert src._series_length_for_stage("SF") == 5
+        assert src._series_length_for_stage("FINALS") == 7  # modern
+
+    def test_winner_advance_label(self):
+        src = self._make_source()
+        assert src._winner_advance_label("FINALS") == "WNBA_WINNER"
+        assert src._winner_advance_label("R1") is None
+        assert src._winner_advance_label("SF") is None
+
+    def test_outcome_labels(self):
+        labels = self._make_source().outcome_labels
+        assert "wnba_semis" in labels
+        assert "wnba_finals" in labels
+        assert "wnba_winner" in labels
+
+    def test_finals_winner_advance_reaches_synthetic_depth(self):
+        """2024 WNBA Finals: Liberty beat Lynx 3-2 in best-of-5. Synthesize
+        the 5-game series and confirm Liberty reaches WNBA_WINNER depth."""
+        games = [
+            {"game_id": "f1", "stage": "FINALS", "matchday": 1,
+             "home": "Liberty", "away": "Lynx",
+             "home_goals": 87, "away_goals": 81,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f2", "stage": "FINALS", "matchday": 2,
+             "home": "Liberty", "away": "Lynx",
+             "home_goals": 78, "away_goals": 80,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f3", "stage": "FINALS", "matchday": 3,
+             "home": "Lynx", "away": "Liberty",
+             "home_goals": 80, "away_goals": 77,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f4", "stage": "FINALS", "matchday": 4,
+             "home": "Lynx", "away": "Liberty",
+             "home_goals": 71, "away_goals": 80,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f5", "stage": "FINALS", "matchday": 5,
+             "home": "Liberty", "away": "Lynx",
+             "home_goals": 67, "away_goals": 62,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make_source(season_year=2024, bracket_games=games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["Liberty"] == KNOCKOUT_ROUND_DEPTH["WNBA_WINNER"]
+        assert state["_round_reached"]["Lynx"] == KNOCKOUT_ROUND_DEPTH["FINALS"]
+        outcomes = src.terminal_outcomes(state)
+        assert "wnba_winner" in outcomes["Liberty"]
+        assert "wnba_winner" not in outcomes["Lynx"]
+        assert "wnba_finals" in outcomes["Lynx"]
+
+    def test_wnba_po_thresholds_are_depth_ordered(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH
+        ctx = LEAGUE_CONTEXTS["WNBA_PO"]
+        depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
+        for i in range(len(depths) - 1):
+            assert depths[i] < depths[i + 1]


### PR DESCRIPTION
Adds WNBA via ESPN unofficial API. `WnbaRegularSource` (40-game season, win-count thresholds 20/25/30/35) and `WnbaPlayoffSource` with per-stage series lengths (R1=3, SF=5, FINALS=5 in 2024 / 7 in 2025+). Headline parser handles WNBA's prefix-less format. All-Star filter reused from NBA.

**Live verify (2024 season)**: 12 teams, Liberty 32W-9L (#1), Lynx 31W-10L (#2) — matches actual standings. Playoff cascade: Liberty=WNBA_WINNER, Lynx=FINALS — matches actual outcome (Liberty beat Lynx 3-2 in best-of-5 Finals).

**Tests**: 17 new, 495 total passing.

Refs #16