### PR TITLE
Phase P: NFL (regular + playoffs)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -91,6 +91,13 @@
       "help_text": "UEFA's quadrennial national-team tournament. Pure knockout in V1 — group-stage importance not yet modeled. R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
     },
     {
+      "id": "enable_nfl",
+      "type": "boolean",
+      "label": "NFL (regular season + playoffs)",
+      "default": false,
+      "help_text": "Regular season uses win count (7+ bubble, 9+ playoff-secured, 11+ division winner, 13+ #1 seed) over the 17-game season. Playoffs are single-game elimination: Wild Card → Divisional → Conference Championship → Super Bowl → Champion. No API key required — uses ESPN's unofficial site.api.espn.com."
+    },
+    {
       "id": "enable_nhl",
       "type": "boolean",
       "label": "NHL (regular season + Stanley Cup Playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -299,6 +299,7 @@ def _build_sources(settings: Dict[str, Any]):
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
         NcaaBaseballSource, NcaaSoftballSource, NcaaSoccerSource,
         NcaafSource, NcaamSource,
+        NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
     )
     from .sources.soccer import COMPETITIONS
@@ -349,6 +350,22 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("world_cup"))
     if settings.get("enable_euros", False) and fd_key:
         sources.append(_make_soccer("euros"))
+
+    # NFL — no API key required (ESPN unofficial). Same pair-and-seed
+    # pattern as NHL/MLB/NBA. Bracket is single-game elimination
+    # (SERIES_LENGTH=1 per stage) across 4 rounds: WC -> DIV -> CONF
+    # -> SB. Strength sharing matters most here because NFL teams
+    # play only 17 regular-season games — even fewer baseline games
+    # than WNBA.
+    if settings.get("enable_nfl", False):
+        nfl_reg = NflRegularSource()
+        sources.append(nfl_reg)
+        nfl_po = NflPlayoffSource()
+        try:
+            nfl_po.set_regular_season_strengths(nfl_reg.estimate_strengths())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[nfl] could not seed playoff strengths: %s", exc)
+        sources.append(nfl_po)
 
     # NHL — no API key required (api-web.nhle.com is free). Pair the
     # regular and playoff sources together: the playoff source borrows

--- a/scoring.py
+++ b/scoring.py
@@ -201,6 +201,18 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "F4":              4,  # Final Four (2 games)
     "NCG":             5,  # National Championship Game
     "NCG_WINNER":      6,  # National Champion
+    # NFL playoffs (Phase P): 4 rounds, single-game elimination.
+    # SERIES_LENGTH=1 per stage; clinches at 1 win. The "WC" label
+    # entry above (depth 0) is shared between MLB Wild Card Series
+    # and NFL Wild Card Playoffs — both happen to be at depth 0 in
+    # their respective brackets, and terminal_outcomes reads
+    # per-league bands so there's no cross-contamination (same
+    # pattern as R1 shared across NHL and NBA, FINALS shared across
+    # NBA and WNBA).
+    "DIV":             1,  # Divisional Playoffs
+    "CONF":            2,  # Conference Championship
+    "SB":              3,  # Super Bowl
+    "SB_WINNER":       4,  # Super Bowl Champion
 }
 
 
@@ -577,6 +589,36 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (50, "no_1_overall",         5.0),
         ],
         boundary_summary="30+ wins → bubble · 35+ → at-large lock · 40+ → top regional · 45+ → national seed · 50+ → #1 overall",
+    ),
+    # Phase P: NFL regular season. 17-game season since 2021;
+    # 14 teams make playoffs (7 per conference, including a 7th seed
+    # added in 2020). 9 wins has been the modern playoff bubble line;
+    # 11 wins typically locks a division; 13+ is #1-seed pace.
+    "NFL": LeagueContext(
+        code="NFL", matchdays_total=17, format="win_count",
+        thresholds=[
+            (7,  "playoff_bubble",  1.5),  # 7-seed line late season
+            (9,  "playoff_secured", 2.5),  # comfortable in
+            (11, "division_winner", 4.0),  # division-clinching pace
+            (13, "no_1_seed",       5.0),  # #1 seed contention
+        ],
+        boundary_summary="7+ wins → bubble · 9+ → comfortable · 11+ → division · 13+ → #1 seed",
+    ),
+    # Phase P: NFL playoffs. 4 rounds, single-game elimination.
+    # Weights ramp aggressively because single-elim concentrates
+    # leverage — a Wild Card upset eliminates a 12-win team in one
+    # game. Same shape as March Madness (Phase L) but 4 rounds
+    # instead of 6 because the field is 14 teams (7 per conference)
+    # not 64.
+    "NFL_PO": LeagueContext(
+        code="NFL_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("DIV",       "divisional",   1.5),
+            ("CONF",      "conf_champ",   3.5),
+            ("SB",        "super_bowl",   6.0),
+            ("SB_WINNER", "sb_winner",   10.0),
+        ],
+        boundary_summary="WC → Divisional → Conf Championship → Super Bowl → Champion",
     ),
 }
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -7,6 +7,7 @@ from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
     NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
 )
+from .nfl import NflPlayoffSource, NflRegularSource
 from .ncaa_baseball import NcaaBaseballSource
 from .ncaa_softball import NcaaSoftballSource
 from .ncaa_soccer import NcaaSoccerSource
@@ -29,5 +30,6 @@ __all__ = [
     "NcaaBaseballSource", "NcaaSoftballSource", "NcaaSoccerSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",
+    "NflRegularSource", "NflPlayoffSource",
     "SoccerSource", "KnockoutSoccerSource", "SOCCER_COMPETITIONS",
 ]

--- a/sources/nfl.py
+++ b/sources/nfl.py
@@ -1,0 +1,434 @@
+"""NFL source — ESPN's unofficial site.api.espn.com. No API key required.
+
+Two source classes:
+  - `NflRegularSource(PointsBasedSportSource)`: 17-game season since
+    2021 (was 16 before). Raw wins as the threshold field; bands at
+    7 / 9 / 11 / 13 wins.
+  - `NflPlayoffSource(BestOfNSeriesSource)`: single-game elimination
+    bracket, SERIES_LENGTH=1 per stage. Stages: WC -> DIV -> CONF ->
+    SB. Same architectural shape as March Madness (Phase L).
+
+API patterns:
+  - /scoreboard?dates=YYYYMMDD for per-day games.
+  - Tournament stage in competition.notes[0].headline:
+      "AFC Wild Card Playoffs" / "NFC Wild Card Playoffs" -> WC
+      "AFC Divisional Playoffs" / "NFC Divisional Playoffs" -> DIV
+      "AFC Championship" / "NFC Championship" -> CONF
+      "Super Bowl LIX" (Roman numerals vary) -> SB
+  - No "Game N" suffix on NFL headlines because each round is a
+    single game. Headline parser maps headline to stage only;
+    matchday is always 1.
+  - All-Star / Pro Bowl filter: `competition.type.abbreviation
+    == "ALLSTAR"` (same NBA/WNBA trap).
+
+Team names use ESPN's `team.displayName` (e.g., "Philadelphia
+Eagles", "Kansas City Chiefs"), which is what EPG providers use.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base import GameRow
+from .bracket import BestOfNSeriesSource
+from .points_based import PointsBasedSportSource
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.nfl")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/football/nfl"
+
+# Modern NFL averages ~22 points per team per game. Used as the prior
+# for teams the simulator hasn't seen yet (early-season imports).
+_DEFAULT_POINTS_FOR = 22.0
+_DEFAULT_POINTS_AGAINST = 22.0
+
+# NFL regular season runs early-September through early-January; playoffs
+# January through early-February. ESPN tags `season.year` by the FINAL
+# calendar year of the season (e.g., "2025" for the 2024 season — the
+# Super Bowl was in February 2025).
+SEASON_START_MONTH = 9   # September
+PLAYOFF_END_MONTH = 2    # February (Super Bowl)
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Dict[str, Any]]:
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[nfl] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[nfl] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    name = (team_obj.get("displayName") or "").strip()
+    if name:
+        return name
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _default_season_end_year() -> int:
+    """ESPN's `season.year` is the calendar year the Super Bowl is
+    played in. The 2024 season -> 2025. Pre-September treats the
+    current calendar year's season as already concluding."""
+    now = datetime.now(timezone.utc)
+    return now.year + 1 if now.month >= SEASON_START_MONTH else now.year
+
+
+# Headline parser. NFL exposes the playoff stage in `notes[0].headline`.
+# Patterns observed against 2024 postseason (ESPN's live API):
+#   "AFC Wild Card Playoffs" / "NFC Wild Card Playoffs"     -> WC
+#   "AFC Divisional Playoffs" / "NFC Divisional Playoffs"   -> DIV
+#   "AFC Championship" / "NFC Championship"                 -> CONF
+#   "Super Bowl LIX" (the Roman numeral varies year-to-year) -> SB
+_HEADLINE_RE = re.compile(
+    r"^(?:"
+    r"(?P<conf>AFC|NFC)\s+(?P<round>Wild\s+Card\s+Playoffs|Divisional\s+Playoffs|Championship)"
+    r"|Super\s+Bowl(?:\s+[IVXLCDM]+)?"
+    r")",
+    re.IGNORECASE,
+)
+
+_ROUND_TO_STAGE: Dict[str, str] = {
+    "wild card playoffs":  "WC",
+    "divisional playoffs": "DIV",
+    "championship":        "CONF",
+}
+
+
+def _parse_stage_from_headline(headline: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return {"stage": str, "matchday": 1}, or None."""
+    if not headline:
+        return None
+    m = _HEADLINE_RE.search(headline)
+    if not m:
+        return None
+    # Super Bowl: regex matches the "Super Bowl" branch with no `conf`
+    # / `round` group filled in.
+    if not m.group("round"):
+        return {"stage": "SB", "matchday": 1}
+    round_key = re.sub(r"\s+", " ", m.group("round").lower().strip())
+    stage = _ROUND_TO_STAGE.get(round_key)
+    if stage is None:
+        return None
+    return {"stage": stage, "matchday": 1}
+
+
+def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert one ESPN scoreboard event into the canonical record.
+    Filters out the Pro Bowl (tagged competition.type.abbreviation
+    == "ALLSTAR" — same NBA/WNBA trap)."""
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    comp_type_abbrev = ((comp.get("type") or {}).get("abbreviation") or "").upper()
+    if comp_type_abbrev == "ALLSTAR":
+        return None
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = _team_canonical_name(home.get("team") or {})
+    away_team = _team_canonical_name(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    elif state == "in":
+        status = "SCHEDULED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    return {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "season_type": ((event.get("season") or {}).get("type")),
+        "notes": comp.get("notes") or [],
+    }
+
+
+# =====================================================================
+# NflRegularSource
+# =====================================================================
+
+
+class NflRegularSource(PointsBasedSportSource):
+    """NFL regular-season importance via PointsBasedSportSource.
+
+    Uses raw `wins` (LEAGUE_CONTEXTS["NFL"] is format="win_count"). NFL
+    has 17 games per team since 2021 — the 7th playoff seed cutoff has
+    settled around 9-10 wins. Bands tuned to the modern 17-game era;
+    pre-2021 seasons would have lower cutoffs but the curator only
+    surfaces current games anyway.
+    """
+
+    league_context_code = "NFL"
+    _count_field = "wins"
+    _DEFAULT_POINTS_FOR = _DEFAULT_POINTS_FOR
+    _DEFAULT_POINTS_AGAINST = _DEFAULT_POINTS_AGAINST
+
+    def __init__(self, season_end_year: Optional[int] = None) -> None:
+        super().__init__()
+        self.season_end_year = season_end_year or _default_season_end_year()
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NFL"
+
+    @property
+    def sport_label(self) -> str:
+        return "NFL"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Per-day scoreboard sweep for the next N days (regular season
+        only, season.type==2)."""
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None or rec.get("season_type") != 2:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "nfl_game_id": eid,
+                        "fd_competition_code": self.league_context_code,
+                    },
+                ))
+        return out
+
+    def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
+        """Walk every day of the regular season (early-September through
+        early-January of the next calendar year). Filter to
+        season.type == 2 so playoffs don't leak into the win-count
+        importance signal — the playoff source covers that separately.
+        """
+        seen: Dict[Any, Dict[str, Any]] = {}
+        # NFL season starts early-September of (end_year - 1).
+        season_start = datetime(
+            self.season_end_year - 1, SEASON_START_MONTH, 1, tzinfo=timezone.utc,
+        ).date()
+        # Regular season ends first week of January. Pad to Jan 15.
+        regular_end = datetime(self.season_end_year, 1, 15, tzinfo=timezone.utc).date()
+        now = datetime.now(timezone.utc).date()
+        end = min(now + timedelta(days=7), regular_end)
+        if end < season_start:
+            return []
+        day = season_start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 2:
+                        # Skip preseason (type=1), Pro Bowl, postseason.
+                        continue
+                    if rec["id"] in seen:
+                        continue
+                    seen[rec["id"]] = {
+                        k: v for k, v in rec.items()
+                        if k not in ("season_type", "notes")
+                    }
+            day += timedelta(days=1)
+        return list(seen.values())
+
+
+# =====================================================================
+# NflPlayoffSource
+# =====================================================================
+
+
+class NflPlayoffSource(BestOfNSeriesSource):
+    """NFL playoffs as single-game-elim BestOfNSeriesSource (same shape
+    as March Madness, just with 4 rounds instead of 6).
+
+    Stages: WC -> DIV -> CONF -> SB. Each "series" is one game;
+    clinching wins == 1. Cross-conference until the Super Bowl —
+    AFC and NFC ladders feed independently until the SB pairs the
+    two conference winners.
+    """
+
+    KO_STAGES = ("WC", "DIV", "CONF", "SB")
+    SERIES_LENGTH = 1
+    supports_importance = True
+
+    def __init__(self, season_end_year: Optional[int] = None) -> None:
+        self.season_end_year = season_end_year or _default_season_end_year()
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NFL"
+
+    @property
+    def sport_label(self) -> str:
+        return "NFL Playoffs"
+
+    def _league_context_code(self) -> str:
+        return "NFL_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        if stage == "SB":
+            return "SB_WINNER"
+        return None
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None or rec.get("season_type") != 3:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "nfl_game_id": eid,
+                        "fd_competition_code": self._league_context_code(),
+                    },
+                ))
+        return out
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]]
+    ) -> None:
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_POINTS_FOR,
+            "pa_per_game": _DEFAULT_POINTS_AGAINST,
+        }
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Pull the postseason window: January 1 through mid-February
+        of season_end_year (Super Bowl is typically the first Sunday
+        of February but moves with the schedule)."""
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        out: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        start = datetime(self.season_end_year, 1, 1, tzinfo=timezone.utc).date()
+        end = datetime(self.season_end_year, 2, 28, tzinfo=timezone.utc).date()
+        day = start
+        while day <= end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec.get("season_type") != 3:
+                        continue
+                    if rec["id"] in seen_ids:
+                        continue
+                    headline = None
+                    notes = rec.get("notes") or []
+                    if notes:
+                        headline = (notes[0] or {}).get("headline")
+                    parsed = _parse_stage_from_headline(headline)
+                    if parsed is None:
+                        continue
+                    seen_ids.add(rec["id"])
+                    out.append({
+                        "game_id": rec["id"],
+                        "stage": parsed["stage"],
+                        "matchday": parsed["matchday"],
+                        "home": rec["home"],
+                        "away": rec["away"],
+                        "home_goals": rec["home_points"],
+                        "away_goals": rec["away_points"],
+                        "status": rec["status"],
+                        "start_time": rec["start_time"],
+                        "extra": {"headline": headline},
+                    })
+            day += timedelta(days=1)
+        self._bracket_games_cache = out
+        return out

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4053,3 +4053,264 @@ class TestNcaaSoftballSource:
             "tournament_bubble", "at_large_lock", "top_regional_seed",
             "national_seed", "no_1_overall",
         }
+
+
+# =====================================================================
+# Phase P: NFL
+# =====================================================================
+
+class TestNflHeadlineParser:
+    """NFL headlines have no Game N suffix (single-game elim per round)
+    and use AFC/NFC prefixes for the first three rounds, then bare
+    "Super Bowl LIX" (Roman numeral varies) for the championship."""
+
+    @staticmethod
+    def _parse(headline):
+        from dispatcharr_ranked_matchups.sources.nfl import _parse_stage_from_headline
+        return _parse_stage_from_headline(headline)
+
+    def test_afc_wild_card(self):
+        assert self._parse("AFC Wild Card Playoffs") == {"stage": "WC", "matchday": 1}
+
+    def test_nfc_wild_card(self):
+        assert self._parse("NFC Wild Card Playoffs") == {"stage": "WC", "matchday": 1}
+
+    def test_afc_divisional(self):
+        assert self._parse("AFC Divisional Playoffs") == {"stage": "DIV", "matchday": 1}
+
+    def test_nfc_divisional(self):
+        assert self._parse("NFC Divisional Playoffs") == {"stage": "DIV", "matchday": 1}
+
+    def test_afc_championship(self):
+        assert self._parse("AFC Championship") == {"stage": "CONF", "matchday": 1}
+
+    def test_nfc_championship(self):
+        assert self._parse("NFC Championship") == {"stage": "CONF", "matchday": 1}
+
+    def test_super_bowl_with_roman_numeral(self):
+        assert self._parse("Super Bowl LIX") == {"stage": "SB", "matchday": 1}
+
+    def test_super_bowl_no_numeral(self):
+        # Defensive — if ESPN ever drops the Roman numeral.
+        assert self._parse("Super Bowl") == {"stage": "SB", "matchday": 1}
+
+    def test_no_headline_returns_none(self):
+        assert self._parse(None) is None
+        assert self._parse("") is None
+
+    def test_unrecognized_returns_none(self):
+        assert self._parse("Pro Bowl Skills Competition") is None
+        assert self._parse("Preseason - Week 3") is None
+
+    def test_case_insensitive(self):
+        assert self._parse("afc wild card playoffs") == {"stage": "WC", "matchday": 1}
+        assert self._parse("super bowl lix") == {"stage": "SB", "matchday": 1}
+
+
+class TestNflProBowlFilter:
+    """Pro Bowl is tagged competition.type.abbreviation=ALLSTAR — same
+    trap as NBA/WNBA. Filter must drop it from regular-season fetches."""
+
+    @staticmethod
+    def _extract(event):
+        from dispatcharr_ranked_matchups.sources.nfl import _extract_game_record
+        return _extract_game_record(event)
+
+    def test_pro_bowl_filtered(self):
+        event = {
+            "id": "401706000",
+            "date": "2025-02-02T20:00Z",
+            "season": {"year": 2025, "type": 2, "slug": "regular-season"},
+            "competitions": [{
+                "type": {"id": "4", "abbreviation": "ALLSTAR"},
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "score": "76",
+                     "team": {"displayName": "NFC"}},
+                    {"homeAway": "away", "score": "63",
+                     "team": {"displayName": "AFC"}},
+                ],
+            }],
+        }
+        assert self._extract(event) is None
+
+    def test_regular_season_passes(self):
+        event = {
+            "id": "401706001",
+            "date": "2024-11-17T18:00Z",
+            "season": {"year": 2025, "type": 2, "slug": "regular-season"},
+            "competitions": [{
+                "type": {"id": "1", "abbreviation": "STD"},
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "score": "37",
+                     "team": {"displayName": "Philadelphia Eagles"}},
+                    {"homeAway": "away", "score": "20",
+                     "team": {"displayName": "Washington Commanders"}},
+                ],
+            }],
+        }
+        rec = self._extract(event)
+        assert rec is not None
+        assert rec["home"] == "Philadelphia Eagles"
+
+
+class TestNflRegularSource:
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.nfl import NflRegularSource
+        return NflRegularSource(season_end_year=2025)
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "NFL"
+        assert src.sport_label == "NFL"
+        assert src.league_context_code == "NFL"
+        assert src._count_field == "wins"
+
+    def test_supports_importance(self):
+        assert self._make().supports_importance is True
+
+    def test_outcome_labels(self):
+        labels = self._make().outcome_labels
+        assert "playoff_bubble" in labels
+        assert "playoff_secured" in labels
+        assert "division_winner" in labels
+        assert "no_1_seed" in labels
+
+    def test_thresholds_monotonic(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS["NFL"]
+        cuts = [t[0] for t in ctx.thresholds]
+        for i in range(len(cuts) - 1):
+            assert cuts[i] < cuts[i + 1]
+
+    def test_terminal_outcomes_by_win_count(self):
+        src = self._make()
+        state = {
+            "_applied": frozenset(),
+            "_teams": {
+                "Cellar": {"wins":  4, "losses": 13, "pf": 0, "pa": 0, "games_played": 17},
+                "Bubble": {"wins":  8, "losses":  9, "pf": 0, "pa": 0, "games_played": 17},
+                "Comfy":  {"wins": 10, "losses":  7, "pf": 0, "pa": 0, "games_played": 17},
+                "DivWin": {"wins": 12, "losses":  5, "pf": 0, "pa": 0, "games_played": 17},
+                "Top":    {"wins": 14, "losses":  3, "pf": 0, "pa": 0, "games_played": 17},
+            },
+        }
+        outcomes = src.terminal_outcomes(state)
+        assert outcomes["Cellar"] == []
+        assert set(outcomes["Bubble"]) == {"playoff_bubble"}
+        assert set(outcomes["Comfy"]) == {"playoff_bubble", "playoff_secured"}
+        assert set(outcomes["DivWin"]) == {
+            "playoff_bubble", "playoff_secured", "division_winner",
+        }
+        assert set(outcomes["Top"]) == {
+            "playoff_bubble", "playoff_secured", "division_winner", "no_1_seed",
+        }
+
+
+class TestNflPlayoffSource:
+
+    @staticmethod
+    def _make(bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.nfl import NflPlayoffSource
+        src = NflPlayoffSource(season_end_year=2025)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "NFL"
+        assert "Playoffs" in src.sport_label
+        assert src._league_context_code() == "NFL_PO"
+
+    def test_ko_stages(self):
+        assert self._make().KO_STAGES == ("WC", "DIV", "CONF", "SB")
+
+    def test_series_length_uniform_one(self):
+        src = self._make()
+        for stage in src.KO_STAGES:
+            assert src._series_length_for_stage(stage) == 1
+            assert src._clinching_wins_for_stage(stage) == 1
+
+    def test_winner_advance_label(self):
+        src = self._make()
+        assert src._winner_advance_label("SB") == "SB_WINNER"
+        assert src._winner_advance_label("WC") is None
+        assert src._winner_advance_label("DIV") is None
+        assert src._winner_advance_label("CONF") is None
+
+    def test_outcome_labels(self):
+        labels = self._make().outcome_labels
+        assert "divisional" in labels
+        assert "conf_champ" in labels
+        assert "super_bowl" in labels
+        assert "sb_winner" in labels
+
+    def test_sb_winner_cascade(self):
+        """2024 NFL season: Eagles beat Chiefs 40-22 in Super Bowl LIX.
+        Synthesize each round's single game and confirm Eagles reaches
+        SB_WINNER, Chiefs reaches SB depth."""
+        games = [
+            # Wild Card
+            {"game_id": "wc1", "stage": "WC", "matchday": 1,
+             "home": "Philadelphia Eagles", "away": "Green Bay Packers",
+             "home_goals": 22, "away_goals": 10,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "wc2", "stage": "WC", "matchday": 1,
+             "home": "Buffalo Bills", "away": "Denver Broncos",
+             "home_goals": 31, "away_goals": 7,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # Divisional
+            {"game_id": "div1", "stage": "DIV", "matchday": 1,
+             "home": "Philadelphia Eagles", "away": "Los Angeles Rams",
+             "home_goals": 28, "away_goals": 22,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "div2", "stage": "DIV", "matchday": 1,
+             "home": "Kansas City Chiefs", "away": "Houston Texans",
+             "home_goals": 23, "away_goals": 14,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "div3", "stage": "DIV", "matchday": 1,
+             "home": "Buffalo Bills", "away": "Baltimore Ravens",
+             "home_goals": 27, "away_goals": 25,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # Conference Championships
+            {"game_id": "conf1", "stage": "CONF", "matchday": 1,
+             "home": "Philadelphia Eagles", "away": "Washington Commanders",
+             "home_goals": 55, "away_goals": 23,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "conf2", "stage": "CONF", "matchday": 1,
+             "home": "Kansas City Chiefs", "away": "Buffalo Bills",
+             "home_goals": 32, "away_goals": 29,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # Super Bowl LIX: Eagles 40, Chiefs 22
+            {"game_id": "sb", "stage": "SB", "matchday": 1,
+             "home": "Philadelphia Eagles", "away": "Kansas City Chiefs",
+             "home_goals": 40, "away_goals": 22,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make(bracket_games=games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["Philadelphia Eagles"] == KNOCKOUT_ROUND_DEPTH["SB_WINNER"]
+        assert state["_round_reached"]["Kansas City Chiefs"] == KNOCKOUT_ROUND_DEPTH["SB"]
+        assert state["_round_reached"]["Washington Commanders"] == KNOCKOUT_ROUND_DEPTH["CONF"]
+        assert state["_round_reached"]["Buffalo Bills"] == KNOCKOUT_ROUND_DEPTH["CONF"]
+        assert state["_round_reached"]["Los Angeles Rams"] == KNOCKOUT_ROUND_DEPTH["DIV"]
+        assert state["_round_reached"]["Green Bay Packers"] == KNOCKOUT_ROUND_DEPTH["WC"]
+
+        outcomes = src.terminal_outcomes(state)
+        assert set(outcomes["Philadelphia Eagles"]) == {
+            "divisional", "conf_champ", "super_bowl", "sb_winner",
+        }
+        assert set(outcomes["Kansas City Chiefs"]) == {
+            "divisional", "conf_champ", "super_bowl",
+        }
+
+    def test_nfl_po_thresholds_are_depth_ordered(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH
+        ctx = LEAGUE_CONTEXTS["NFL_PO"]
+        depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
+        for i in range(len(depths) - 1):
+            assert depths[i] < depths[i + 1]


### PR DESCRIPTION
Adds NFL — the most-watched US sport, glaringly missing from umbrella #16. Architecturally a clone of March Madness (single-game elim, 4 rounds: WC/DIV/CONF/SB). ESPN unofficial API.

**Live verify (2024 NFL season)**: 32 teams. Top 6 standings match reality. Postseason 13 games (6+4+2+1). Eagles=SB_WINNER, Chiefs=SB runner-up — matches Super Bowl LIX outcome (Eagles 40-22).

Tests: 528 -> 553 (+25).