### PR TITLE
Phase R: field events (F1 + NASCAR + Golf)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -161,6 +161,27 @@
       "help_text": "Mexican Apertura + Clausura + Liguilla playoff. Schedule + closeness scoring only in V1 (same minimal scope as MLS / NWSL). ESPN unofficial API + Odds API (soccer_mexico_ligamx). Relevant for US viewers with Univision / Telemundo channels in their EPG."
     },
     {
+      "id": "enable_f1",
+      "type": "boolean",
+      "label": "Formula 1",
+      "default": false,
+      "help_text": "~24 Grands Prix per year. Each scheduled race surfaces in the guide as a single 'Event'-tier entry — no per-driver importance ranking (the rarity of races makes 'show if toggled' the right product). No API key required — ESPN unofficial."
+    },
+    {
+      "id": "enable_nascar",
+      "type": "boolean",
+      "label": "NASCAR Cup Series",
+      "default": false,
+      "help_text": "~36 Cup Series races per year. Same field-event shape as F1: each race is one 'Event'-tier row. No API key required — ESPN unofficial."
+    },
+    {
+      "id": "enable_golf",
+      "type": "boolean",
+      "label": "PGA Tour (incl. majors)",
+      "default": false,
+      "help_text": "PGA Tour tour stops + the four majors (Masters / PGA Championship / US Open / The Open). Major tournaments get a higher score tier ('Major') than regular tour stops ('Event'). No API key required — ESPN unofficial."
+    },
+    {
       "id": "enable_wnba",
       "type": "boolean",
       "label": "WNBA (regular season + playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -301,6 +301,7 @@ def _build_sources(settings: Dict[str, Any]):
         NcaafSource, NcaamSource,
         NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
+        F1Source, NascarSource, GolfSource,
     )
     from .sources.soccer import COMPETITIONS
     from .scoring import LEAGUE_CONTEXTS
@@ -448,6 +449,17 @@ def _build_sources(settings: Dict[str, Any]):
     # Liga MX — Mexican top-flight. Same V1 minimal pattern.
     if settings.get("enable_liga_mx", False):
         sources.append(LigaMxSource(odds_api_key=odds_key or ""))
+
+    # Phase R: field events (racing + golf). No two-team head-to-head;
+    # each row is one race or tournament. Low event volume (~1/week)
+    # means "surface if toggled" is the right product — no importance
+    # ranking needed.
+    if settings.get("enable_f1", False):
+        sources.append(F1Source())
+    if settings.get("enable_nascar", False):
+        sources.append(NascarSource())
+    if settings.get("enable_golf", False):
+        sources.append(GolfSource())
 
     # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
     # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1

--- a/scoring.py
+++ b/scoring.py
@@ -825,6 +825,16 @@ def score_game(signals: GameSignals, weights: Weights) -> GameScore:
             "ROUND_OF_16": 1.5, "LAST_16": 1.5,
             "ROUND_OF_32": 1.0, "LAST_32": 1.0,
             "PLAYOFF_ROUND": 1.0, "PLAYOFFS": 1.0,
+            # Phase R: field events (F1 GP, NASCAR race, golf tour
+            # weekly events). These have no two-team head-to-head
+            # structure so the rank / favorite / closeness signals
+            # don't apply — the tournament_stage band is what gets
+            # them into the guide at all. "MAJOR" is for golf's four
+            # majors (Masters / PGA / US Open / British Open) and
+            # any future marquee racing event we want bumped above
+            # the regular tour.
+            "EVENT": 1.5,
+            "MAJOR": 4.5,
         }.get(ts, 0.0)
         if stage_score > 0:
             tourn_pts = stage_score * weights.tournament
@@ -1002,6 +1012,8 @@ def pick_tagline(
             "ROUND_OF_16": "Round of 16", "LAST_16": "Round of 16",
             "ROUND_OF_32": "Round of 32", "LAST_32": "Round of 32",
             "PLAYOFF_ROUND": "Playoff", "PLAYOFFS": "Playoff",
+            "EVENT": "Event",
+            "MAJOR": "Major",
         }
         if ts in stage_labels:
             return stage_labels[ts]

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -4,6 +4,7 @@ from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .nwsl import NwslSource
 from .liga_mx import LigaMxSource
+from .field_event import F1Source, NascarSource, GolfSource, FieldEventSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
@@ -26,6 +27,7 @@ __all__ = [
     "GameRow", "SportSource",
     "MlbRegularSource", "MlbPlayoffSource",
     "MlsSource", "NwslSource", "LigaMxSource",
+    "FieldEventSource", "F1Source", "NascarSource", "GolfSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -1,0 +1,204 @@
+"""Field-event source — racing and golf.
+
+Racing and golf don't fit the team-based GameRow model because they're
+field events: one race or tournament with 20+ competitors and a
+finishing order, not a head-to-head outcome between two teams.
+
+V1 design (Phase R)
+
+  - Emit one GameRow per scheduled event, with `home = event_name`
+    (e.g., "Heineken Chinese GP", "The Masters") and `away = "Field"`
+    as a sentinel.
+  - Tag with `tournament_stage = "EVENT"` (regular tour stop) or
+    `"MAJOR"` (golf majors / future marquee racing events). The
+    scoring layer's `tournament` signal handles the rest; both labels
+    map to non-zero stage_score so field events always surface in the
+    guide when toggled on.
+  - No importance simulation, no closeness, no rank — the rarity of
+    these events (~1/week) means just-show-it-up is the right product.
+    The matcher fuzzy-matches the event name against EPG titles.
+
+Subclasses parameterize the league via class attrs (ESPN_SLUG,
+SPORT_PREFIX, SPORT_LABEL, MAJOR_REGEX). The base does all the work.
+
+ESPN doesn't enforce a 25-event range cap on these endpoints because
+volumes are low (F1: 24 GPs/year, NASCAR: 36 races/year, PGA: ~45
+tour events/year). Range queries are safe.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Optional, Pattern
+
+import requests
+
+from .base import GameRow, SportSource
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.field_event")
+
+
+_FIELD_AWAY_SENTINEL = "Field"
+
+
+class FieldEventSource(SportSource):
+    """ABC for field-event leagues (racing, golf). Subclasses set
+    five class attrs:
+
+      - `ESPN_SLUG`: path under `/apis/site/v2/sports/` (e.g.,
+        "racing/f1", "racing/nascar-premier", "golf/pga").
+      - `SPORT_PREFIX`: short channel-name prefix.
+      - `SPORT_LABEL`: human-readable label.
+      - `FD_COMPETITION_CODE`: arbitrary string carried through extra
+        for future routing.
+      - `MAJOR_REGEX`: optional compiled regex; when an event name
+        matches, the event is tagged tournament_stage="MAJOR"
+        (otherwise "EVENT"). Default None means everything is "EVENT".
+    """
+
+    # supports_importance left at the SportSource default (False).
+    # Field events surface via the tournament signal alone in V1.
+
+    ESPN_SLUG: str = ""
+    SPORT_PREFIX: str = ""
+    SPORT_LABEL: str = ""
+    FD_COMPETITION_CODE: str = ""
+    MAJOR_REGEX: Optional[Pattern[str]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return self.SPORT_PREFIX
+
+    @property
+    def sport_label(self) -> str:
+        return self.SPORT_LABEL
+
+    def _espn_base(self) -> str:
+        return f"https://site.api.espn.com/apis/site/v2/sports/{self.ESPN_SLUG}"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Pull events scheduled in the next N days via the ESPN
+        scoreboard range endpoint. Field-event sports have low enough
+        volume that range queries (which silently cap at 25 for team
+        sports) work fine — ESPN returns the whole window unfiltered.
+        """
+        today = datetime.now(timezone.utc).date()
+        end = today + timedelta(days=days_ahead)
+        url = (
+            f"{self._espn_base()}/scoreboard"
+            f"?dates={today.strftime('%Y%m%d')}-{end.strftime('%Y%m%d')}"
+        )
+        data = _http_get(url)
+        if not isinstance(data, dict):
+            return []
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for event in data.get("events") or []:
+            eid = event.get("id")
+            if eid in seen_ids:
+                continue
+            name = (event.get("name") or "").strip()
+            short_name = (event.get("shortName") or "").strip()
+            display_name = name or short_name
+            if not display_name:
+                continue
+            start = parse_iso_utc(event.get("date"))
+            if start is None:
+                continue
+            seen_ids.add(eid)
+            # Detect majors so the score gets bumped to the MAJOR tier
+            # (e.g., golf's Masters / PGA / US Open / British Open).
+            stage = "EVENT"
+            if self.MAJOR_REGEX is not None and self.MAJOR_REGEX.search(display_name):
+                stage = "MAJOR"
+            out.append(GameRow(
+                sport_prefix=self.sport_prefix,
+                sport_label=self.sport_label,
+                home=display_name,
+                away=_FIELD_AWAY_SENTINEL,
+                rank_home=None,
+                rank_away=None,
+                start_time=start,
+                extra={
+                    "espn_event_id": eid,
+                    "fd_competition_code": self.FD_COMPETITION_CODE,
+                    "is_field_event": True,
+                    "stage": stage,
+                    "short_name": short_name,
+                },
+            ))
+        return out
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Any]:
+    """ESPN unofficial API wrapper. Returns parsed JSON or None on
+    any error. Shared across all field-event subclasses."""
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[field_event] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[field_event] %s failed: %s", url, exc)
+        return None
+
+
+# =====================================================================
+# Concrete subclasses
+# =====================================================================
+
+
+class F1Source(FieldEventSource):
+    """Formula 1 — ~24 Grands Prix per year. Each weekend covers
+    practice + qualifying + race; ESPN's scoreboard usually returns
+    one event per GP date with the race itself."""
+
+    ESPN_SLUG = "racing/f1"
+    SPORT_PREFIX = "F1"
+    SPORT_LABEL = "Formula 1"
+    FD_COMPETITION_CODE = "F1"
+    # F1 has no "major" tier in the same sense as golf; the Monaco
+    # and Italian GPs are historically marquee but the points-per-race
+    # is identical across the calendar. No MAJOR_REGEX.
+
+
+class NascarSource(FieldEventSource):
+    """NASCAR Cup Series — ~36 races per year, including the Daytona
+    500 (season opener) and the Coca-Cola 600. Both are 'crown jewels'
+    but for V1 every race is EVENT-tier."""
+
+    ESPN_SLUG = "racing/nascar-premier"
+    SPORT_PREFIX = "NASCAR"
+    SPORT_LABEL = "NASCAR Cup Series"
+    FD_COMPETITION_CODE = "NASCAR"
+
+
+# Golf majors. The Masters / PGA Championship / US Open / British
+# Open (The Open Championship) are the four majors. Each typically
+# runs Thursday-Sunday and shows up on ESPN as a single multi-day
+# tournament event whose name contains the major name. Regex is
+# liberal in word ordering to cover ESPN's stylings ("The Masters",
+# "Masters Tournament", "U.S. Open Championship", "The Open
+# Championship", "PGA Championship").
+_GOLF_MAJOR_RE: Pattern[str] = re.compile(
+    r"\b(masters|pga\s+championship|u\.?s\.?\s+open|"
+    r"the\s+open(?:\s+championship)?|british\s+open)\b",
+    re.IGNORECASE,
+)
+
+
+class GolfSource(FieldEventSource):
+    """PGA Tour — ~45 tournaments per year. Four majors get the
+    MAJOR tier; everything else is EVENT-tier. The MAJOR_REGEX
+    intentionally catches both "The Open" and "British Open"
+    framings; ESPN has inconsistently used both."""
+
+    ESPN_SLUG = "golf/pga"
+    SPORT_PREFIX = "PGA"
+    SPORT_LABEL = "PGA Tour"
+    FD_COMPETITION_CODE = "PGA"
+    MAJOR_REGEX = _GOLF_MAJOR_RE

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4412,3 +4412,200 @@ class TestLigaMxSource:
         assert len(games) == 1
         assert games[0].extra.get("season_slug") == "torneo-clausura"
         assert games[0].extra.get("fd_competition_code") == "LigaMX"
+
+
+# =====================================================================
+# Phase R: field events (F1 + NASCAR + Golf)
+# =====================================================================
+
+class TestFieldEventSourceContract:
+    """FieldEventSource is the ABC for racing + golf — events that
+    aren't head-to-head. Pin the contract: home=event_name, away="Field"
+    sentinel, no importance simulation."""
+
+    def test_f1_identity(self):
+        from dispatcharr_ranked_matchups.sources.field_event import F1Source
+        src = F1Source()
+        assert src.sport_prefix == "F1"
+        assert src.sport_label == "Formula 1"
+        assert src.ESPN_SLUG == "racing/f1"
+
+    def test_nascar_identity(self):
+        from dispatcharr_ranked_matchups.sources.field_event import NascarSource
+        src = NascarSource()
+        assert src.sport_prefix == "NASCAR"
+        assert "NASCAR" in src.sport_label
+        assert src.ESPN_SLUG == "racing/nascar-premier"
+
+    def test_golf_identity(self):
+        from dispatcharr_ranked_matchups.sources.field_event import GolfSource
+        src = GolfSource()
+        assert src.sport_prefix == "PGA"
+        assert "PGA" in src.sport_label
+        assert src.ESPN_SLUG == "golf/pga"
+
+    def test_field_events_do_not_support_importance(self):
+        """Field events surface via tournament_stage alone in V1; no
+        Monte Carlo importance simulation."""
+        from dispatcharr_ranked_matchups.sources.field_event import (
+            F1Source, NascarSource, GolfSource,
+        )
+        for src in (F1Source(), NascarSource(), GolfSource()):
+            assert src.supports_importance is False
+
+
+class TestGolfMajorDetection:
+    """The four golf majors get the MAJOR score tier. Detection is
+    regex-based against event name; regex must catch ESPN's varied
+    naming."""
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.field_event import GolfSource
+        return GolfSource()
+
+    @staticmethod
+    def _is_major(src, name):
+        return src.MAJOR_REGEX is not None and bool(src.MAJOR_REGEX.search(name))
+
+    def test_masters(self):
+        src = self._make()
+        assert self._is_major(src, "Masters Tournament")
+        assert self._is_major(src, "The Masters")
+
+    def test_pga_championship(self):
+        src = self._make()
+        assert self._is_major(src, "PGA Championship")
+
+    def test_us_open(self):
+        src = self._make()
+        assert self._is_major(src, "U.S. Open Championship")
+        assert self._is_major(src, "US Open")
+
+    def test_british_open(self):
+        src = self._make()
+        # ESPN has used both "The Open Championship" and "British Open".
+        assert self._is_major(src, "The Open Championship")
+        assert self._is_major(src, "British Open")
+
+    def test_regular_tour_event_not_major(self):
+        src = self._make()
+        assert not self._is_major(src, "Charles Schwab Challenge")
+        assert not self._is_major(src, "FedEx St. Jude Championship")
+        assert not self._is_major(src, "Players Championship")
+
+    def test_f1_no_major_regex(self):
+        """F1 has no major tier in V1; the class attr is None."""
+        from dispatcharr_ranked_matchups.sources.field_event import F1Source
+        assert F1Source.MAJOR_REGEX is None
+
+
+class TestFieldEventFetchUpcoming:
+    """Pin the GameRow shape FieldEventSource emits."""
+
+    def test_emits_event_tier_row(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401900100",
+                "name": "Heineken Chinese Grand Prix",
+                "shortName": "Heineken Chinese GP",
+                "date": "2026-04-12T05:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import F1Source
+        src = F1Source()
+        games = src.fetch_upcoming(days_ahead=7)
+        assert len(games) == 1
+        g = games[0]
+        assert g.home == "Heineken Chinese Grand Prix"
+        # Sentinel away team — field events have no opponent.
+        assert g.away == "Field"
+        assert g.sport_prefix == "F1"
+        assert g.extra.get("stage") == "EVENT"
+        assert g.extra.get("is_field_event") is True
+        assert g.extra.get("fd_competition_code") == "F1"
+
+    def test_emits_major_tier_for_golf_major(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401900200",
+                "name": "Masters Tournament",
+                "shortName": "Masters Tournament",
+                "date": "2026-04-09T17:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import GolfSource
+        src = GolfSource()
+        games = src.fetch_upcoming(days_ahead=7)
+        assert len(games) == 1
+        assert games[0].extra.get("stage") == "MAJOR"
+
+    def test_emits_event_tier_for_regular_golf_tournament(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401900201",
+                "name": "Charles Schwab Challenge",
+                "shortName": "Charles Schwab Challenge",
+                "date": "2026-05-21T17:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import GolfSource
+        src = GolfSource()
+        games = src.fetch_upcoming(days_ahead=7)
+        assert len(games) == 1
+        assert games[0].extra.get("stage") == "EVENT"
+
+    def test_empty_response_returns_empty_list(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: {"events": []})
+        from dispatcharr_ranked_matchups.sources.field_event import F1Source
+        assert F1Source().fetch_upcoming(days_ahead=7) == []
+
+    def test_http_failure_returns_empty_list(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: None)
+        from dispatcharr_ranked_matchups.sources.field_event import NascarSource
+        assert NascarSource().fetch_upcoming(days_ahead=7) == []
+
+
+class TestFieldEventScoring:
+    """tournament_stage = EVENT or MAJOR must produce a non-zero score
+    so field events appear in the curated guide."""
+
+    def test_event_stage_scores_nonzero(self):
+        from dispatcharr_ranked_matchups.scoring import (
+            GameSignals, Weights, score_game,
+        )
+        signals = GameSignals(
+            team_a="Heineken Chinese Grand Prix",
+            team_b="Field",
+            tournament_stage="EVENT",
+        )
+        score = score_game(signals, Weights())
+        assert score.raw > 0
+
+    def test_major_stage_scores_higher_than_event(self):
+        from dispatcharr_ranked_matchups.scoring import (
+            GameSignals, Weights, score_game,
+        )
+        weights = Weights()
+        event_score = score_game(
+            GameSignals(team_a="X", team_b="Field", tournament_stage="EVENT"),
+            weights,
+        )
+        major_score = score_game(
+            GameSignals(team_a="X", team_b="Field", tournament_stage="MAJOR"),
+            weights,
+        )
+        # MAJOR must outrank EVENT — golf majors should beat regular
+        # tour stops in the guide.
+        assert major_score.raw > event_score.raw


### PR DESCRIPTION
Adds racing + golf via a new `FieldEventSource` ABC. Field events don't fit the team-based GameRow model (no head-to-head opponent); each row is one race or tournament with `home = event_name`, `away = "Field"` sentinel, and `tournament_stage = "EVENT"` (or `"MAJOR"` for golf's four majors).

Score is delivered via the existing `tournament` signal (scoring.py gets "EVENT" / "MAJOR" added to the stage table). Rarity (~1/week) means "surface if toggled" — no per-driver/per-golfer importance ranking needed.

**Live verify (next 30 days)**:
- F1: 2 events (Monaco GP next)
- NASCAR: 4 events
- Golf: 5 events including **U.S. Open correctly tagged MAJOR** by the regex

Tests: 563 -> 580 (+17).