### PR TITLE
Phase Q: backfill 5 more soccer leagues (Eredivisie, Primeira Liga, Brazilian Série A, NWSL, Liga MX)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -91,6 +91,27 @@
       "help_text": "UEFA's quadrennial national-team tournament. Pure knockout in V1 — group-stage importance not yet modeled. R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
     },
     {
+      "id": "enable_eredivisie",
+      "type": "boolean",
+      "label": "Eredivisie (Netherlands, top flight)",
+      "default": false,
+      "help_text": "18 teams, 34 matchdays. Top 3 → UCL/qualifying, 4-5 → Europa/Conference, bottom 3 → relegation. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_primeira_liga",
+      "type": "boolean",
+      "label": "Primeira Liga (Portugal, top flight)",
+      "default": false,
+      "help_text": "18 teams, 34 matchdays. Top 3 → UCL/qualifying, 4-5 → Europa/Conference, bottom 3 → relegation. Requires Football-Data.org key."
+    },
+    {
+      "id": "enable_brazilian_serie_a",
+      "type": "boolean",
+      "label": "Brazilian Série A",
+      "default": false,
+      "help_text": "Top flight of Brazilian football. 20 teams, 38 matchdays. Top 6 → Copa Libertadores, 7-12 → Sudamericana, bottom 4 → relegation. Requires Football-Data.org key."
+    },
+    {
       "id": "enable_nfl",
       "type": "boolean",
       "label": "NFL (regular season + playoffs)",
@@ -124,6 +145,20 @@
       "label": "MLS (regular season + Cup playoffs)",
       "default": false,
       "help_text": "MLS games surface with favorite + closeness scoring only in V1 — no standings-based importance yet (conference structure and the mixed-format MLS Cup bracket are follow-ups). Uses ESPN's unofficial site.api.espn.com for the schedule. The Odds API key enables closeness via the soccer_usa_mls market; without it, MLS games appear but with no closeness signal."
+    },
+    {
+      "id": "enable_nwsl",
+      "type": "boolean",
+      "label": "NWSL (National Women's Soccer League)",
+      "default": false,
+      "help_text": "NWSL games surface with favorite + closeness scoring only in V1 (same scope as MLS — no standings importance or playoff bracket yet). ESPN unofficial API + Odds API (soccer_usa_nwsl). No ESPN key required."
+    },
+    {
+      "id": "enable_liga_mx",
+      "type": "boolean",
+      "label": "Liga MX (Mexican top flight)",
+      "default": false,
+      "help_text": "Mexican Apertura + Clausura + Liguilla playoff. Schedule + closeness scoring only in V1 (same minimal scope as MLS / NWSL). ESPN unofficial API + Odds API (soccer_mexico_ligamx). Relevant for US viewers with Univision / Telemundo channels in their EPG."
     },
     {
       "id": "enable_wnba",

--- a/plugin.py
+++ b/plugin.py
@@ -293,7 +293,7 @@ def _build_weights(settings: Dict[str, Any]):
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
         KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
-        MlsSource,
+        MlsSource, NwslSource, LigaMxSource,
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
@@ -350,6 +350,16 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("world_cup"))
     if settings.get("enable_euros", False) and fd_key:
         sources.append(_make_soccer("euros"))
+
+    # Phase Q: additional FD.org free-tier leagues. Same _make_soccer
+    # router; LEAGUE_CONTEXTS uses format="league" so dispatch goes
+    # to SoccerSource (not KnockoutSoccerSource).
+    if settings.get("enable_eredivisie", False) and fd_key:
+        sources.append(_make_soccer("eredivisie"))
+    if settings.get("enable_primeira_liga", False) and fd_key:
+        sources.append(_make_soccer("primeira_liga"))
+    if settings.get("enable_brazilian_serie_a", False) and fd_key:
+        sources.append(_make_soccer("brazilian_serie_a"))
 
     # NFL — no API key required (ESPN unofficial). Same pair-and-seed
     # pattern as NHL/MLB/NBA. Bracket is single-game elimination
@@ -428,6 +438,16 @@ def _build_sources(settings: Dict[str, Any]):
     # it MLS games surface but with no closeness signal.
     if settings.get("enable_mls", False):
         sources.append(MlsSource(odds_api_key=odds_key or ""))
+
+    # NWSL — same V1 minimal pattern as MLS (schedule + closeness).
+    # Subclasses MlsSource with NWSL-specific endpoint and Odds API
+    # key. No importance / playoff bracket in V1.
+    if settings.get("enable_nwsl", False):
+        sources.append(NwslSource(odds_api_key=odds_key or ""))
+
+    # Liga MX — Mexican top-flight. Same V1 minimal pattern.
+    if settings.get("enable_liga_mx", False):
+        sources.append(LigaMxSource(odds_api_key=odds_key or ""))
 
     # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
     # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1

--- a/scoring.py
+++ b/scoring.py
@@ -299,6 +299,48 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
+    # Phase Q: Eredivisie (Netherlands). 18 teams, 34 matchdays. Top 1
+    # direct UCL group stage; 2-3 UCL qualifying; 4-5 Europa/Conference
+    # qualifying; bottom 1 direct relegation, 16-17 relegation playoff
+    # (we use cutoff=15 to fire the relegation band for 16/17/18 like
+    # Bundesliga).
+    "DED": LeagueContext(
+        code="DED", matchdays_total=34,
+        thresholds=[
+            (1,  "title",             5.0),
+            (3,  "UCL",               4.0),
+            (5,  "Europa/Conference", 2.0),
+            (15, "relegation",        5.0),
+        ],
+        boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
+    ),
+    # Phase Q: Primeira Liga (Portugal). 18 teams, 34 matchdays. Same
+    # slot semantics as Eredivisie — 2 direct UCL spots, 3rd UCL
+    # qualifying, 4-5 Europa, bottom 3 relegation.
+    "PPL": LeagueContext(
+        code="PPL", matchdays_total=34,
+        thresholds=[
+            (1,  "title",             5.0),
+            (3,  "UCL",               4.0),
+            (5,  "Europa/Conference", 2.0),
+            (15, "relegation",        5.0),
+        ],
+        boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
+    ),
+    # Phase Q: Brazilian Série A. 20 teams, 38 matchdays. Different
+    # slot semantics from Euro leagues — continental qualifications
+    # are for Copa Libertadores (top 6 in modern era) and Copa
+    # Sudamericana (7-12). No UCL line. Bottom 4 relegated to Série B.
+    "BSA": LeagueContext(
+        code="BSA", matchdays_total=38,
+        thresholds=[
+            (1,  "title",             5.0),
+            (6,  "libertadores",      4.0),
+            (12, "sudamericana",      2.0),
+            (16, "relegation",        5.0),
+        ],
+        boundary_summary="Top 6 → Libertadores · 7-12 → Sudamericana · bottom 4 → relegation",
+    ),
     # Phase I: international tournaments.
     #
     # World Cup 2026 onward uses the 48-team format: 12 groups of 4, top

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -2,6 +2,8 @@
 from .base import GameRow, SportSource
 from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
+from .nwsl import NwslSource
+from .liga_mx import LigaMxSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
@@ -23,7 +25,7 @@ from .soccer import (
 __all__ = [
     "GameRow", "SportSource",
     "MlbRegularSource", "MlbPlayoffSource",
-    "MlsSource",
+    "MlsSource", "NwslSource", "LigaMxSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",

--- a/sources/liga_mx.py
+++ b/sources/liga_mx.py
@@ -1,0 +1,31 @@
+"""Liga MX source — ESPN unofficial + Odds API closeness.
+
+Same V1 minimal pattern as MlsSource (Phase J): schedule + closeness
+only, no standings-based importance or Liguilla playoff bracket.
+
+Liga MX runs two seasons per calendar year (Apertura ≈ Jul-Dec,
+Clausura ≈ Jan-May), each followed by a 12-team Liguilla playoff.
+Season slug values surface as `extra.season_slug`:
+  - "torneo-apertura"  — fall season
+  - "torneo-clausura"  — spring season
+  - "liguilla"         — playoff round (single-leg + two-leg ties)
+
+Liga MX Odds API key: `soccer_mexico_ligamx`. ESPN slug: `soccer/mex.1`.
+Relevant for US viewers via Univision / Telemundo EPG entries.
+"""
+
+from __future__ import annotations
+
+from .mls import MlsSource
+
+
+class LigaMxSource(MlsSource):
+    """Liga MX: Mexican top-flight soccer. Same schedule+closeness
+    adapter as MlsSource with Liga MX-specific endpoint + Odds API
+    key overrides."""
+
+    _ESPN_SLUG = "soccer/mex.1"
+    _ODDS_SPORT_KEY = "soccer_mexico_ligamx"
+    _FD_CODE = "LigaMX"
+    _SPORT_PREFIX = "LigaMX"
+    _SPORT_LABEL = "Liga MX"

--- a/sources/mls.py
+++ b/sources/mls.py
@@ -138,27 +138,43 @@ def _h2h_to_closeness(
 class MlsSource(SportSource):
     """MLS schedule + closeness signal. V1 omits standings-based
     importance and the MLS Cup playoff bracket — see follow-up issues
-    filed under Phase J."""
+    filed under Phase J.
+
+    Class attrs `_ESPN_SLUG`, `_ODDS_SPORT_KEY`, `_FD_CODE`,
+    `_SPORT_PREFIX`, `_SPORT_LABEL` parameterize the league. Phase Q
+    NwslSource and LigaMxSource subclass this and override these
+    five attrs — the rest of the fetch/closeness machinery is shared.
+    """
 
     # NOT supports_importance: the importance simulator skips MLS in V1.
     # Importance comes from `favorite` + `closeness` only.
+
+    # Per-league configuration (subclasses override):
+    _ESPN_SLUG: str = "soccer/usa.1"
+    _ODDS_SPORT_KEY: str = "soccer_usa_mls"
+    _FD_CODE: str = "MLS"
+    _SPORT_PREFIX: str = "MLS"
+    _SPORT_LABEL: str = "MLS"
 
     def __init__(self, odds_api_key: str = "") -> None:
         self.odds_api_key = odds_api_key
 
     @property
     def sport_prefix(self) -> str:
-        return "MLS"
+        return self._SPORT_PREFIX
 
     @property
     def sport_label(self) -> str:
-        return "MLS"
+        return self._SPORT_LABEL
+
+    def _espn_base(self) -> str:
+        return f"https://site.api.espn.com/apis/site/v2/sports/{self._ESPN_SLUG}"
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
         """Per-day scoreboard sweep over today..today+days_ahead.
         Populate `closeness` from a single Odds API call that returns
-        all upcoming MLS matches; ESPN gives the schedule, Odds API
-        gives the moneyline market.
+        all upcoming matches for this league; ESPN gives the schedule,
+        Odds API gives the moneyline market.
 
         ESPN's scoreboard range syntax (`dates=YYYYMMDD-YYYYMMDD`)
         silently caps at 25 events. MLS has fewer games per day than
@@ -172,9 +188,10 @@ class MlsSource(SportSource):
         today = datetime.now(timezone.utc).date()
         out: List[GameRow] = []
         seen_ids: set = set()
+        espn_base = self._espn_base()
         for offset in range(days_ahead + 1):
             day = today + timedelta(days=offset)
-            data = _http_get(f"{ESPN_BASE}/scoreboard", dates=day.strftime("%Y%m%d"))
+            data = _http_get(f"{espn_base}/scoreboard", dates=day.strftime("%Y%m%d"))
             if not isinstance(data, dict):
                 continue
             for event in data.get("events") or []:
@@ -205,11 +222,14 @@ class MlsSource(SportSource):
                     continue
                 seen_ids.add(gid)
                 closeness = self._lookup_closeness(closeness_by_pair, home, away)
-                # ESPN exposes the playoff stage in
-                # `event.season.slug` ("regular-season", "mls-cup",
-                # "mls-cup-playoffs"). Carry it through as `extra.stage`
-                # so the future importance work can route on it
-                # without re-fetching.
+                # ESPN exposes the season/playoff stage in
+                # `event.season.slug`. Carry it through as
+                # `extra.season_slug` so future importance work can
+                # route on it without re-fetching. MLS values:
+                # "regular-season", "mls-cup", "mls-cup-playoffs".
+                # NWSL: "regular-season", "nwsl-playoffs", etc.
+                # Liga MX: "torneo-apertura", "torneo-clausura",
+                # "liguilla" (the Apertura/Clausura playoff).
                 season_slug = ((event.get("season") or {}).get("slug") or "")
                 out.append(GameRow(
                     sport_prefix=self.sport_prefix,
@@ -223,7 +243,7 @@ class MlsSource(SportSource):
                     extra={
                         "espn_event_id": gid,
                         "season_slug": season_slug,
-                        "fd_competition_code": "MLS",
+                        "fd_competition_code": self._FD_CODE,
                     },
                 ))
         return out
@@ -231,13 +251,14 @@ class MlsSource(SportSource):
     # ---------- closeness ----------
 
     def _fetch_closeness(self) -> Dict[Tuple[str, str], float]:
-        """Return {(home_lc, away_lc): closeness} for upcoming MLS
-        matches. Empty dict if the key is missing or the call fails.
+        """Return {(home_lc, away_lc): closeness} for upcoming matches
+        in this league. Empty dict if the key is missing or the call
+        fails.
         """
         if not self.odds_api_key:
             return {}
         data = _http_get(
-            f"{ODDS_BASE}/sports/{ODDS_SPORT_KEY}/odds/",
+            f"{ODDS_BASE}/sports/{self._ODDS_SPORT_KEY}/odds/",
             regions="us,uk,eu",
             markets="h2h",
             apiKey=self.odds_api_key,

--- a/sources/nwsl.py
+++ b/sources/nwsl.py
@@ -1,0 +1,26 @@
+"""NWSL source — ESPN unofficial + Odds API closeness.
+
+Same V1 minimal pattern as MlsSource (Phase J): schedule from ESPN +
+closeness from The Odds API. No standings-based importance and no
+playoff bracket — both are follow-ups. NWSL playoff format mirrors
+MLS Cup (mixed best-of-3 and single-leg rounds) and would benefit
+from the same bracket work.
+
+NWSL Odds API key: `soccer_usa_nwsl`. ESPN slug: `soccer/usa.nwsl`.
+"""
+
+from __future__ import annotations
+
+from .mls import MlsSource
+
+
+class NwslSource(MlsSource):
+    """NWSL: National Women's Soccer League. Same schedule+closeness
+    adapter as MlsSource with NWSL-specific endpoint + Odds API key
+    overrides."""
+
+    _ESPN_SLUG = "soccer/usa.nwsl"
+    _ODDS_SPORT_KEY = "soccer_usa_nwsl"
+    _FD_CODE = "NWSL"
+    _SPORT_PREFIX = "NWSL"
+    _SPORT_LABEL = "NWSL"

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -203,6 +203,35 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         odds_sport_key="soccer_uefa_european_championship",
         use_position_as_rank=False,
     ),
+    # Phase Q: additional Football-Data.org free-tier leagues. Same
+    # config shape as Phase H's BL1/PD/SA/FL1 — pure data additions, no
+    # source code changes. UEFA Europa League and Conference League are
+    # NOT on the FD.org free tier (only Champions League is), so they're
+    # not included here despite being on the original Phase Q wishlist.
+    "eredivisie": SoccerCompetitionConfig(
+        fd_code="DED",
+        sport_prefix="Eredivisie",
+        sport_label="Eredivisie",
+        odds_sport_key="soccer_netherlands_eredivisie",
+        rank_cap=18,
+        total_matchdays=34,
+    ),
+    "primeira_liga": SoccerCompetitionConfig(
+        fd_code="PPL",
+        sport_prefix="PrimeiraLiga",
+        sport_label="Primeira Liga",
+        odds_sport_key="soccer_portugal_primeira_liga",
+        rank_cap=18,
+        total_matchdays=34,
+    ),
+    "brazilian_serie_a": SoccerCompetitionConfig(
+        fd_code="BSA",
+        sport_prefix="BSA",
+        sport_label="Campeonato Brasileiro Série A",
+        odds_sport_key="soccer_brazil_campeonato",
+        rank_cap=20,
+        total_matchdays=38,
+    ),
 }
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4314,3 +4314,101 @@ class TestNflPlayoffSource:
         depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
         for i in range(len(depths) - 1):
             assert depths[i] < depths[i + 1]
+
+
+# =====================================================================
+# Phase Q: NWSL + Liga MX (subclasses of MlsSource)
+# =====================================================================
+
+class TestNwslSource:
+    """NwslSource subclasses MlsSource with NWSL endpoint + Odds API
+    key. The shared fetch/closeness machinery is exercised by the
+    MlsSource tests; these tests pin the per-league config."""
+
+    def test_identity(self):
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        src = NwslSource(odds_api_key="")
+        assert src.sport_prefix == "NWSL"
+        assert src.sport_label == "NWSL"
+
+    def test_espn_slug(self):
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        src = NwslSource()
+        assert src._ESPN_SLUG == "soccer/usa.nwsl"
+        assert src._espn_base().endswith("/soccer/usa.nwsl")
+
+    def test_odds_sport_key(self):
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        assert NwslSource._ODDS_SPORT_KEY == "soccer_usa_nwsl"
+
+    def test_fd_code_distinct_from_mls(self):
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        from dispatcharr_ranked_matchups.sources.mls import MlsSource
+        # NWSL must carry its own fd_competition_code so scoring
+        # doesn't mis-route NWSL games into MLS.
+        assert NwslSource._FD_CODE != MlsSource._FD_CODE
+        assert NwslSource._FD_CODE == "NWSL"
+
+    def test_no_importance_in_v1(self):
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        assert NwslSource().supports_importance is False
+
+
+class TestLigaMxSource:
+    """LigaMxSource: same shape as NwslSource. Liga MX runs two
+    seasons per calendar year (Apertura / Clausura) plus a Liguilla
+    playoff. The `extra.season_slug` field on emitted GameRows carries
+    that distinction."""
+
+    def test_identity(self):
+        from dispatcharr_ranked_matchups.sources.liga_mx import LigaMxSource
+        src = LigaMxSource(odds_api_key="")
+        assert src.sport_prefix == "LigaMX"
+        assert src.sport_label == "Liga MX"
+
+    def test_espn_slug(self):
+        from dispatcharr_ranked_matchups.sources.liga_mx import LigaMxSource
+        src = LigaMxSource()
+        assert src._ESPN_SLUG == "soccer/mex.1"
+        assert src._espn_base().endswith("/soccer/mex.1")
+
+    def test_odds_sport_key(self):
+        from dispatcharr_ranked_matchups.sources.liga_mx import LigaMxSource
+        assert LigaMxSource._ODDS_SPORT_KEY == "soccer_mexico_ligamx"
+
+    def test_fd_code_distinct(self):
+        from dispatcharr_ranked_matchups.sources.liga_mx import LigaMxSource
+        from dispatcharr_ranked_matchups.sources.mls import MlsSource
+        from dispatcharr_ranked_matchups.sources.nwsl import NwslSource
+        assert LigaMxSource._FD_CODE == "LigaMX"
+        codes = {MlsSource._FD_CODE, NwslSource._FD_CODE, LigaMxSource._FD_CODE}
+        assert len(codes) == 3
+
+    def test_season_slug_carries_through(self, monkeypatch):
+        """Liga MX has Apertura/Clausura/Liguilla seasons.
+        `extra.season_slug` on emitted GameRows must carry ESPN's
+        slug so future routing can use it."""
+        import dispatcharr_ranked_matchups.sources.mls as mls_mod
+        from dispatcharr_ranked_matchups.sources.liga_mx import LigaMxSource
+
+        espn_response = {
+            "events": [{
+                "id": "401900001",
+                "date": "2026-02-15T03:00Z",
+                "season": {"year": 2026, "type": 2, "slug": "torneo-clausura"},
+                "competitions": [{
+                    "competitors": [
+                        {"homeAway": "home",
+                         "team": {"displayName": "Club America"}},
+                        {"homeAway": "away",
+                         "team": {"displayName": "Chivas Guadalajara"}},
+                    ],
+                }],
+            }],
+        }
+        monkeypatch.setattr(mls_mod, "_http_get", lambda *a, **kw: espn_response)
+        src = LigaMxSource(odds_api_key="")
+        games = src.fetch_upcoming(days_ahead=0)
+        assert len(games) == 1
+        assert games[0].extra.get("season_slug") == "torneo-clausura"
+        assert games[0].extra.get("fd_competition_code") == "LigaMX"


### PR DESCRIPTION
Backfills 5 leagues that the original umbrella #16 missed.

**Q.1 — FD.org free-tier additions** (pure config):
- Eredivisie (DED)
- Primeira Liga (PPL)
- Brazilian Série A (BSA)

UEFA Europa League / Conference League are NOT on FD.org free tier — skipped.

**Q.2 — ESPN-backed additions** (refactored MlsSource as parameterized base):
- NWSL — soccer/usa.nwsl + soccer_usa_nwsl
- Liga MX — soccer/mex.1 + soccer_mexico_ligamx

MlsSource refactored to take per-league class attrs. NwslSource + LigaMxSource are thin subclasses. Shared machinery, no duplication.

Both V1 minimal (schedule + closeness, no importance, no bracket) — same follow-up shape as MLS.

Tests: 553 → 563 (+10).