### PR TITLE
Phase T: Tennis (ATP + WTA)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -189,6 +189,20 @@
       "help_text": "Each UFC fight card surfaces as one entry in the guide (the card title carries the headliner, e.g., 'UFC 309: Jones vs. Miocic'). Numbered PPVs get a higher tier ('Major') than Fight Nights and ESPN cards ('Event'). No API key required — ESPN unofficial."
     },
     {
+      "id": "enable_atp",
+      "type": "boolean",
+      "label": "ATP Tour (men's tennis)",
+      "default": false,
+      "help_text": "Each active ATP tournament surfaces as one entry. The four Grand Slams (Wimbledon / Australian Open / French Open / US Open) and the year-end ATP Finals get the 'Major' tier; regular tour stops get 'Event'. No API key required — ESPN unofficial."
+    },
+    {
+      "id": "enable_wta",
+      "type": "boolean",
+      "label": "WTA Tour (women's tennis)",
+      "default": false,
+      "help_text": "Same Grand Slam roster as ATP. Each active WTA tournament surfaces as one entry; Slams and the year-end WTA Finals get 'Major', regular tour stops get 'Event'. No API key required — ESPN unofficial."
+    },
+    {
       "id": "enable_wnba",
       "type": "boolean",
       "label": "WNBA (regular season + playoffs)",

--- a/plugin.py
+++ b/plugin.py
@@ -302,6 +302,7 @@ def _build_sources(settings: Dict[str, Any]):
         NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
         F1Source, NascarSource, GolfSource, UfcSource,
+        AtpSource, WtaSource,
     )
     from .sources.soccer import COMPETITIONS
     from .scoring import LEAGUE_CONTEXTS
@@ -466,6 +467,16 @@ def _build_sources(settings: Dict[str, Any]):
     # (numbered UFC events) get MAJOR tier, Fight Nights get EVENT.
     if settings.get("enable_ufc", False):
         sources.append(UfcSource())
+
+    # Phase T: Tennis. ESPN's tennis scoreboard returns whole
+    # tournaments (one entry per active event), not individual
+    # matches — so tennis fits the FieldEventSource model. Grand
+    # Slams + year-end Finals get MAJOR; regular tour stops get
+    # EVENT.
+    if settings.get("enable_atp", False):
+        sources.append(AtpSource())
+    if settings.get("enable_wta", False):
+        sources.append(WtaSource())
 
     # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
     # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -4,7 +4,10 @@ from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .nwsl import NwslSource
 from .liga_mx import LigaMxSource
-from .field_event import F1Source, NascarSource, GolfSource, UfcSource, FieldEventSource
+from .field_event import (
+    F1Source, NascarSource, GolfSource, UfcSource,
+    AtpSource, WtaSource, FieldEventSource,
+)
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
@@ -28,6 +31,7 @@ __all__ = [
     "MlbRegularSource", "MlbPlayoffSource",
     "MlsSource", "NwslSource", "LigaMxSource",
     "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
+    "AtpSource", "WtaSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -228,3 +228,40 @@ class UfcSource(FieldEventSource):
     SPORT_LABEL = "UFC"
     FD_COMPETITION_CODE = "UFC"
     MAJOR_REGEX = _UFC_PPV_RE
+
+
+# Tennis Grand Slams + marquee year-end events. ESPN's tennis
+# scoreboard returns whole tournaments (each entry spans 1-2 weeks),
+# not individual matches — so tennis fits the FieldEventSource model
+# the same way racing and golf do. The four Slams plus the year-end
+# Finals get the MAJOR tier; regular tour events stay EVENT.
+_TENNIS_MAJOR_RE: Pattern[str] = re.compile(
+    r"\b(?:wimbledon|australian\s+open|french\s+open|roland\s+garros|"
+    r"u\.?s\.?\s+open|atp\s+finals|wta\s+finals)\b",
+    re.IGNORECASE,
+)
+
+
+class AtpSource(FieldEventSource):
+    """ATP Tour — men's professional tennis. One entry per active
+    tournament. Grand Slams (Wimbledon / Australian Open / French
+    Open / US Open) and ATP Finals get MAJOR; regular tour stops
+    stay EVENT."""
+
+    ESPN_SLUG = "tennis/atp"
+    SPORT_PREFIX = "ATP"
+    SPORT_LABEL = "ATP Tour"
+    FD_COMPETITION_CODE = "ATP"
+    MAJOR_REGEX = _TENNIS_MAJOR_RE
+
+
+class WtaSource(FieldEventSource):
+    """WTA Tour — women's professional tennis. Same shape and same
+    Grand Slam roster as ATP (the Slams are shared events). MAJOR
+    detection is identical."""
+
+    ESPN_SLUG = "tennis/wta"
+    SPORT_PREFIX = "WTA"
+    SPORT_LABEL = "WTA Tour"
+    FD_COMPETITION_CODE = "WTA"
+    MAJOR_REGEX = _TENNIS_MAJOR_RE

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4691,3 +4691,87 @@ class TestUfcSource:
         games = UfcSource().fetch_upcoming(days_ahead=7)
         assert len(games) == 1
         assert games[0].extra.get("stage") == "EVENT"
+
+
+# =====================================================================
+# Phase T: Tennis (ATP + WTA)
+# =====================================================================
+
+class TestTennisSources:
+    """ESPN's tennis scoreboard returns whole tournaments (each entry
+    spans 1-2 weeks for a Slam, or 5-7 days for tour stops), not
+    individual matches — same FieldEventSource shape as racing + UFC."""
+
+    def test_atp_identity(self):
+        from dispatcharr_ranked_matchups.sources.field_event import AtpSource
+        src = AtpSource()
+        assert src.sport_prefix == "ATP"
+        assert "ATP" in src.sport_label
+        assert src.ESPN_SLUG == "tennis/atp"
+
+    def test_wta_identity(self):
+        from dispatcharr_ranked_matchups.sources.field_event import WtaSource
+        src = WtaSource()
+        assert src.sport_prefix == "WTA"
+        assert "WTA" in src.sport_label
+        assert src.ESPN_SLUG == "tennis/wta"
+
+    def test_no_importance(self):
+        from dispatcharr_ranked_matchups.sources.field_event import (
+            AtpSource, WtaSource,
+        )
+        assert AtpSource().supports_importance is False
+        assert WtaSource().supports_importance is False
+
+    def test_grand_slams_detected_as_major(self):
+        from dispatcharr_ranked_matchups.sources.field_event import AtpSource
+        src = AtpSource()
+        assert src.MAJOR_REGEX is not None
+        # All four Grand Slams + variants.
+        assert src.MAJOR_REGEX.search("Wimbledon")
+        assert src.MAJOR_REGEX.search("Australian Open")
+        assert src.MAJOR_REGEX.search("French Open")
+        assert src.MAJOR_REGEX.search("Roland Garros")
+        assert src.MAJOR_REGEX.search("U.S. Open")
+        assert src.MAJOR_REGEX.search("US Open")
+
+    def test_year_end_finals_detected_as_major(self):
+        from dispatcharr_ranked_matchups.sources.field_event import (
+            AtpSource, WtaSource,
+        )
+        assert AtpSource().MAJOR_REGEX is not None
+        assert WtaSource().MAJOR_REGEX is not None
+        assert AtpSource().MAJOR_REGEX.search("ATP Finals")
+        assert WtaSource().MAJOR_REGEX.search("WTA Finals")
+
+    def test_regular_tour_stops_not_major(self):
+        from dispatcharr_ranked_matchups.sources.field_event import AtpSource
+        src = AtpSource()
+        assert src.MAJOR_REGEX is not None
+        assert not src.MAJOR_REGEX.search("Nordea Open")
+        assert not src.MAJOR_REGEX.search("EFG Swiss Open Gstaad")
+        assert not src.MAJOR_REGEX.search("Bitpanda Hamburg Open")
+
+    def test_atp_emits_slam_with_major_tier(self, monkeypatch):
+        import dispatcharr_ranked_matchups.sources.field_event as field_mod
+        espn_response = {
+            "events": [{
+                "id": "401901000",
+                "name": "Wimbledon",
+                "shortName": "Wimbledon",
+                "date": "2026-06-29T04:00Z",
+                "competitions": [{"competitors": []}],
+            }, {
+                "id": "401901001",
+                "name": "Nordea Open",
+                "shortName": "Nordea Open",
+                "date": "2026-07-13T04:00Z",
+                "competitions": [{"competitors": []}],
+            }],
+        }
+        monkeypatch.setattr(field_mod, "_http_get", lambda *a, **kw: espn_response)
+        from dispatcharr_ranked_matchups.sources.field_event import AtpSource
+        games = AtpSource().fetch_upcoming(days_ahead=60)
+        by_name = {g.home: g for g in games}
+        assert by_name["Wimbledon"].extra.get("stage") == "MAJOR"
+        assert by_name["Nordea Open"].extra.get("stage") == "EVENT"


### PR DESCRIPTION
Tennis as 11-line FieldEventSource subclasses. ESPN returns tournaments (not matches), which fits the field-event model exactly. Grand Slams + year-end Finals → MAJOR; regular tour stops → EVENT.

Tests: 586 → 593 (+7).