### PR TITLE
Phase L: NCAA Women's Basketball + March Madness

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -126,6 +126,13 @@
       "help_text": "Regular season uses win count (20+ bubble, 25+ playoff-secured, 30+ top-seed pace, 35+ elite) over the 40-game season. Playoffs have mixed series lengths: R1 best-of-3, Semifinals best-of-5, Finals best-of-5 in 2024 / best-of-7 in 2025+. No API key required — uses ESPN's unofficial site.api.espn.com."
     },
     {
+      "id": "enable_ncaaw_basketball",
+      "type": "boolean",
+      "label": "NCAA Women's Basketball (D1 + March Madness)",
+      "default": false,
+      "help_text": "D1 regular season uses win count (20+ tournament bubble, 25+ at-large lock, 28+ top-4 seed, 32+ #1 seed contention). March Madness bracket is single-game elimination: R64 → R32 → Sweet 16 → Elite 8 → Final Four → National Championship → Champion. ESPN unofficial API + AP Top 25. No API key required."
+    },
+    {
       "id": "enable_ncaa_baseball",
       "type": "boolean",
       "label": "NCAA Baseball (D1)",

--- a/plugin.py
+++ b/plugin.py
@@ -296,6 +296,7 @@ def _build_sources(settings: Dict[str, Any]):
         MlsSource,
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
+        NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
         NcaaBaseballSource, NcaaSoccerSource,
         NcaafSource, NcaamSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
@@ -424,6 +425,19 @@ def _build_sources(settings: Dict[str, Any]):
         except Exception as exc:  # noqa: BLE001
             logger.warning("[wnba] could not seed playoff strengths: %s", exc)
         sources.append(wnba_po)
+
+    # NCAA Women's Basketball + March Madness — no API key required.
+    # Single-game-elim bracket (SERIES_LENGTH=1 per stage). Pair-and-
+    # seed strength sharing identical to NHL/MLB/NBA/WNBA.
+    if settings.get("enable_ncaaw_basketball", False):
+        ncaaw_reg = NcaawBasketballRegularSource()
+        sources.append(ncaaw_reg)
+        ncaaw_po = NcaawBasketballPlayoffSource()
+        try:
+            ncaaw_po.set_regular_season_strengths(ncaaw_reg.estimate_strengths())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ncaaw_basketball] could not seed playoff strengths: %s", exc)
+        sources.append(ncaaw_po)
 
     # Phase M: NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
     # poll, no key needed. Win-count thresholds (30 / 35 / 40 / 45 / 50) drive

--- a/scoring.py
+++ b/scoring.py
@@ -192,6 +192,15 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # cross-contamination. SF needs its own depth between R1 and FINALS.
     "SF":              1,  # WNBA Semifinals (between R1 and FINALS)
     "WNBA_WINNER":     4,  # WNBA Champion (same synthetic depth as FINALS_WINNER)
+    # NCAA Women's March Madness (Phase L): 6 rounds, all single-game
+    # elimination. SERIES_LENGTH=1 per stage; first to 1 win clinches.
+    "R64":             0,  # 1st Round (32 games)
+    "R32":             1,  # 2nd Round (16 games)
+    "S16":             2,  # Sweet 16 (8 games)
+    "E8":              3,  # Elite 8 (4 games)
+    "F4":              4,  # Final Four (2 games)
+    "NCG":             5,  # National Championship Game
+    "NCG_WINNER":      6,  # National Champion
 }
 
 
@@ -520,6 +529,37 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             ("WNBA_WINNER",  "wnba_winner",   10.0),
         ],
         boundary_summary="R1 → Semis → WNBA Finals → Champion",
+    ),
+    # Phase L: NCAA Women's Basketball regular season. ~32-game D1 season;
+    # 64 teams make the NCAA Tournament. Threshold bands cover the
+    # selection / seeding lines: 20 wins is the rough at-large bubble
+    # for power-conf teams, 25+ is a comfortable at-large lock, 28+
+    # tends to anchor a top-4 seed line, 32+ contends for #1 overall.
+    "NCAAW_BBALL": LeagueContext(
+        code="NCAAW_BBALL", matchdays_total=32, format="win_count",
+        thresholds=[
+            (20, "tournament_bubble",   1.5),
+            (25, "at_large_lock",       2.5),
+            (28, "top_4_seed",          4.0),
+            (32, "no_1_seed",           5.0),
+        ],
+        boundary_summary="20+ wins → bubble · 25+ → at-large lock · 28+ → top-4 seed · 32+ → #1 seed",
+    ),
+    # Phase L: NCAA Women's March Madness. 6 rounds, single-game
+    # elimination at each step. Weights ramp steeper than the pro
+    # bracket leagues because single-game elim concentrates leverage
+    # — every game IS the series for the round.
+    "NCAAW_BBALL_PO": LeagueContext(
+        code="NCAAW_BBALL_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("R32",        "round_of_32",    1.0),
+            ("S16",        "sweet_16",       2.0),
+            ("E8",         "elite_8",        3.5),
+            ("F4",         "final_four",     5.0),
+            ("NCG",        "national_final", 7.0),
+            ("NCG_WINNER", "national_champ", 10.0),
+        ],
+        boundary_summary="R64 → R32 → Sweet 16 → Elite 8 → Final Four → NCG → Champion",
     ),
 }
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -4,6 +4,9 @@ from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
+from .ncaaw_basketball import (
+    NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
+)
 from .ncaa_baseball import NcaaBaseballSource
 from .ncaa_soccer import NcaaSoccerSource
 from .ncaaf import NcaafSource
@@ -21,6 +24,7 @@ __all__ = [
     "MlsSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
+    "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",
     "NcaaBaseballSource", "NcaaSoccerSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",

--- a/sources/ncaaw_basketball.py
+++ b/sources/ncaaw_basketball.py
@@ -1,0 +1,461 @@
+"""NCAA Women's Basketball source — ESPN's unofficial site.api.espn.com.
+No API key required.
+
+Two source classes:
+  - `NcaawBasketballRegularSource(PointsBasedSportSource)`: regular
+    season win-count importance. AP Top-25 ranks attached to upcoming
+    games via the rankings endpoint.
+  - `NcaawBasketballPlayoffSource(BestOfNSeriesSource)`: March Madness
+    bracket as single-game elim (SERIES_LENGTH=1 per stage, clinches
+    at ceil(1/2)=1 win). Stages: R64 -> R32 -> S16 -> E8 -> F4 -> NCG.
+    First Four play-in games are NOT modeled (they're structurally
+    before R64 and only feed 4 of the 64 R64 slots).
+
+API patterns:
+  - /scoreboard?dates=YYYYMMDD for per-day games (range syntax caps at
+    25 events).
+  - /rankings exposes AP Top 25 + Coaches Poll. Prefer AP.
+  - Tournament stage in competition.notes[0].headline, e.g.
+      "NCAA Women's Championship - Regional 2 in Birmingham - 1st Round"
+      "NCAA Women's Championship - Regional 2 in Birmingham - Sweet 16"
+      "NCAA Women's Championship - Final Four"
+      "NCAA Women's Championship - National Championship"
+
+Team names use ESPN's `team.location` ("UConn", "South Carolina")
+which matches EPG provider titles better than the full displayName
+("UConn Huskies").
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base import GameRow
+from .bracket import BestOfNSeriesSource
+from .points_based import PointsBasedSportSource
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaaw_basketball")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/basketball/womens-college-basketball"
+
+# Modern D1 women's basketball averages ~72 points per team per game.
+_DEFAULT_POINTS_FOR = 72.0
+_DEFAULT_POINTS_AGAINST = 72.0
+
+# Season runs early-November through early-April (regular ends ~mid-March,
+# tournament early April). Window for per-day iteration.
+SEASON_START_MONTH = 11  # November
+SEASON_END_MONTH = 4     # April (tournament)
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Dict[str, Any]]:
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[ncaaw_basketball] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[ncaaw_basketball] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """Use `team.location` (school name) which is what NCAA EPG entries
+    use (e.g., 'UConn at South Carolina', not 'UConn Huskies at South
+    Carolina Gamecocks')."""
+    loc = (team_obj.get("location") or "").strip()
+    if loc:
+        return loc
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _default_season_end_year() -> int:
+    """Season runs Nov YYYY through April YYYY+1. The "season year" is
+    the calendar year the tournament ends in (matching ESPN's convention
+    for tournaments — the 2024-25 season ends with the March 2025 NCG)."""
+    now = datetime.now(timezone.utc)
+    # Pre-November: still in previous season's offseason.
+    return now.year + 1 if now.month >= SEASON_START_MONTH else now.year
+
+
+# Tournament-stage regex. Matches the round suffix on ESPN's headline.
+# The "Regional N in {City}" prefix only appears for R64..E8; F4 and NCG
+# have no regional prefix. Both formats handled here.
+_HEADLINE_RE = re.compile(
+    r"NCAA\s+Women'?s?\s+Championship\s*-\s*"
+    r"(?:Regional\s+\d+\s+in\s+[^-]+\s*-\s*)?"
+    r"(?P<round>1st\s+Round|2nd\s+Round|Sweet\s*16|Elite\s*8|Final\s+Four|National\s+Championship)",
+    re.IGNORECASE,
+)
+
+_ROUND_TO_STAGE: Dict[str, str] = {
+    "1st round":             "R64",
+    "2nd round":             "R32",
+    "sweet 16":              "S16",
+    "elite 8":               "E8",
+    "final four":            "F4",
+    "national championship": "NCG",
+}
+
+
+def _parse_stage_from_headline(headline: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return {"stage": str, "matchday": 1}, or None.
+
+    Single-elimination, so matchday is always 1 (each "tie" is one
+    game; BestOfNSeriesSource resolves at ceil(1/2)=1 win)."""
+    if not headline:
+        return None
+    m = _HEADLINE_RE.search(headline)
+    if not m:
+        return None
+    round_key = re.sub(r"\s+", " ", m.group("round").lower().strip())
+    # Normalize "sweet16" / "elite8" variants (sometimes ESPN drops the space).
+    round_key = round_key.replace("sweet16", "sweet 16").replace("elite8", "elite 8")
+    stage = _ROUND_TO_STAGE.get(round_key)
+    if stage is None:
+        return None
+    return {"stage": stage, "matchday": 1}
+
+
+def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    # No All-Star filter needed for NCAA — there's no All-Star Game in
+    # college basketball. competition.type.abbreviation is always STD
+    # for regular season, and the tournament uses headline-based
+    # stage routing.
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = _team_canonical_name(home.get("team") or {})
+    away_team = _team_canonical_name(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    return {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "season_type": ((event.get("season") or {}).get("type")),
+        "notes": comp.get("notes") or [],
+    }
+
+
+# =====================================================================
+# NcaawBasketballRegularSource
+# =====================================================================
+
+
+class NcaawBasketballRegularSource(PointsBasedSportSource):
+    """D1 Women's Basketball regular season via ESPN.
+
+    Win-count importance bands tuned against historical NCAA Tournament
+    selection criteria (64-team field). 20-win lock for at-large is a
+    soft baseline; 25+ tends to anchor a top-4 seed line.
+    """
+
+    league_context_code = "NCAAW_BBALL"
+    _DEFAULT_POINTS_FOR = _DEFAULT_POINTS_FOR
+    _DEFAULT_POINTS_AGAINST = _DEFAULT_POINTS_AGAINST
+
+    def __init__(self, season_end_year: Optional[int] = None) -> None:
+        super().__init__()
+        self.season_end_year = season_end_year or _default_season_end_year()
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAAW"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Women's Basketball"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Per-day scoreboard sweep + AP Top 25 attached as ranks."""
+        ranks = self._fetch_rankings()
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None:
+                    continue
+                # Both regular-season AND tournament games surface here.
+                # Filtering by season.type isn't strictly necessary — we
+                # surface postseason games in fetch_upcoming so the user's
+                # guide picks them up; the playoff source covers the
+                # importance-cascade side separately.
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                rank_home = ranks.get(rec["home"])
+                rank_away = ranks.get(rec["away"])
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=rank_home,
+                    rank_away=rank_away,
+                    start_time=start,
+                    extra={
+                        "ncaaw_game_id": eid,
+                        "fd_competition_code": self.league_context_code,
+                    },
+                ))
+        return out
+
+    def _fetch_rankings(self) -> Dict[str, int]:
+        """Return {team_location: rank} from ESPN's AP poll. Empty
+        dict if missing — rank-pair signal sits out the cycle."""
+        data = _http_get(f"{ESPN_BASE}/rankings")
+        if not data:
+            return {}
+        ranks_by_team: Dict[str, int] = {}
+        polls = data.get("rankings") or []
+        if not polls:
+            return ranks_by_team
+        # Prefer AP Top 25; fall back to first poll otherwise.
+        poll = next(
+            (p for p in polls if "ap" in (p.get("shortName") or "").lower()),
+            polls[0],
+        )
+        for r in poll.get("ranks") or []:
+            team_obj = r.get("team") or {}
+            name = _team_canonical_name(team_obj)
+            try:
+                rank = int(r.get("current") or 0)
+            except (TypeError, ValueError):
+                continue
+            if name and rank > 0:
+                ranks_by_team[name] = rank
+        return ranks_by_team
+
+    def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
+        """Walk every day from season start through min(today + 7d,
+        regular season end). Filter to regular-season games only
+        (season.type == 2) so the tournament doesn't pollute the
+        win-count importance signal — the playoff source has its own
+        bracket-based importance."""
+        seen: Dict[Any, Dict[str, Any]] = {}
+        # Season starts early-November of (end_year - 1).
+        season_start = datetime(
+            self.season_end_year - 1, SEASON_START_MONTH, 1, tzinfo=timezone.utc,
+        ).date()
+        # Regular season ends mid-March of end_year (around the start of
+        # the tournament). Pad to March 31.
+        regular_end = datetime(self.season_end_year, 3, 31, tzinfo=timezone.utc).date()
+        now = datetime.now(timezone.utc).date()
+        end = min(now + timedelta(days=7), regular_end)
+        if end < season_start:
+            return []
+        day = season_start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 2:
+                        continue
+                    if rec["id"] in seen:
+                        continue
+                    seen[rec["id"]] = {
+                        k: v for k, v in rec.items()
+                        if k not in ("season_type", "notes")
+                    }
+            day += timedelta(days=1)
+        return list(seen.values())
+
+
+# =====================================================================
+# NcaawBasketballPlayoffSource (March Madness)
+# =====================================================================
+
+
+class NcaawBasketballPlayoffSource(BestOfNSeriesSource):
+    """NCAA Women's March Madness as a single-game-elim
+    BestOfNSeriesSource with SERIES_LENGTH=1 per stage.
+
+    Each "series" is one game; first-to-1-win clinches. The bracket
+    state machine handles round_reached cascade as long as every
+    stage's series_length is 1 (so clinching_wins == 1).
+    """
+
+    KO_STAGES = ("R64", "R32", "S16", "E8", "F4", "NCG")
+    SERIES_LENGTH = 1   # uniform single-game elim
+    supports_importance = True
+
+    def __init__(self, season_end_year: Optional[int] = None) -> None:
+        self.season_end_year = season_end_year or _default_season_end_year()
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAAW"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Women's Tournament"
+
+    def _league_context_code(self) -> str:
+        return "NCAAW_BBALL_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        if stage == "NCG":
+            return "NCG_WINNER"
+        return None
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None or rec.get("season_type") != 3:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "ncaaw_game_id": eid,
+                        "fd_competition_code": self._league_context_code(),
+                    },
+                ))
+        return out
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]]
+    ) -> None:
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_POINTS_FOR,
+            "pa_per_game": _DEFAULT_POINTS_AGAINST,
+        }
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Pull the March Madness window (mid-March through early-April
+        of season_end_year). Stage routing via headline regex."""
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        out: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        # Tournament window: March 15 - April 15 of season_end_year.
+        start = datetime(self.season_end_year, 3, 15, tzinfo=timezone.utc).date()
+        end = datetime(self.season_end_year, 4, 15, tzinfo=timezone.utc).date()
+        day = start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 3:
+                        continue
+                    if rec["id"] in seen_ids:
+                        continue
+                    headline = None
+                    notes = rec.get("notes") or []
+                    if notes:
+                        headline = (notes[0] or {}).get("headline")
+                    parsed = _parse_stage_from_headline(headline)
+                    if parsed is None:
+                        continue
+                    seen_ids.add(rec["id"])
+                    out.append({
+                        "game_id": rec["id"],
+                        "stage": parsed["stage"],
+                        "matchday": parsed["matchday"],
+                        "home": rec["home"],
+                        "away": rec["away"],
+                        "home_goals": rec["home_points"],
+                        "away_goals": rec["away_points"],
+                        "status": rec["status"],
+                        "start_time": rec["start_time"],
+                        "extra": {"headline": headline},
+                    })
+            day += timedelta(days=1)
+        self._bracket_games_cache = out
+        return out

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -3788,3 +3788,189 @@ class TestWnbaPlayoffSource:
         depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
         for i in range(len(depths) - 1):
             assert depths[i] < depths[i + 1]
+
+
+# =====================================================================
+# Phase L: NCAA Women's Basketball + March Madness
+# =====================================================================
+
+class TestNcaawBasketballHeadlineParser:
+    """NCAA W headlines have a "Regional N in {City}" prefix for R64-E8
+    and no prefix for F4/NCG. Plus the round names use "1st Round" /
+    "2nd Round" (numeric) and "Sweet 16" / "Elite 8" (with space)."""
+
+    @staticmethod
+    def _parse(headline):
+        from dispatcharr_ranked_matchups.sources.ncaaw_basketball import (
+            _parse_stage_from_headline,
+        )
+        return _parse_stage_from_headline(headline)
+
+    def test_first_round_with_regional(self):
+        assert self._parse(
+            "NCAA Women's Championship - Regional 2 in Birmingham - 1st Round"
+        ) == {"stage": "R64", "matchday": 1}
+
+    def test_second_round_with_regional(self):
+        assert self._parse(
+            "NCAA Women's Championship - Regional 3 in Birmingham - 2nd Round"
+        ) == {"stage": "R32", "matchday": 1}
+
+    def test_sweet_sixteen_with_regional(self):
+        assert self._parse(
+            "NCAA Women's Championship - Regional 1 in Spokane - Sweet 16"
+        ) == {"stage": "S16", "matchday": 1}
+
+    def test_elite_eight_with_regional(self):
+        assert self._parse(
+            "NCAA Women's Championship - Regional 4 in Spokane - Elite 8"
+        ) == {"stage": "E8", "matchday": 1}
+
+    def test_final_four_no_regional(self):
+        assert self._parse(
+            "NCAA Women's Championship - Final Four"
+        ) == {"stage": "F4", "matchday": 1}
+
+    def test_national_championship(self):
+        assert self._parse(
+            "NCAA Women's Championship - National Championship"
+        ) == {"stage": "NCG", "matchday": 1}
+
+    def test_none_for_unparseable(self):
+        assert self._parse(None) is None
+        assert self._parse("") is None
+        assert self._parse("Some Conference Tournament - Game 1") is None
+
+    def test_apostrophe_optional(self):
+        # ESPN occasionally drops the apostrophe in "Women's"; the
+        # regex allows both forms.
+        assert self._parse(
+            "NCAA Womens Championship - Final Four"
+        ) == {"stage": "F4", "matchday": 1}
+
+
+class TestNcaawBasketballRegularSource:
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.ncaaw_basketball import (
+            NcaawBasketballRegularSource,
+        )
+        return NcaawBasketballRegularSource(season_end_year=2025)
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "NCAAW"
+        assert "Women" in src.sport_label
+        assert src.league_context_code == "NCAAW_BBALL"
+        assert src._count_field == "wins"
+
+    def test_supports_importance(self):
+        assert self._make().supports_importance is True
+
+    def test_outcome_labels(self):
+        labels = self._make().outcome_labels
+        assert "tournament_bubble" in labels
+        assert "at_large_lock" in labels
+        assert "top_4_seed" in labels
+        assert "no_1_seed" in labels
+
+    def test_thresholds_monotonic(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS["NCAAW_BBALL"]
+        cuts = [t[0] for t in ctx.thresholds]
+        for i in range(len(cuts) - 1):
+            assert cuts[i] < cuts[i + 1]
+
+
+class TestNcaawBasketballPlayoffSource:
+
+    @staticmethod
+    def _make(bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.ncaaw_basketball import (
+            NcaawBasketballPlayoffSource,
+        )
+        src = NcaawBasketballPlayoffSource(season_end_year=2025)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "NCAAW"
+        assert "Tournament" in src.sport_label
+        assert src._league_context_code() == "NCAAW_BBALL_PO"
+
+    def test_supports_importance(self):
+        assert self._make().supports_importance is True
+
+    def test_ko_stages(self):
+        assert self._make().KO_STAGES == ("R64", "R32", "S16", "E8", "F4", "NCG")
+
+    def test_series_length_uniform_one(self):
+        """Single-game elim — every stage uses SERIES_LENGTH=1; the
+        clinching-wins target is ceil(1/2)=1."""
+        src = self._make()
+        for stage in src.KO_STAGES:
+            assert src._series_length_for_stage(stage) == 1
+            assert src._clinching_wins_for_stage(stage) == 1
+
+    def test_winner_advance_label(self):
+        src = self._make()
+        assert src._winner_advance_label("NCG") == "NCG_WINNER"
+        assert src._winner_advance_label("F4") is None
+        assert src._winner_advance_label("R64") is None
+
+    def test_outcome_labels(self):
+        labels = self._make().outcome_labels
+        assert "round_of_32" in labels
+        assert "sweet_16" in labels
+        assert "elite_8" in labels
+        assert "final_four" in labels
+        assert "national_final" in labels
+        assert "national_champ" in labels
+
+    def test_champion_cascade(self):
+        """A team that wins each round reaches NCG_WINNER depth and
+        terminal_outcomes returns every band. Synthesize one team's
+        path through R64-NCG (6 wins)."""
+        # Champion's path: beat 6 different opponents in 6 single-game
+        # series, one at each stage.
+        games = []
+        for i, (stage, opp) in enumerate([
+            ("R64", "Sixteen"),
+            ("R32", "Eight"),
+            ("S16", "Four"),
+            ("E8", "Two"),
+            ("F4", "One"),
+            ("NCG", "Final"),
+        ]):
+            games.append({
+                "game_id": f"ncaaw-{i+1}",
+                "stage": stage,
+                "matchday": 1,
+                "home": "Champion",
+                "away": opp,
+                "home_goals": 80,
+                "away_goals": 70,
+                "status": "FINISHED",
+                "start_time": None,
+                "extra": {},
+            })
+        src = self._make(bracket_games=games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["Champion"] == KNOCKOUT_ROUND_DEPTH["NCG_WINNER"]
+        assert state["_round_reached"]["Final"] == KNOCKOUT_ROUND_DEPTH["NCG"]
+        assert state["_round_reached"]["One"] == KNOCKOUT_ROUND_DEPTH["F4"]
+        outcomes = src.terminal_outcomes(state)
+        assert "national_champ" in outcomes["Champion"]
+        assert "national_final" in outcomes["Final"]
+        assert "national_final" not in outcomes["One"]
+        assert "final_four" in outcomes["One"]
+
+    def test_ncaaw_po_thresholds_are_depth_ordered(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH
+        ctx = LEAGUE_CONTEXTS["NCAAW_BBALL_PO"]
+        depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
+        for i in range(len(depths) - 1):
+            assert depths[i] < depths[i + 1]


### PR DESCRIPTION
**Summary**: D1 regular season + 6-round single-elim tournament. Uses BestOfNSeriesSource with SERIES_LENGTH=1 per stage (clinches at 1 win).

**Live verify (2025)**: 63 bracket games (32+16+8+4+2+1 = correct elim math). UConn=NCG_WINNER (actual champion), South Carolina=NCG runner-up, UCLA/Texas=F4 losers. Matches reality.

Tests: 495 -> 515 (+20). Refs #16