### PR TITLE
Phase O Phase 1: NCAA Baseball/Softball best-of-3 postseason coverage

### DIFF
--- a/_util.py
+++ b/_util.py
@@ -36,6 +36,41 @@ def stable_hash_int(s: str) -> int:
     return int(digest[:16], 16)
 
 
+def extract_game_number_after_marker(headline: str, marker: str) -> Optional[int]:
+    """Extract the integer game number that immediately follows `marker` in
+    `headline`. Strips an "(if necessary)" trailer that ESPN attaches to
+    Game-3 placeholders on best-of-3 series. Returns None on any parse
+    failure so the caller can skip the event gracefully.
+
+    Shared between NCAA Baseball / Softball playoff sources where ESPN
+    encodes the game index in headlines like
+    "...Super Regional - Game 3 (if necessary)" or
+    "...Championship Final - Game 2".
+
+    Example:
+        >>> extract_game_number_after_marker(
+        ...     "NCAA Baseball Championship - Auburn Super Regional - Game 3 (if necessary)",
+        ...     "Super Regional - Game ",
+        ... )
+        3
+    """
+    if not headline or marker not in headline:
+        return None
+    tail = headline.split(marker, 1)[1].strip()
+    digits = []
+    for ch in tail:
+        if ch.isdigit():
+            digits.append(ch)
+        else:
+            break
+    if not digits:
+        return None
+    try:
+        return int("".join(digits))
+    except ValueError:
+        return None
+
+
 def poisson_sample(lam: float, rng: random.Random) -> int:
     """Draw one Poisson(lam) sample via Knuth's algorithm. Pure-Python (no
     numpy dependency, the plugin runs in Dispatcharr's lean container).

--- a/plugin.py
+++ b/plugin.py
@@ -297,7 +297,9 @@ def _build_sources(settings: Dict[str, Any]):
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
-        NcaaBaseballSource, NcaaSoftballSource, NcaaSoccerSource,
+        NcaaBaseballRegularSource, NcaaBaseballPlayoffSource,
+        NcaaSoftballRegularSource, NcaaSoftballPlayoffSource,
+        NcaaSoccerSource,
         NcaafSource, NcaamSource,
         NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
@@ -505,19 +507,38 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[ncaaw_basketball] could not seed playoff strengths: %s", exc)
         sources.append(ncaaw_po)
 
-    # Phase M: NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
-    # poll, no key needed. Win-count thresholds (30 / 35 / 40 / 45 / 50) drive
-    # the importance signal. CWS postseason bracket isn't modeled yet — postseason
-    # games still surface via favorite + rank-pair signal.
+    # Phase M / Phase O Phase 1: NCAA Division I baseball. Free ESPN
+    # unofficial API + D1Baseball poll. Regular-season win-count thresholds
+    # (30 / 35 / 40 / 45 / 50) drive the in-season importance signal.
+    # Phase O Phase 1 adds postseason coverage for the cleanly-labeled
+    # best-of-3 stages (Super Regional, MCWS Finals). Same pair-and-seed
+    # pattern as MLB: the playoff source borrows regular-season strengths
+    # from the regular source so postseason Poisson sampling reflects
+    # per-team scoring skill rather than the league-average prior.
     if settings.get("enable_ncaa_baseball", False):
-        sources.append(NcaaBaseballSource())
+        ncbsb_reg = NcaaBaseballRegularSource()
+        sources.append(ncbsb_reg)
+        ncbsb_po = NcaaBaseballPlayoffSource()
+        try:
+            ncbsb_po.set_regular_season_strengths(ncbsb_reg.estimate_strengths())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ncaa_baseball] could not seed playoff strengths: %s", exc)
+        sources.append(ncbsb_po)
 
-    # Phase N: NCAA Division I softball. Same structure as NCAA baseball
-    # (free ESPN unofficial, no key, win-count thresholds). WCWS bracket
-    # is double-elimination and not modeled in V1 — postseason games
-    # still surface via favorite + rank-pair signal.
+    # Phase N / Phase O Phase 1: NCAA Division I softball. Same structure
+    # as NCAA baseball — regular-season win-count + best-of-3 postseason
+    # (Super Regional, WCWS Finals) coverage. Phase 2 (filed) will model
+    # the Regional double-elim + 8-team WCWS bracket via chronological
+    # inference.
     if settings.get("enable_ncaa_softball", False):
-        sources.append(NcaaSoftballSource())
+        ncsbl_reg = NcaaSoftballRegularSource()
+        sources.append(ncsbl_reg)
+        ncsbl_po = NcaaSoftballPlayoffSource()
+        try:
+            ncsbl_po.set_regular_season_strengths(ncsbl_reg.estimate_strengths())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ncaa_softball] could not seed playoff strengths: %s", exc)
+        sources.append(ncsbl_po)
 
     # Phase O: NCAA D1 men's + women's soccer. One source class
     # parametrized on gender — same structure / endpoints / threshold

--- a/scoring.py
+++ b/scoring.py
@@ -213,6 +213,29 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "CONF":            2,  # Conference Championship
     "SB":              3,  # Super Bowl
     "SB_WINNER":       4,  # Super Bowl Champion
+    # NCAA Baseball College World Series (Phase O Phase 1: super-regional
+    # + finals only — both are cleanly-labeled best-of-3 in ESPN data).
+    # DO NOT treat the BSB_REG / MCWS depths as reachable yet: Phase 1
+    # only emits BSB_SR and MCWS_F ties, so a team caps at MCWS_F depth
+    # (advancing winners → MCWS_W). The intermediate depths exist in
+    # this table so the LEAGUE_CONTEXTS thresholds can label them with
+    # forward-compatible names; Phase 2 (#43) wires the regional
+    # double-elim and 8-team MCWS bracket via chronological inference
+    # so those depths actually fire.
+    "BSB_REG":         0,  # Regional (16 sites × 4 teams, double-elim; Phase 2)
+    "BSB_SR":          1,  # Super Regional (8 sites × 2 teams, best-of-3)
+    "MCWS":            2,  # 8-team double-elim in Omaha (Phase 2)
+    "MCWS_F":          3,  # Championship Final (best-of-3)
+    "MCWS_W":          4,  # MCWS Champion
+    # NCAA Softball Women's College World Series (Phase O Phase 1):
+    # parallel to baseball above. Same Phase 1 limitation — only SB_SR
+    # and WCWS_F are emitted by the source; the intermediate stages are
+    # forward-compat placeholders for Phase 2.
+    "SB_REG":          0,  # Regional (Phase 2)
+    "SB_SR":           1,  # Super Regional (best-of-3)
+    "WCWS":            2,  # 8-team double-elim in OKC (Phase 2)
+    "WCWS_F":          3,  # Championship Finals (best-of-3)
+    "WCWS_W":          4,  # WCWS Champion
 }
 
 
@@ -400,6 +423,26 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (50, "overall_one_seed",  5.0),  # #1 overall seed conversation
         ],
         boundary_summary="30+ wins → tournament bubble · 35+ → at-large lock · 45+ → national seed",
+    ),
+    # Phase O Phase 1: NCAA Baseball postseason. Only the cleanly-labeled
+    # best-of-3 stages (Super Regional, MCWS Finals) are modeled. Regional
+    # double-elim and the 8-team MCWS bracket lack game-level metadata in
+    # ESPN's data and require chronological inference (Phase 2: #43).
+    # Threshold weights match the existing MLB_PO scale: each round-deeper
+    # reach roughly doubles consequence. The "omaha_bound" band fires for
+    # teams that win their Super Regional (depth 2 reached via the
+    # _winner_advance_label hop on MCWS_F), even though Phase 1 doesn't
+    # actually model the 8-team MCWS bracket — the depth label captures
+    # the structural reality that a Super Regional winner IS Omaha-bound.
+    "MCWS_PO": LeagueContext(
+        code="MCWS_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("BSB_SR",  "super_regional",  1.5),
+            ("MCWS",    "omaha_bound",     3.0),
+            ("MCWS_F",  "cws_final",       5.0),
+            ("MCWS_W",  "cws_champion",   10.0),
+        ],
+        boundary_summary="Super Regional → Omaha → CWS Final → Champion",
     ),
     # Phase O: NCAA Division I soccer (Men's and Women's). Standings-points
     # format (3 W / 1 D / 0 L) because draws are common in college soccer
@@ -631,6 +674,20 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (50, "no_1_overall",         5.0),
         ],
         boundary_summary="30+ wins → bubble · 35+ → at-large lock · 40+ → top regional · 45+ → national seed · 50+ → #1 overall",
+    ),
+    # Phase O Phase 1: NCAA Softball WCWS. Parallel to MCWS_PO above.
+    # Only Super Regional + WCWS Finals (best-of-3 stages with ESPN
+    # game numbers) are modeled. Regional double-elim and 8-team WCWS
+    # bracket games are Phase 2.
+    "WCWS_PO": LeagueContext(
+        code="WCWS_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("SB_SR",  "super_regional",  1.5),
+            ("WCWS",   "okc_bound",       3.0),
+            ("WCWS_F", "wcws_final",      5.0),
+            ("WCWS_W", "wcws_champion",  10.0),
+        ],
+        boundary_summary="Super Regional → OKC → WCWS Final → Champion",
     ),
     # Phase P: NFL regular season. 17-game season since 2021;
     # 14 teams make playoffs (7 per conference, including a 7th seed

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -14,8 +14,8 @@ from .ncaaw_basketball import (
     NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
 )
 from .nfl import NflPlayoffSource, NflRegularSource
-from .ncaa_baseball import NcaaBaseballSource
-from .ncaa_softball import NcaaSoftballSource
+from .ncaa_baseball import NcaaBaseballPlayoffSource, NcaaBaseballRegularSource
+from .ncaa_softball import NcaaSoftballPlayoffSource, NcaaSoftballRegularSource
 from .ncaa_soccer import NcaaSoccerSource
 from .ncaaf import NcaafSource
 from .ncaam import NcaamSource
@@ -35,7 +35,9 @@ __all__ = [
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",
-    "NcaaBaseballSource", "NcaaSoftballSource", "NcaaSoccerSource",
+    "NcaaBaseballRegularSource", "NcaaBaseballPlayoffSource",
+    "NcaaSoftballRegularSource", "NcaaSoftballPlayoffSource",
+    "NcaaSoccerSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",
     "NflRegularSource", "NflPlayoffSource",

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -6,12 +6,25 @@ a homelab TV-guide curator. If it ever 404s, `fetch_upcoming` and
 drops out of the guide for that refresh cycle — graceful-degrade is
 already the contract.
 
+Two source classes ship under the `enable_ncaa_baseball` toggle:
+  - `NcaaBaseballRegularSource(PointsBasedSportSource)`: regular-season
+    win-count importance. Tournament-bubble through national-seed bands
+    (see LEAGUE_CONTEXTS["BSB"]).
+  - `NcaaBaseballPlayoffSource(BestOfNSeriesSource)`: postseason. Phase 1
+    ships the cleanly-labeled best-of-3 stages — Super Regional and the
+    MCWS Championship Final. Regional (4-team double-elim per site) and
+    the 8-team MCWS bracket in Omaha are Phase 2 (#43): ESPN headlines
+    on those stages carry no game-number or bracket-position metadata,
+    so chronological inference is needed and that's a separate design.
+
 API endpoints used:
   - /apis/site/v2/sports/baseball/college-baseball/scoreboard
-    - Daily / date-range scoreboard. `dates=YYYYMMDD` or
-      `dates=YYYYMMDD-YYYYMMDD` for ranges. Returns competitions[]
-      with competitors[] (2 teams), score, status. Used by both
-      fetch_upcoming and _fetch_full_season_games.
+    - Daily scoreboard. `dates=YYYYMMDD` returns all games for that day
+      (the `dates=YYYYMMDD-YYYYMMDD` range form silently caps at 25
+      events). Used by both fetch_upcoming and _fetch_full_season_games.
+      Postseason events carry `season.type=3` and `competition.notes[]
+      .headline` like "NCAA Baseball Championship - Auburn Super Regional
+      - Game 2".
   - /apis/site/v2/sports/baseball/college-baseball/rankings
     - D1Baseball.com Top 25 (the canonical D1 poll). Used to populate
       rank_home / rank_away on GameRow records so the rank-pair signal
@@ -22,25 +35,25 @@ Team name canonicalization: ESPN returns `team.location` ("UCLA") and
 typically appears in EPG titles ("UCLA at Texas") rather than the
 mascot ("Bruins at Longhorns"). The school name is the stable join
 key for matching.
-
-CWS bracket is NOT modeled in V1 — the double-elimination structure
-(regional / super-regional / CWS bracket / CWS Finals) is a new tie
-shape neither AggregateLegSource nor BestOfNSeriesSource handles.
-Importance during the postseason falls back to favorite + rank-pair
-signals; structural CWS-progression leverage is filed as follow-up.
 """
 
 from __future__ import annotations
 
 import logging
+import random
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from .base import GameRow
+from .base import GameRow, MatchResult
+from .bracket import BestOfNSeriesSource
 from .points_based import PointsBasedSportSource
-from .._util import parse_iso_utc
+from .._util import (
+    extract_game_number_after_marker,
+    parse_iso_utc,
+    poisson_sample as _poisson,
+)
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_baseball")
 
@@ -87,6 +100,36 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
     if loc:
         return loc
     return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _is_postseason_event(event: Dict[str, Any]) -> bool:
+    """ESPN tags NCAA Baseball / Softball postseason events with
+    `season.type` in the 3-6 range — each stage gets its own type
+    value (verified against live 2026 data):
+      - 2: Regular season (NOT postseason).
+      - 3: Regional round (4-team double-elim per site).
+      - 4: Super Regional round (best-of-3, 8 sites).
+      - 5: 8-team Men's / Women's College World Series bracket in
+           Omaha / OKC (double-elim).
+      - 6: Championship Finals (best-of-3 in Omaha / OKC).
+
+    The regular-season source filters these out; the playoff source
+    filters them in. Headline parsing further narrows to the stages we
+    actually model (Phase 1: SUPER_REGIONAL + FINALS only — the others
+    are headline-metadata-poor and require chronological inference for
+    Phase 2).
+
+    DO NOT use the `notes[].headline` "Championship" substring as a
+    postseason discriminator — D1 conference tournaments in May use
+    that same word and are NOT postseason. season.type is the
+    authoritative tag from ESPN.
+
+    DO NOT narrow to `type == 3` only — that was the original (wrong)
+    assumption from the issue body and would mute Super Regional and
+    Finals coverage entirely (those are types 4 and 6).
+    """
+    season_type = (event.get("season") or {}).get("type")
+    return isinstance(season_type, int) and season_type > 2
 
 
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -150,7 +193,7 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     }
 
 
-class NcaaBaseballSource(PointsBasedSportSource):
+class NcaaBaseballRegularSource(PointsBasedSportSource):
     """NCAA Division I baseball regular-season importance.
 
     Win-count threshold bands tuned against historical NCAA Tournament
@@ -158,6 +201,11 @@ class NcaaBaseballSource(PointsBasedSportSource):
     teams by a blend of RPI/wins/strength-of-schedule; 35+ wins is the
     rough at-large cutoff line, and 45+ wins put a team in national-seed
     contention.
+
+    Postseason games (season.type=3 in ESPN's tags) are filtered out
+    of both fetch_upcoming and _fetch_full_season_games — NcaaBaseball
+    PlayoffSource owns those. Otherwise the regular-season win count
+    would inflate by postseason wins, breaking the threshold bands.
     """
 
     league_context_code = "BSB"
@@ -204,6 +252,11 @@ class NcaaBaseballSource(PointsBasedSportSource):
             if not data:
                 continue
             for event in data.get("events") or []:
+                if _is_postseason_event(event):
+                    # Owned by NcaaBaseballPlayoffSource. Skipping here
+                    # prevents duplicate GameRow records under one
+                    # espn_event_id.
+                    continue
                 rec = _extract_game_record(event)
                 if rec is None:
                     continue
@@ -262,6 +315,12 @@ class NcaaBaseballSource(PointsBasedSportSource):
             data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
             if data:
                 for event in data.get("events") or []:
+                    if _is_postseason_event(event):
+                        # Postseason win/loss counts must NOT flow into
+                        # the regular-season Monte Carlo — would corrupt
+                        # the win-count threshold bands. See class
+                        # docstring.
+                        continue
                     rec = _extract_game_record(event)
                     if rec is None or rec["id"] is None:
                         continue
@@ -299,3 +358,338 @@ class NcaaBaseballSource(PointsBasedSportSource):
             if name and rank > 0:
                 ranks_by_team[name] = rank
         return ranks_by_team
+
+
+# =====================================================================
+# NcaaBaseballPlayoffSource — Phase 1 best-of-3 stages
+# =====================================================================
+
+
+# Headline → (stage, game_index) parser. ESPN's 2025-2026 headlines for
+# the best-of-3 stages have always included a "Game N" suffix. The marker
+# strings below MUST stay synchronized with ESPN's exact headline text;
+# if ESPN ever drops the " - Game " separator (or pluralizes "Final"
+# on baseball the way they do for "Finals" on softball) the parser
+# returns (None, None) and the events fall through to the favorite +
+# rank-pair signals only — same graceful-degrade contract as the
+# rest of the source.
+_SUPER_REGIONAL_MARKER = "Super Regional - Game "
+_FINALS_MARKER = "Championship Final - Game "
+
+
+def _parse_baseball_playoff_headline(headline: str) -> Tuple[Optional[str], Optional[int]]:
+    """Map an ESPN postseason headline to (stage, game_index) for the
+    Phase 1 best-of-3 stages. Returns (None, None) for Regional games
+    (no game number, no bracket position — Phase 2) and the MCWS bracket
+    games ("Men's College World Series - Double Elimination Round" /
+    "Elimination Game", also Phase 2).
+
+    Patterns observed in 2025-2026 ESPN data:
+      - "NCAA Baseball Championship - Auburn Super Regional - Game 1"
+      - "NCAA Baseball Championship - Auburn Super Regional - Game 3 (if necessary)"
+      - "Men's College World Series Championship Final - Game 1"
+    """
+    if not headline:
+        return None, None
+    if _SUPER_REGIONAL_MARKER in headline:
+        return "BSB_SR", extract_game_number_after_marker(headline, _SUPER_REGIONAL_MARKER)
+    if _FINALS_MARKER in headline:
+        return "MCWS_F", extract_game_number_after_marker(headline, _FINALS_MARKER)
+    return None, None
+
+
+class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
+    """NCAA Baseball postseason — Phase 1: Super Regional + MCWS Finals.
+
+    Both stages are best-of-3 (`SERIES_LENGTH = 3`) with ESPN headlines
+    that carry the game number, so the BestOfNSeriesSource infrastructure
+    fits cleanly. The intermediate Regional (4-team double-elim per
+    site) and 8-team MCWS bracket in Omaha lack game-number metadata in
+    ESPN's data and require chronological inference — Phase 2 (#43).
+
+    The forward-compatible depth structure (BSB_REG=0 → BSB_SR=1 → MCWS=2
+    → MCWS_F=3 → MCWS_W=4) means Phase 2 can extend KO_STAGES without
+    touching threshold labels in LEAGUE_CONTEXTS["MCWS_PO"]. The
+    `omaha_bound` band (depth 2) fires for Super Regional WINNERS in
+    Phase 1 because `_winner_advance_label("BSB_SR")` returns None →
+    default `stage_depth + 1` rule → winner gets depth 2 (= MCWS depth).
+
+    Strength sharing: pre-postseason, the plugin pulls regular-season
+    strength estimates from NcaaBaseballRegularSource and seeds them
+    via `set_regular_season_strengths`. Without this hook, postseason
+    sampling falls back to the 6-runs-per-team default — workable but
+    less informative than per-team Poisson rates from the 55-game
+    regular season.
+    """
+
+    KO_STAGES = ("BSB_SR", "MCWS_F")
+    SERIES_LENGTH = 3
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        # BestOfNSeriesSource's parent (BracketSportSource) inherits from
+        # SportSource which has no __init__ args. Match the MlbPlayoffSource
+        # pattern: own all caches in __init__ rather than relying on
+        # class-level None defaults (which leak across instances during
+        # tests).
+        now = datetime.now(timezone.utc)
+        self.season_year = (
+            season_year
+            if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAABSB"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Baseball Postseason"
+
+    def _league_context_code(self) -> str:
+        return "MCWS_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        # MCWS Final winner → MCWS_W (depth 4). Super Regional winner
+        # advances via the default `stage_depth + 1` rule → depth 2,
+        # which is the placeholder MCWS depth (8-team bracket; Phase 2).
+        if stage == "MCWS_F":
+            return "MCWS_W"
+        return None
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Pull next-N-day postseason games. Same per-day scoreboard
+        sweep as the regular-season source but with `_is_postseason_event`
+        flipped (filter IN postseason). Headlines are then parsed via
+        `_parse_baseball_playoff_headline`; only stages Phase 1 models
+        (Super Regional + MCWS Finals) survive — Regional and 8-team
+        MCWS bracket games are silently dropped here AND from the
+        regular-season source's sibling fetch. They are entirely absent
+        from the curated guide until Phase 2 ships.
+
+        DO NOT lift the headline filter without also implementing
+        Phase 2 chronological inference: doing so would emit Regional
+        games with `fd_competition_code="MCWS_PO"` and the importance
+        simulator would see them with no upstream feeders, producing
+        an under-informed leverage signal that's worse than no signal.
+        """
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                if not _is_postseason_event(event):
+                    continue
+                row = self._event_to_game_row(event)
+                if row is None:
+                    continue
+                eid = row.extra.get("espn_event_id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                out.append(row)
+        return out
+
+    def _event_to_game_row(self, event: Dict[str, Any]) -> Optional[GameRow]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+        stage, game_num = _parse_baseball_playoff_headline(headline)
+        if stage is None or game_num is None:
+            return None
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        # TBD-vs-TBD games appear in ESPN's data before participants are
+        # determined (e.g., Finals before the MCWS bracket resolves).
+        # Skip them — the bracket source can't track a placeholder team
+        # and the EPG client doesn't surface a "TBD" matchup usefully.
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+        start = parse_iso_utc(event.get("date"))
+        if start is None:
+            return None
+        return GameRow(
+            sport_prefix=self.sport_prefix,
+            sport_label=self.sport_label,
+            home=home_team,
+            away=away_team,
+            rank_home=None,
+            rank_away=None,
+            start_time=start,
+            extra={
+                "espn_event_id": event.get("id"),
+                "fd_competition_code": self._league_context_code(),
+                "stage": stage,
+                "matchday": game_num,
+                "headline": headline,
+            },
+        )
+
+    # ---------- strengths (reused from regular season) ----------
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]]
+    ) -> None:
+        """Hook for plugin.py to seed per-team scoring/conceding rates
+        from the regular-season source. Same shape as MlbPlayoffSource."""
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_RUNS_FOR,
+            "pa_per_game": _DEFAULT_RUNS_AGAINST,
+        }
+
+    # ---------- sample_result (per-game Poisson with extra-innings) ----------
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        del state  # per-game classification only
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_runs = _poisson(lam_home, rng)
+        away_runs = _poisson(lam_away, rng)
+        # NCAA postseason has no draws — coin-flip the +1 to break the tie.
+        if home_runs == away_runs:
+            if rng.random() < 0.5:
+                home_runs += 1
+            else:
+                away_runs += 1
+        return MatchResult(home_goals=home_runs, away_goals=away_runs)
+
+    # ---------- bracket fetch ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Sweep the postseason date window day-by-day, filter to
+        season.type=3 events with a Phase 1 stage headline, and emit
+        the bracket per-game record shape.
+
+        Window: May 25 (selection day; Regional play starts Friday of
+        Memorial Day weekend) through July 1 (worst-case Finals slip).
+        """
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        out: List[Dict[str, Any]] = []
+        season_start = datetime(self.season_year, 5, 25, tzinfo=timezone.utc).date()
+        season_end = datetime(self.season_year, 7, 1, tzinfo=timezone.utc).date()
+        day = season_start
+        while day <= season_end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    if not _is_postseason_event(event):
+                        continue
+                    rec = self._event_to_bracket_record(event)
+                    if rec is not None:
+                        out.append(rec)
+            day += timedelta(days=1)
+
+        self._bracket_games_cache = out
+        return out
+
+    def _event_to_bracket_record(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Convert one ESPN postseason event into the bracket per-game
+        record shape (`game_id`, `stage`, `matchday`, `home`, `away`,
+        `home_goals`, `away_goals`, `status`, `start_time`, `extra`).
+        Returns None for stages we don't model in Phase 1.
+        """
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+        stage, game_num = _parse_baseball_playoff_headline(headline)
+        if stage is None or game_num is None:
+            return None
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        if completed or state == "post":
+            status = "FINISHED"
+        else:
+            status = "SCHEDULED"
+        try:
+            hr = int(home.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            hr = None
+        try:
+            ar = int(away.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            ar = None
+        if status == "FINISHED" and (hr is None or ar is None):
+            status = "SCHEDULED"
+            hr = None
+            ar = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            "matchday": game_num,
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hr,
+            "away_goals": ar,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"headline": headline},
+        }

--- a/sources/ncaa_softball.py
+++ b/sources/ncaa_softball.py
@@ -1,16 +1,25 @@
 """NCAA Softball source — ESPN's unofficial site.api.espn.com.
 No API key required.
 
-V1 (Phase N) covers the regular season only. The Women's College
-World Series bracket is double-elimination (4 super-regional brackets
-of 8 teams each, then the 8-team WCWS bracket with double-elim
-through the semis, then a best-of-3 Championship Series). Neither
-the BestOfNSeriesSource nor AggregateLegSource tie shapes cleanly
-models double-elim — filed as a Phase N follow-up.
+Two source classes ship under the `enable_ncaa_softball` toggle:
+  - `NcaaSoftballRegularSource(PointsBasedSportSource)`: regular-season
+    win-count importance (LEAGUE_CONTEXTS["SBL"]).
+  - `NcaaSoftballPlayoffSource(BestOfNSeriesSource)`: postseason. Phase 1
+    ships the cleanly-labeled best-of-3 stages — Super Regional and
+    WCWS Championship Finals. Regional (4-team double-elim per site)
+    and the 8-team WCWS bracket in OKC are Phase 2 (#43): ESPN
+    headlines on those stages are "Women's College World Series -
+    Double Elimination Round" with no game-number or bracket-position
+    metadata, so chronological inference is needed.
 
 API path: ESPN groups college softball under the `baseball` sport
 namespace (NOT `softball`). The scoreboard endpoint:
   /apis/site/v2/sports/baseball/college-softball/scoreboard?dates=YYYYMMDD
+
+Postseason events carry `season.type=3` and headlines like
+"NCAA Softball Championship - Lincoln Super Regional - Game 2" or
+"Women's College World Series Championship Finals - Game 1". Note:
+softball uses "Finals" (plural) where baseball uses "Final" (singular).
 
 Rankings poll: ESPN exposes the ESPN.com/USA Softball Collegiate
 Top 25 (the canonical D1 softball poll). Used for the rank-pair
@@ -29,14 +38,20 @@ because EPG entries use the school name.
 from __future__ import annotations
 
 import logging
+import random
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from .base import GameRow
+from .base import GameRow, MatchResult
+from .bracket import BestOfNSeriesSource
 from .points_based import PointsBasedSportSource
-from .._util import parse_iso_utc
+from .._util import (
+    extract_game_number_after_marker,
+    parse_iso_utc,
+    poisson_sample as _poisson,
+)
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_softball")
 
@@ -76,6 +91,15 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
     if loc:
         return loc
     return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _is_postseason_event(event: Dict[str, Any]) -> bool:
+    """ESPN postseason discriminator. See
+    ncaa_baseball._is_postseason_event for the full stage → type
+    mapping (3=Regional, 4=Super Regional, 5=WCWS bracket, 6=Finals).
+    """
+    season_type = (event.get("season") or {}).get("type")
+    return isinstance(season_type, int) and season_type > 2
 
 
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -134,13 +158,18 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     }
 
 
-class NcaaSoftballSource(PointsBasedSportSource):
+class NcaaSoftballRegularSource(PointsBasedSportSource):
     """D1 NCAA Softball regular-season importance.
 
     Win-count threshold bands tuned against historical NCAA Tournament
     selection criteria (64-team field — same field size as baseball).
     The selection committee weights RPI + strength-of-schedule + wins,
     but win-count alone is a strong proxy for tournament status.
+
+    Postseason games (season.type=3) are filtered out of both
+    fetch_upcoming and _fetch_full_season_games — NcaaSoftballPlayoff
+    Source owns those. Otherwise the regular-season win count would
+    inflate by postseason wins, breaking the threshold bands.
     """
 
     league_context_code = "SBL"
@@ -177,6 +206,9 @@ class NcaaSoftballSource(PointsBasedSportSource):
             if not data:
                 continue
             for event in data.get("events") or []:
+                if _is_postseason_event(event):
+                    # Owned by NcaaSoftballPlayoffSource.
+                    continue
                 rec = _extract_game_record(event)
                 if rec is None:
                     continue
@@ -250,6 +282,11 @@ class NcaaSoftballSource(PointsBasedSportSource):
             data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
             if data:
                 for event in data.get("events") or []:
+                    if _is_postseason_event(event):
+                        # Postseason win/loss counts must NOT flow into
+                        # the regular-season Monte Carlo. See class
+                        # docstring.
+                        continue
                     rec = _extract_game_record(event)
                     if rec is None or rec["id"] is None:
                         continue
@@ -258,3 +295,293 @@ class NcaaSoftballSource(PointsBasedSportSource):
                     seen[rec["id"]] = rec
             day += timedelta(days=1)
         return list(seen.values())
+
+
+# =====================================================================
+# NcaaSoftballPlayoffSource — Phase 1 best-of-3 stages
+# =====================================================================
+
+
+# ESPN's softball headlines use "Finals" (plural) where baseball uses
+# "Final" (singular). Both sports share the "Super Regional - Game N"
+# convention.
+_SUPER_REGIONAL_MARKER = "Super Regional - Game "
+_FINALS_MARKER = "Championship Finals - Game "
+
+
+def _parse_softball_playoff_headline(headline: str) -> Tuple[Optional[str], Optional[int]]:
+    """Map an ESPN softball postseason headline to (stage, game_index)
+    for the Phase 1 best-of-3 stages. Returns (None, None) for stages
+    we don't model (Regional, 8-team WCWS bracket — both lack game
+    metadata in ESPN's data and are Phase 2).
+
+    Patterns observed in 2025-2026 ESPN data:
+      - "NCAA Softball Championship - Lincoln Super Regional - Game 1"
+      - "NCAA Softball Championship - Lincoln Super Regional - Game 3 (if necessary)"
+      - "Women's College World Series Championship Finals - Game 1"
+    """
+    if not headline:
+        return None, None
+    if _SUPER_REGIONAL_MARKER in headline:
+        return "SB_SR", extract_game_number_after_marker(headline, _SUPER_REGIONAL_MARKER)
+    if _FINALS_MARKER in headline:
+        return "WCWS_F", extract_game_number_after_marker(headline, _FINALS_MARKER)
+    return None, None
+
+
+class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
+    """NCAA Softball postseason — Phase 1: Super Regional + WCWS Finals.
+
+    Both stages are best-of-3 (`SERIES_LENGTH = 3`). Regional double-elim
+    and the 8-team WCWS bracket in OKC carry no headline game-number
+    metadata in ESPN's data and require chronological inference —
+    Phase 2 (#43).
+
+    The depth structure (SB_REG=0 → SB_SR=1 → WCWS=2 → WCWS_F=3 →
+    WCWS_W=4) is forward-compatible with Phase 2. The `okc_bound`
+    band (depth 2) fires for Super Regional WINNERS in Phase 1 via
+    the default `stage_depth + 1` advance rule.
+
+    Strength sharing: pre-postseason, the plugin pulls regular-season
+    strengths from NcaaSoftballRegularSource and seeds them via
+    `set_regular_season_strengths`. Fallback default is 5.0 runs per
+    side (softball league average).
+    """
+
+    KO_STAGES = ("SB_SR", "WCWS_F")
+    SERIES_LENGTH = 3
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        now = datetime.now(timezone.utc)
+        self.season_year = (
+            season_year
+            if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAASBL"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Softball Postseason"
+
+    def _league_context_code(self) -> str:
+        return "WCWS_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        if stage == "WCWS_F":
+            return "WCWS_W"
+        return None
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                if not _is_postseason_event(event):
+                    continue
+                row = self._event_to_game_row(event)
+                if row is None:
+                    continue
+                eid = row.extra.get("ncaasbl_game_id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                out.append(row)
+        return out
+
+    def _event_to_game_row(self, event: Dict[str, Any]) -> Optional[GameRow]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+        stage, game_num = _parse_softball_playoff_headline(headline)
+        if stage is None or game_num is None:
+            return None
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+        start = parse_iso_utc(event.get("date"))
+        if start is None:
+            return None
+        return GameRow(
+            sport_prefix=self.sport_prefix,
+            sport_label=self.sport_label,
+            home=home_team,
+            away=away_team,
+            rank_home=None,
+            rank_away=None,
+            start_time=start,
+            extra={
+                "ncaasbl_game_id": event.get("id"),
+                "fd_competition_code": self._league_context_code(),
+                "stage": stage,
+                "matchday": game_num,
+                "headline": headline,
+            },
+        )
+
+    # ---------- strengths ----------
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]]
+    ) -> None:
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_RUNS_FOR,
+            "pa_per_game": _DEFAULT_RUNS_AGAINST,
+        }
+
+    # ---------- sample_result ----------
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        del state
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_runs = _poisson(lam_home, rng)
+        away_runs = _poisson(lam_away, rng)
+        if home_runs == away_runs:
+            if rng.random() < 0.5:
+                home_runs += 1
+            else:
+                away_runs += 1
+        return MatchResult(home_goals=home_runs, away_goals=away_runs)
+
+    # ---------- bracket fetch ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Sweep the WCWS date window day-by-day, filter to
+        season.type=3 events with a Phase 1 stage headline, emit the
+        bracket per-game record shape.
+
+        Window: May 15 (Regional play opens the postseason; we start a
+        few days early to catch any timezone wraparound) through
+        June 15 (Championship Finals worst-case Game 3 slip).
+        """
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        out: List[Dict[str, Any]] = []
+        season_start = datetime(self.season_year, 5, 15, tzinfo=timezone.utc).date()
+        season_end = datetime(self.season_year, 6, 15, tzinfo=timezone.utc).date()
+        day = season_start
+        while day <= season_end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    if not _is_postseason_event(event):
+                        continue
+                    rec = self._event_to_bracket_record(event)
+                    if rec is not None:
+                        out.append(rec)
+            day += timedelta(days=1)
+
+        self._bracket_games_cache = out
+        return out
+
+    def _event_to_bracket_record(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+        stage, game_num = _parse_softball_playoff_headline(headline)
+        if stage is None or game_num is None:
+            return None
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        if completed or state == "post":
+            status = "FINISHED"
+        else:
+            status = "SCHEDULED"
+        try:
+            hr = int(home.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            hr = None
+        try:
+            ar = int(away.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            ar = None
+        if status == "FINISHED" and (hr is None or ar is None):
+            status = "SCHEDULED"
+            hr = None
+            ar = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            "matchday": game_num,
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hr,
+            "away_goals": ar,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"headline": headline},
+        }

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2251,7 +2251,7 @@ class TestPointsBasedSourceCountField:
 # Phase M: NCAA Baseball
 # =====================================================================
 
-class TestNcaaBaseballSource:
+class TestNcaaBaseballRegularSource:
     """Phase M: D1 baseball via ESPN unofficial API + D1Baseball.com poll.
     Tests cover the canonical-game-record extraction (the tricky part is
     homeAway / completed / score parsing), team-name canonicalization
@@ -2260,9 +2260,9 @@ class TestNcaaBaseballSource:
 
     @staticmethod
     def _make_source():
-        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballSource
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballRegularSource
         # Pin season_year so test isn't dependent on calendar.
-        return NcaaBaseballSource(season_year=2026)
+        return NcaaBaseballRegularSource(season_year=2026)
 
     @staticmethod
     def _competitor(team_loc, team_name, score, home_away="home", winner=None):
@@ -2281,8 +2281,8 @@ class TestNcaaBaseballSource:
             "competitions": [{
                 "status": {"type": {"completed": completed, "state": state}},
                 "competitors": [
-                    TestNcaaBaseballSource._competitor("UCLA", "Bruins", hp, "home", hp > ap if hp is not None else None),
-                    TestNcaaBaseballSource._competitor("Texas", "Longhorns", ap, "away", ap > hp if ap is not None else None),
+                    TestNcaaBaseballRegularSource._competitor("UCLA", "Bruins", hp, "home", hp > ap if hp is not None else None),
+                    TestNcaaBaseballRegularSource._competitor("Texas", "Longhorns", ap, "away", ap > hp if ap is not None else None),
                 ],
             }],
         }
@@ -2301,8 +2301,8 @@ class TestNcaaBaseballSource:
     def test_count_field_is_wins(self):
         # Inherits the PointsBasedSportSource default — D1 baseball has
         # no OT/SO bonus point complication like NHL.
-        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballSource
-        assert NcaaBaseballSource._count_field == "wins"
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballRegularSource
+        assert NcaaBaseballRegularSource._count_field == "wins"
 
     # ---------- _extract_game_record ----------
 
@@ -2402,6 +2402,210 @@ class TestNcaaBaseballSource:
         cuts = [cut for cut, _label, _w in LEAGUE_CONTEXTS["BSB"].thresholds]
         for i in range(len(cuts) - 1):
             assert cuts[i] < cuts[i + 1], f"BSB band cutoffs must be monotonic: {cuts}"
+
+
+# =====================================================================
+# Phase O Phase 1: NcaaBaseballPlayoffSource
+# =====================================================================
+
+class TestNcaaBaseballPlayoffSource:
+    """NcaaBaseballPlayoffSource: BestOfNSeriesSource subclass that ships
+    the cleanly-labeled best-of-3 stages (Super Regional + MCWS Finals).
+    Regional double-elim and 8-team MCWS bracket are Phase 2 — those
+    headlines lack game-number metadata so chronological inference is
+    needed and that's a separate design.
+    """
+
+    @staticmethod
+    def _make_source(bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            NcaaBaseballPlayoffSource,
+        )
+        src = NcaaBaseballPlayoffSource(season_year=2026)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make_source()
+        assert src.sport_prefix == "NCAABSB"
+        assert "Postseason" in src.sport_label
+        assert src._league_context_code() == "MCWS_PO"
+
+    def test_supports_importance(self):
+        assert self._make_source().supports_importance is True
+
+    def test_ko_stages(self):
+        src = self._make_source()
+        # Phase 1: only the cleanly-labeled stages are emitted.
+        # Phase 2 will extend KO_STAGES with REGIONAL + MCWS bracket.
+        assert src.KO_STAGES == ("BSB_SR", "MCWS_F")
+
+    def test_series_length_is_three(self):
+        # Both Super Regional and MCWS Finals are best-of-3.
+        src = self._make_source()
+        assert src.SERIES_LENGTH == 3
+        assert src._series_length_for_stage("BSB_SR") == 3
+        assert src._series_length_for_stage("MCWS_F") == 3
+
+    def test_winner_advance_label(self):
+        src = self._make_source()
+        # MCWS Final winner → MCWS_W synthetic depth.
+        assert src._winner_advance_label("MCWS_F") == "MCWS_W"
+        # Super Regional advances via default stage_depth + 1 rule
+        # (which lands at MCWS depth — the unmodeled 8-team bracket).
+        assert src._winner_advance_label("BSB_SR") is None
+
+    def test_outcome_labels_uses_mcws_po_thresholds(self):
+        src = self._make_source()
+        labels = src.outcome_labels
+        assert "super_regional" in labels
+        assert "omaha_bound" in labels
+        assert "cws_final" in labels
+        assert "cws_champion" in labels
+
+    def test_set_regular_season_strengths_passes_through(self):
+        src = self._make_source()
+        assert src.estimate_strengths() == {}
+        src.set_regular_season_strengths(
+            {"LSU": {"pf_per_game": 8.4, "pa_per_game": 4.1}}
+        )
+        s = src.estimate_strengths()
+        assert s["LSU"]["pf_per_game"] == 8.4
+
+    def test_super_regional_resolves_in_two_wins(self):
+        """Super Regional best-of-3: clinches at 2 wins. Build a 2-0
+        sweep; verify winner reaches MCWS depth, loser caps at BSB_SR."""
+        games = [
+            {"game_id": "sr1", "stage": "BSB_SR", "matchday": 1,
+             "home": "LSU", "away": "Tennessee",
+             "home_goals": 7, "away_goals": 3,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "sr2", "stage": "BSB_SR", "matchday": 2,
+             "home": "LSU", "away": "Tennessee",
+             "home_goals": 5, "away_goals": 2,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make_source(games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        # LSU wins → advances via default stage_depth + 1 = MCWS depth.
+        assert state["_round_reached"]["LSU"] == KNOCKOUT_ROUND_DEPTH["MCWS"]
+        # Tennessee loses → caps at BSB_SR depth.
+        assert state["_round_reached"]["Tennessee"] == KNOCKOUT_ROUND_DEPTH["BSB_SR"]
+
+    def test_mcws_finals_winner_reaches_synthetic_depth(self):
+        """Best-of-3 Finals, winner reaches MCWS_W depth."""
+        games = [
+            {"game_id": "f1", "stage": "MCWS_F", "matchday": 1,
+             "home": "LSU", "away": "Florida",
+             "home_goals": 4, "away_goals": 2,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f2", "stage": "MCWS_F", "matchday": 2,
+             "home": "LSU", "away": "Florida",
+             "home_goals": 1, "away_goals": 6,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f3", "stage": "MCWS_F", "matchday": 3,
+             "home": "Florida", "away": "LSU",
+             "home_goals": 2, "away_goals": 9,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make_source(games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["LSU"] == KNOCKOUT_ROUND_DEPTH["MCWS_W"]
+        assert state["_round_reached"]["Florida"] == KNOCKOUT_ROUND_DEPTH["MCWS_F"]
+        outcomes = src.terminal_outcomes(state)
+        # Champion gets every band.
+        assert set(outcomes["LSU"]) == {
+            "super_regional", "omaha_bound", "cws_final", "cws_champion",
+        }
+        # Finalist loser missed cws_champion only.
+        assert set(outcomes["Florida"]) == {
+            "super_regional", "omaha_bound", "cws_final",
+        }
+
+
+class TestBaseballPlayoffHeadlineParser:
+    """The Phase 1 headline parser maps ESPN's exact headline text to
+    (stage, game_index). Regression-pin against the 2025-2026 observed
+    headlines so an ESPN copy change is caught at unit-test time, not
+    at refresh time on Selection Monday."""
+
+    @staticmethod
+    def _parse(headline):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_playoff_headline,
+        )
+        return _parse_baseball_playoff_headline(headline)
+
+    def test_super_regional_game_1(self):
+        assert self._parse(
+            "NCAA Baseball Championship - Auburn Super Regional - Game 1"
+        ) == ("BSB_SR", 1)
+
+    def test_super_regional_game_3_if_necessary(self):
+        # The "(if necessary)" trailer must be stripped — ESPN attaches
+        # it to Game 3 placeholders that haven't been confirmed.
+        assert self._parse(
+            "NCAA Baseball Championship - Auburn Super Regional - Game 3 (if necessary)"
+        ) == ("BSB_SR", 3)
+
+    def test_mcws_final_game_1(self):
+        # Note baseball uses "Final" (singular), softball uses "Finals" (plural).
+        assert self._parse(
+            "Men's College World Series Championship Final - Game 1"
+        ) == ("MCWS_F", 1)
+
+    def test_regional_returns_none(self):
+        # Regionals carry no game number → Phase 2 territory.
+        # Parser must return (None, None) so caller skips the event.
+        assert self._parse(
+            "NCAA Baseball Championship - Auburn Regional"
+        ) == (None, None)
+
+    def test_mcws_bracket_double_elim_returns_none(self):
+        # 8-team bracket games carry the generic "Double Elimination Round"
+        # headline with no game number → Phase 2 territory.
+        assert self._parse(
+            "Men's College World Series - Double Elimination Round"
+        ) == (None, None)
+
+    def test_mcws_elimination_game_returns_none(self):
+        # MCWS losers-bracket games ESPN tags as "Elimination Game" —
+        # still Phase 2 (no game number).
+        assert self._parse(
+            "Men's College World Series - Elimination Game"
+        ) == (None, None)
+
+    def test_empty_headline(self):
+        assert self._parse("") == (None, None)
+
+
+class TestNcaaBaseballPostseasonFilter:
+    """The regular-season source MUST filter out season.type=3 events
+    so postseason game wins don't inflate the regular-season win count
+    that drives the BSB threshold bands."""
+
+    def test_is_postseason_event(self):
+        """ESPN spreads NCAA Baseball/Softball postseason across multiple
+        season.type values (3=Regional, 4=Super Regional, 5=MCWS/WCWS
+        bracket, 6=Finals). All four must read as postseason. Regular
+        season is 2, preseason 1, both must read as NOT postseason."""
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _is_postseason_event,
+        )
+        # Postseason: all stage values.
+        assert _is_postseason_event({"season": {"type": 3}}) is True
+        assert _is_postseason_event({"season": {"type": 4}}) is True
+        assert _is_postseason_event({"season": {"type": 5}}) is True
+        assert _is_postseason_event({"season": {"type": 6}}) is True
+        # Non-postseason.
+        assert _is_postseason_event({"season": {"type": 2}}) is False
+        assert _is_postseason_event({"season": {"type": 1}}) is False
+        # Defensive: missing / malformed.
+        assert _is_postseason_event({}) is False
+        assert _is_postseason_event({"season": {}}) is False
+        assert _is_postseason_event({"season": {"type": None}}) is False
 
 
 # =====================================================================
@@ -3980,14 +4184,14 @@ class TestNcaawBasketballPlayoffSource:
 # Phase N: NCAA Softball
 # =====================================================================
 
-class TestNcaaSoftballSource:
+class TestNcaaSoftballRegularSource:
     """V1: regular-season importance only. WCWS bracket (double-elim)
     is filed as a follow-up — same scope deferral as NCAA Baseball's CWS."""
 
     @staticmethod
     def _make():
-        from dispatcharr_ranked_matchups.sources.ncaa_softball import NcaaSoftballSource
-        return NcaaSoftballSource(season_year=2025)
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import NcaaSoftballRegularSource
+        return NcaaSoftballRegularSource(season_year=2025)
 
     def test_identity(self):
         src = self._make()
@@ -4053,6 +4257,149 @@ class TestNcaaSoftballSource:
             "tournament_bubble", "at_large_lock", "top_regional_seed",
             "national_seed", "no_1_overall",
         }
+
+
+# =====================================================================
+# Phase O Phase 1: NcaaSoftballPlayoffSource
+# =====================================================================
+
+class TestNcaaSoftballPlayoffSource:
+    """NcaaSoftballPlayoffSource: best-of-3 Super Regional + WCWS Finals.
+    Sibling of NcaaBaseballPlayoffSource with one twist — softball
+    headlines use "Finals" (plural) where baseball uses "Final"
+    (singular)."""
+
+    @staticmethod
+    def _make_source(bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            NcaaSoftballPlayoffSource,
+        )
+        src = NcaaSoftballPlayoffSource(season_year=2026)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make_source()
+        assert src.sport_prefix == "NCAASBL"
+        assert "Postseason" in src.sport_label
+        assert src._league_context_code() == "WCWS_PO"
+
+    def test_ko_stages(self):
+        src = self._make_source()
+        assert src.KO_STAGES == ("SB_SR", "WCWS_F")
+
+    def test_series_length_is_three(self):
+        src = self._make_source()
+        assert src._series_length_for_stage("SB_SR") == 3
+        assert src._series_length_for_stage("WCWS_F") == 3
+
+    def test_winner_advance_label(self):
+        src = self._make_source()
+        assert src._winner_advance_label("WCWS_F") == "WCWS_W"
+        assert src._winner_advance_label("SB_SR") is None
+
+    def test_outcome_labels_uses_wcws_po_thresholds(self):
+        src = self._make_source()
+        labels = src.outcome_labels
+        assert "super_regional" in labels
+        assert "okc_bound" in labels
+        assert "wcws_final" in labels
+        assert "wcws_champion" in labels
+
+    def test_set_regular_season_strengths_passes_through(self):
+        src = self._make_source()
+        assert src.estimate_strengths() == {}
+        src.set_regular_season_strengths(
+            {"Oklahoma": {"pf_per_game": 7.2, "pa_per_game": 2.8}}
+        )
+        s = src.estimate_strengths()
+        assert s["Oklahoma"]["pf_per_game"] == 7.2
+
+    def test_wcws_finals_winner_reaches_synthetic_depth(self):
+        games = [
+            {"game_id": "f1", "stage": "WCWS_F", "matchday": 1,
+             "home": "Texas Tech", "away": "Texas",
+             "home_goals": 3, "away_goals": 2,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "f2", "stage": "WCWS_F", "matchday": 2,
+             "home": "Texas Tech", "away": "Texas",
+             "home_goals": 5, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make_source(games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["Texas Tech"] == KNOCKOUT_ROUND_DEPTH["WCWS_W"]
+        assert state["_round_reached"]["Texas"] == KNOCKOUT_ROUND_DEPTH["WCWS_F"]
+
+
+class TestSoftballPlayoffHeadlineParser:
+    """The softball headline parser is a near-mirror of the baseball one
+    except for the "Finals" (plural) vs "Final" (singular) Championship
+    label. Regression-pin against the 2025-2026 observed headlines."""
+
+    @staticmethod
+    def _parse(headline):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_playoff_headline,
+        )
+        return _parse_softball_playoff_headline(headline)
+
+    def test_super_regional_game_1(self):
+        assert self._parse(
+            "NCAA Softball Championship - Lincoln Super Regional - Game 1"
+        ) == ("SB_SR", 1)
+
+    def test_super_regional_game_3_if_necessary(self):
+        assert self._parse(
+            "NCAA Softball Championship - Lincoln Super Regional - Game 3 (if necessary)"
+        ) == ("SB_SR", 3)
+
+    def test_wcws_finals_game_1(self):
+        # Plural "Finals" for softball — distinct from baseball's "Final".
+        assert self._parse(
+            "Women's College World Series Championship Finals - Game 1"
+        ) == ("WCWS_F", 1)
+
+    def test_wcws_finals_singular_form_returns_none(self):
+        # Guard against accidentally accepting baseball's pattern.
+        assert self._parse(
+            "Women's College World Series Championship Final - Game 1"
+        ) == (None, None)
+
+    def test_regional_returns_none(self):
+        assert self._parse(
+            "NCAA Softball Championship - Tuscaloosa Regional"
+        ) == (None, None)
+
+    def test_wcws_bracket_double_elim_returns_none(self):
+        assert self._parse(
+            "Women's College World Series - Double Elimination Round"
+        ) == (None, None)
+
+    def test_wcws_elimination_game_returns_none(self):
+        # WCWS losers-bracket games — observed in live 2026 data
+        # (May 30+). Must skip; no game number → Phase 2.
+        assert self._parse(
+            "Women's College World Series - Elimination Game"
+        ) == (None, None)
+
+    def test_wcws_elimination_game_if_necessary_returns_none(self):
+        # ESPN appends " If Necessary" to placeholder losers-bracket
+        # games in the 8-team WCWS bracket. Observed live 2026-06-01.
+        assert self._parse(
+            "Women's College World Series - Elimination Game If Necessary"
+        ) == (None, None)
+
+    def test_regional_elimination_game_returns_none(self):
+        # Regional losers-bracket games carry "Elimination Game" too —
+        # also Phase 2 territory.
+        assert self._parse(
+            "NCAA Softball Championship - Athens Regional - Elimination Game"
+        ) == (None, None)
+
+    def test_empty_headline(self):
+        assert self._parse("") == (None, None)
 
 
 # =====================================================================

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,12 @@
-"""Tests for _util.parse_iso_utc and stable_hash_int."""
+"""Tests for _util.parse_iso_utc, stable_hash_int, extract_game_number_after_marker."""
 
 from datetime import datetime, timezone
 
-from dispatcharr_ranked_matchups._util import parse_iso_utc, stable_hash_int
+from dispatcharr_ranked_matchups._util import (
+    extract_game_number_after_marker,
+    parse_iso_utc,
+    stable_hash_int,
+)
 
 
 class TestParseIsoUtc:
@@ -48,3 +52,51 @@ class TestStableHashInt:
         # caught by this assertion.
         # md5("test") = 098f6bcd4621d373cade4e832627b4f6
         assert stable_hash_int("test") == int("098f6bcd4621d373", 16)
+
+
+class TestExtractGameNumberAfterMarker:
+    """Shared helper extracted from NCAA Baseball / Softball playoff
+    sources. Pulls the integer game number that follows a marker string
+    in an ESPN headline, stripping the "(if necessary)" trailer."""
+
+    def test_simple_game_number(self):
+        assert extract_game_number_after_marker(
+            "Super Regional - Game 1", "Super Regional - Game "
+        ) == 1
+
+    def test_two_digit_game_number(self):
+        # Not currently observed in NCAA postseason (games are best-of-3
+        # or best-of-7 max), but the parser must handle multi-digit
+        # numbers if ESPN ever emits them.
+        assert extract_game_number_after_marker(
+            "Super Regional - Game 10", "Super Regional - Game "
+        ) == 10
+
+    def test_strips_if_necessary_trailer(self):
+        assert extract_game_number_after_marker(
+            "Super Regional - Game 3 (if necessary)", "Super Regional - Game "
+        ) == 3
+
+    def test_empty_headline(self):
+        assert extract_game_number_after_marker("", "Super Regional - Game ") is None
+
+    def test_marker_not_present(self):
+        # If the marker substring isn't in the headline, return None
+        # — caller is expected to try a different marker or skip.
+        assert extract_game_number_after_marker(
+            "Some other headline", "Super Regional - Game "
+        ) is None
+
+    def test_non_digit_after_marker(self):
+        # If the marker is followed by something non-numeric, return
+        # None rather than guess. ESPN has not been observed to do this,
+        # but graceful-degrade is the contract.
+        assert extract_game_number_after_marker(
+            "Super Regional - Game X", "Super Regional - Game "
+        ) is None
+
+    def test_marker_at_end_of_string(self):
+        # No digits to consume → None.
+        assert extract_game_number_after_marker(
+            "Super Regional - Game ", "Super Regional - Game "
+        ) is None


### PR DESCRIPTION
## Summary

Adds `NcaaBaseballPlayoffSource` and `NcaaSoftballPlayoffSource` (`BestOfNSeriesSource` subclasses, both `SERIES_LENGTH = 3`) covering the cleanly-labeled best-of-3 postseason stages — Super Regional and the Championship Final/Finals. Renames the existing regular-season classes to `*RegularSource` for naming consistency with NBA / NHL / MLB / WNBA siblings; both regular-season sources now filter out postseason events so postseason wins don't inflate the threshold bands that drive `LEAGUE_CONTEXTS["BSB"]` and `["SBL"]`.

Diff: +1286/-51 across 8 files. Net production code ~860 LOC; tests ~370 LOC.

## What's covered

- Super Regional importance (best-of-3, 8 sites each sport).
- MCWS / WCWS Championship Finals importance (best-of-3).
- Strength sharing: per-team Poisson rates from the 55-game regular season seed the postseason simulator (same pattern as `MlbPlayoffSource`).
- Threshold bands: `super_regional` / `omaha_bound` (or `okc_bound`) / `cws_final` (or `wcws_final`) / `cws_champion` (or `wcws_champion`).

## What's NOT covered (Phase 2: #43)

- Regional round (4-team double-elim per site, 16 sites).
- 8-team MCWS / WCWS bracket in Omaha / OKC.

These two stages carry no game-number or bracket-position metadata in ESPN's headlines. State reconstruction requires chronological inference plus per-team loss tracking — a new `DoubleEliminationSource(BracketSportSource)` tie shape that supports N-team-per-tie. Forward-compatible depth structure is already in place via this PR: `BSB_REG=0 → BSB_SR=1 → MCWS=2 → MCWS_F=3 → MCWS_W=4` (and `SB_REG=0 → SB_SR=1 → WCWS=2 → WCWS_F=3 → WCWS_W=4`). Phase 2 extends `KO_STAGES` to include the placeholder stages and adds the chrono-inference emit logic.

## ESPN data quirk caught & fixed

The original `season.type=3` postseason discriminator from #22's issue body was wrong. Live data shows NCAA Baseball / Softball spread postseason across `season.type` in `{3, 4, 5, 6}`:
- `3`: Regional
- `4`: Super Regional
- `5`: MCWS / WCWS 8-team bracket
- `6`: Championship Finals

Filter widened to `season.type > 2`. Unit test pins all four values.

## Headline parsing

Headlines are load-bearing — they're the only signal that distinguishes Super Regional from Regional in ESPN's data. The marker strings (`"Super Regional - Game "` and `"Championship Final - Game "` for baseball; `"Championship Finals - Game "` (plural) for softball) are pinned with verbatim-string regression tests so an ESPN copy change is caught at unit-test time. The shared `_extract_game_number_after_marker` helper handles the `(if necessary)` trailer on Game-3 placeholders.

## Live verification

```
$ python3 [live ESPN probe over 2026-05-22..24 WCWS Super Regional window]
Live ESPN records over WCWS Super Regional window: 18 (expected ~18)
Super Regional winners (OKC-bound): 7, losers: 7
=== ALL SMOKE TESTS PASS ===
```

The 7 actual 2026 WCWS Super Regional winners — Alabama, Arkansas, Mississippi State, Nebraska, Texas, Texas Tech, UCLA — all cascade to the `okc_bound` band. The 7 losers cap at `super_regional`.

## Test plan

- [ ] Pull main on Tower, sync plugin folder.
- [ ] Trigger `refresh` for a settings profile that has `enable_ncaa_softball=True`.
- [ ] Confirm WCWS Super Regional games surface with importance > 0 (favor + closeness + importance signal all firing).
- [ ] Confirm regular-season `_fetch_full_season_games` count drops by the postseason game count (postseason games filtered out of the regular-season Monte Carlo).
- [ ] Confirm baseline regular-season + playoff is structurally clean — no duplicate GameRow records under one `espn_event_id`.

Closes #34.
Refs #22 (Phase 1 of two; Phase 2 in #43).
Refs #43.