### PR TITLE
Phase S: UFC

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -182,6 +182,13 @@
       "help_text": "PGA Tour tour stops + the four majors (Masters / PGA Championship / US Open / The Open). Major tournaments get a higher score tier ('Major') than regular tour stops ('Event'). No API key required — ESPN unofficial."
     },
     {
+      "id": "enable_ufc",
+      "type": "boolean",
+      "label": "UFC",
+      "default": false,
+      "help_text": "Each UFC fight card surfaces as one entry in the guide (the card title carries the headliner, e.g., 'UFC 309: Jones vs. Miocic'). Numbered PPVs get a higher tier ('Major') than Fight Nights and ESPN cards ('Event'). No API key required — ESPN unofficial."
+    },
+    {
       "id": "enable_wnba",
       "type": "boolean",
       "label": "WNBA (regular season + playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -301,7 +301,7 @@ def _build_sources(settings: Dict[str, Any]):
         NcaafSource, NcaamSource,
         NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
-        F1Source, NascarSource, GolfSource,
+        F1Source, NascarSource, GolfSource, UfcSource,
     )
     from .sources.soccer import COMPETITIONS
     from .scoring import LEAGUE_CONTEXTS
@@ -460,6 +460,12 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(NascarSource())
     if settings.get("enable_golf", False):
         sources.append(GolfSource())
+
+    # Phase S: UFC. Same field-event shape — each fight card is one
+    # row with home=card title ("UFC 309: Jones vs. Miocic"). PPVs
+    # (numbered UFC events) get MAJOR tier, Fight Nights get EVENT.
+    if settings.get("enable_ufc", False):
+        sources.append(UfcSource())
 
     # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
     # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -4,7 +4,7 @@ from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .nwsl import NwslSource
 from .liga_mx import LigaMxSource
-from .field_event import F1Source, NascarSource, GolfSource, FieldEventSource
+from .field_event import F1Source, NascarSource, GolfSource, UfcSource, FieldEventSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
@@ -27,7 +27,7 @@ __all__ = [
     "GameRow", "SportSource",
     "MlbRegularSource", "MlbPlayoffSource",
     "MlsSource", "NwslSource", "LigaMxSource",
-    "FieldEventSource", "F1Source", "NascarSource", "GolfSource",
+    "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -202,3 +202,29 @@ class GolfSource(FieldEventSource):
     SPORT_LABEL = "PGA Tour"
     FD_COMPETITION_CODE = "PGA"
     MAJOR_REGEX = _GOLF_MAJOR_RE
+
+
+# UFC PPV detection. ESPN names PPV events "UFC <number>: <headline>"
+# (e.g., "UFC 309: Jones vs. Miocic"). Fight Nights and ESPN-broadcast
+# events use "UFC Fight Night: …" or "UFC on ESPN: …" without a
+# number. The MAJOR tier is reserved for numbered PPVs because those
+# are the marquee cards (typically a title fight as the main event).
+_UFC_PPV_RE: Pattern[str] = re.compile(r"^\s*UFC\s+\d+\b", re.IGNORECASE)
+
+
+class UfcSource(FieldEventSource):
+    """UFC — one EPG entry per fight night card. The card itself is
+    the broadcast unit; ESPN's `event.name` carries the headliner
+    framing ("UFC 309: Jones vs. Miocic", "UFC Fight Night:
+    Sandhagen vs. Figueiredo").
+
+    Architecturally the same shape as racing / golf: emit one row
+    per scheduled card with the card title as `home`. PPVs (numbered
+    UFC events) get MAJOR tier; Fight Nights get EVENT tier.
+    """
+
+    ESPN_SLUG = "mma/ufc"
+    SPORT_PREFIX = "UFC"
+    SPORT_LABEL = "UFC"
+    FD_COMPETITION_CODE = "UFC"
+    MAJOR_REGEX = _UFC_PPV_RE

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4609,3 +4609,85 @@ class TestFieldEventScoring:
         # MAJOR must outrank EVENT — golf majors should beat regular
         # tour stops in the guide.
         assert major_score.raw > event_score.raw
+
+
+# =====================================================================
+# Phase S: UFC
+# =====================================================================
+
+class TestUfcSource:
+    """UFC fits the FieldEventSource pattern — one EPG entry per
+    fight card. Numbered PPVs (UFC 309, etc.) get MAJOR; Fight
+    Nights and ESPN-broadcast cards get EVENT."""
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.field_event import UfcSource
+        return UfcSource()
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "UFC"
+        assert src.sport_label == "UFC"
+        assert src.ESPN_SLUG == "mma/ufc"
+
+    def test_does_not_support_importance(self):
+        assert self._make().supports_importance is False
+
+    def test_ppv_detected_as_major(self):
+        src = self._make()
+        assert src.MAJOR_REGEX is not None
+        # Numbered PPV — MAJOR.
+        assert src.MAJOR_REGEX.search("UFC 309: Jones vs. Miocic")
+        assert src.MAJOR_REGEX.search("UFC 310: Pantoja vs. Asakura")
+        # Three-digit (future-proofing).
+        assert src.MAJOR_REGEX.search("UFC 999: Some Fight")
+
+    def test_fight_night_not_major(self):
+        src = self._make()
+        assert src.MAJOR_REGEX is not None
+        # Fight Night and ESPN cards — EVENT-tier.
+        assert not src.MAJOR_REGEX.search(
+            "UFC Fight Night: Sandhagen vs. Figueiredo"
+        )
+        assert not src.MAJOR_REGEX.search("UFC on ESPN: Lewis vs. Nascimento")
+
+    def test_emits_ppv_with_major_tier(self, monkeypatch):
+        """Live ESPN response shape — UFC card surfaces as one row."""
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401900800",
+                "name": "UFC 309: Jones vs. Miocic",
+                "shortName": "UFC 309",
+                "date": "2024-11-17T03:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import UfcSource
+        games = UfcSource().fetch_upcoming(days_ahead=7)
+        assert len(games) == 1
+        g = games[0]
+        assert g.home == "UFC 309: Jones vs. Miocic"
+        assert g.away == "Field"
+        assert g.sport_prefix == "UFC"
+        assert g.extra.get("stage") == "MAJOR"  # PPV bumped to MAJOR
+        assert g.extra.get("is_field_event") is True
+
+    def test_emits_fight_night_with_event_tier(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401900801",
+                "name": "UFC Fight Night: Sandhagen vs. Figueiredo",
+                "shortName": "UFC Fight Night",
+                "date": "2025-05-03T22:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import UfcSource
+        games = UfcSource().fetch_upcoming(days_ahead=7)
+        assert len(games) == 1
+        assert games[0].extra.get("stage") == "EVENT"


### PR DESCRIPTION
UFC as a 14-line FieldEventSource subclass. Each fight card is one EPG entry; numbered PPVs (`UFC 329: …`) get MAJOR tier, Fight Nights stay EVENT.

**Live verify**: 7 events in next 60 days. UFC 329: McGregor vs. Holloway 2 → MAJOR. Fight Nights → EVENT.

Tests: 580 → 586 (+6).