### PR TITLE
chore: handoff doc for #20 + #43 deferred work

### DIFF
--- a/.planning/HANDOFF-issues-20-and-43.md
+++ b/.planning/HANDOFF-issues-20-and-43.md
@@ -1,0 +1,97 @@
+# Handoff: #20 (WC group stage) + #43 (DoubleEliminationSource)
+
+Written 2026-05-25 after a long autopilot session that shipped 4 PRs and deferred two substantial design pieces. Both deferred items have full research notes in their GitHub issues; this doc is the pointer + delta over what's already there.
+
+## TL;DR
+
+Three PRs shipped against this repo today (#42, #44, #45) plus a `Closes #34`. Two pieces of substantive new-abstraction work remain in the queue. Both are filed (#20, #43), both have design analysis captured in the issue bodies and an issue comment. Pick them up in either order; #43 has the better verification path (2025 historical data is replayable), #20 has the harder calendar (WC kicks off 2026-06-11).
+
+## What just shipped
+
+| PR | Closes | What |
+|---|---|---|
+| #42 | #15 | Deleted `scoring.build_why_text` dead code + tests + CLAUDE.md mention. `_build_description` (plugin.py:1065) is now the sole production EPG renderer. |
+| #44 | #34, Phase 1 of #22 | `NcaaBaseballPlayoffSource` + `NcaaSoftballPlayoffSource` (`BestOfNSeriesSource` subclasses, `SERIES_LENGTH=3`) for Super Regional + Championship Finals stages. Renamed regular-season classes to `*RegularSource`. Live-verified against 2026 WCWS Super Regional data: 7 actual winners cascade to `okc_bound`, 7 losers cap at `super_regional`. |
+| #45 | #41 | 31-case `TestBuildDescription` coverage for the EPG renderer surfaced by #42. |
+| (no PR) | #13 | Closed as duplicate of (already-closed) #14; verified `plugin.py` byte-identical to deployed; refreshed deployed `CLAUDE.md` and `README.md`. |
+
+## What's deferred
+
+### #43 — DoubleEliminationSource (Phase 2 of #22)
+
+**Scope**: New tie shape in `sources/bracket.py` for 4-team Regional double-elim and 8-team MCWS/WCWS bracket. Extends `BracketSportSource` with N-team tie support (existing tie_key is `(stage, frozenset({a, b}))` — 2-team only).
+
+**Design analysis lives in**:
+- **Issue body**: the original sketch — tie state (`losses_by_team`, `bracket_position`), suggested hooks, threshold integration.
+- **Issue comment #4536764707**: 2025 MCWS game-by-game replay data (the authoritative test fixture) + the two bracket-grouping heuristics I derived:
+  - **8-team MCWS / WCWS**: sub-brackets are partitioned by **opening-day pairings** (Day 1 vs Day 2). Verified against 2025 data — Coastal Carolina / Arizona / Oregon State / Louisville in sub-bracket 1 (Day 1 openers); UCLA / Murray State / Arkansas / LSU in sub-bracket 2 (Day 2 openers).
+  - **4-team Regional**: sub-brackets are the **site name from headline** (`"NCAA Baseball Championship - Auburn Regional"` → all teams at Auburn in one tie).
+- **Bracket-end signal**: ESPN explicitly tags the sub-bracket final with `"... advances to Championship Series"` in the headline. Same expected pattern for Regional (likely `"... advances to Super Regional"`, needs verification when 2026 data lands).
+- **Duplicate-event guard**: ESPN's scoreboard occasionally double-emits the same `event_id` (saw `"LSU 9, UCLA 5"` duplicated on 2025-06-17). Dedupe before applying.
+
+**Forward-compat already in place**: Phase 1 (PR #44) put the depth structure in `KNOCKOUT_ROUND_DEPTH` (`BSB_REG=0 → BSB_SR=1 → MCWS=2 → MCWS_F=3 → MCWS_W=4` and the SB/WCWS mirror). The `LEAGUE_CONTEXTS["MCWS_PO"]` / `["WCWS_PO"]` threshold tables already include all four bands. Phase 2 just extends `KO_STAGES` on the two playoff sources and emits records for `BSB_REG` / `MCWS` / `SB_REG` / `WCWS`.
+
+**Suggested 3-phase split** (from issue comment):
+1. **2a**: `DoubleEliminationSource` base in `sources/bracket.py` with N-team tie support + `losses_by_team` tracking. No user-visible change yet.
+2. **2b**: Site-from-headline grouping for Regional + day-partition for MCWS/WCWS. Wire into `NcaaBaseballPlayoffSource` / `NcaaSoftballPlayoffSource`.
+3. **2c**: Replay 2025 MCWS data; assert LSU and Coastal Carolina both reach `MCWS` depth.
+
+**LOC estimate**: ~700 (300 abstraction, 200 plumbing, 200 tests).
+
+**Calendar**: CWS in Omaha runs June 13-23; WCWS bracket in OKC runs ~May 29-June 6 (already starting). Phase 2 will miss the WCWS bracket window but lands cleanly for CWS.
+
+### #20 — WC 2026 group-stage importance
+
+**Scope**: Group-stage Monte Carlo for international tournaments. WC 2026 has 12 groups × 4 teams × 6 games = 72 group games. Currently `KnockoutSoccerSource` emits them via `fetch_upcoming` (rank + closeness signals fire) but reads `importance=0` — there's no structural advancement modeling.
+
+**Design analysis lives in**:
+- **Issue body**: original sketch — state shape, terminal_outcomes proposal, `feeds_from` integration question.
+- **Task #5 description in the queue**: my deferred-design notes — recommend a new `GroupStageSource(SoccerSource)` (NOT extending `KnockoutSoccerSource` because the integration complexity is high), filter `KnockoutSoccerSource.fetch_upcoming` to skip GROUP_STAGE matches (safe for non-WC/EURO competitions which don't have that stage label), hardcoded `outcome_labels=['advance','eliminated']` in `GroupStageSource` bypassing `LEAGUE_CONTEXTS` thresholds (the per-group classification doesn't fit any of the existing `format` types).
+
+**FD.org data shape verified** (via EURO 2024 probe):
+- Match records carry `stage` (e.g. `"GROUP_STAGE"`) and `group` (e.g. `"GROUP_A"` through `"GROUP_F"`).
+- EURO 2024: 36 group games + 15 knockout games = 51 total.
+- WC 2026 will be: 72 group games + ~50 knockout = ~122 total.
+
+**Open design questions** (deferred for fresh context):
+1. **`outcome_labels` bypassing `LEAGUE_CONTEXTS`**: clean but inconsistent with how every other importance-supporting source works. Alternative: add a new `LEAGUE_CONTEXTS` `format="group_advance"` that the simulator's threshold-cascade code learns to handle. More invasive but more consistent.
+2. **`feeds_from` integration with `KnockoutSoccerSource`**: a group winner should structurally feed into a `LAST_32` tie, but the simulator currently doesn't cross between sources. Phase 1 should probably treat them as independent (no cross-source `feeds_from`), and Phase 2 (separate issue) wires it up.
+3. **Best-third-place tiebreaker**: WC 48-team format has top 2 + 8 best third-place across 12 groups advancing to `LAST_32`. The tiebreaker rules (points → goal diff → goals scored → fair play) are non-trivial. Phase 1 should ship top-2-only; tiebreaker is Phase 2.
+
+**LOC estimate**: ~550 (350 source, 200 tests). Verification against EURO 2024 historical data (FD.org has the full replay).
+
+**Calendar**: WC kicks off **2026-06-11** (17 days from this handoff). Phase 1 ships before kickoff is the goal.
+
+## Gotchas (caught the hard way during the session)
+
+1. **ESPN `season.type` for NCAA postseason spans 3-6, not just 3.** Original assumption (from #22 issue body) was `type=3` = postseason. Live data showed: 3=Regional, 4=Super Regional, 5=MCWS/WCWS 8-team bracket, 6=Championship Finals. PR #44 widened the filter to `type > 2`. Encoded in `_is_postseason_event` docstring in `sources/ncaa_baseball.py`.
+
+2. **Softball headline plurality differs from baseball.** MCWS = "Championship **Final** - Game N" (singular). WCWS = "Championship **Finals** - Game N" (plural). Marker strings in `sources/ncaa_baseball.py` and `sources/ncaa_softball.py` are sport-specific. Verbatim-string regression tests pin this.
+
+3. **The dispatcharr-skill primer says match existing patterns.** When I added the Phase 1 playoff sources, the per-sport-file pattern (rather than a cross-sport shared base) IS the convention — even though the two source files have ~80% identical structure. The only extract I made was `extract_game_number_after_marker` into `_util.py` because it's a pure utility with zero sport-specific logic.
+
+4. **No CI on this repo.** No GitHub Actions workflow; `tests/` exists but isn't gated. `pytest` is not installed in pocket-dev (the dev container Claude runs in) — tests have to be exercised either inside the Dispatcharr container or via the manual-import smoke pattern in `tests/test_plugin_helpers.py:_load_plugin_module`. Phase 2.7 live testing is the real verification gate.
+
+5. **Deployed `/appdata` plugin folder is a snapshot, not a git checkout.** Sync is manual `cp` from a working clone. No `.git` directory at the deploy site; `git pull` won't work. The sync direction is **clone → /appdata** (clone is canonical post-merge).
+
+6. **FD.org API key on pocket-dev**: the file at `/appdata/dispatcharr/data/plugins/dispatcharr_ranked_matchups/football_data_api_key` is `node:node` 0600. The Claude user (uid 99) can't read it directly. Use `docker exec Dispatcharr cat /data/plugins/dispatcharr_ranked_matchups/football_data_api_key` to read. Same pattern likely applies to the other API key files in that directory (cfbd, anthropic, odds).
+
+## Verification environment notes
+
+- **Dispatcharr container** runs `ghcr.io/dispatcharr/dispatcharr:latest`, version `0.25.1`. Reload via `docker exec Dispatcharr touch /data/plugins/.reload_token` then any HTTP request to `/api/plugins/plugins/`. Force-reload via authenticated `POST /api/plugins/plugins/reload/`.
+- **Plugin folder on host (= deploy target)**: `/appdata/dispatcharr/data/plugins/dispatcharr_ranked_matchups/` (FUSE-mounted from `/mnt/user/appdata` on Tower).
+- **Working clone for code edits**: anywhere under `/home/claude/work/`. The `tests/conftest.py` pattern registers the package under its canonical name so absolute imports resolve even when the directory name doesn't match.
+- **Live-verify pattern for ESPN-driven sources**: probe with a `urllib.request` shim that mocks `requests` (see the smoke harness used in this session — it lives in chat history; happy to extract to `tests/conftest_live.py` next session if it'd be useful).
+
+## Suggested order for next session
+
+1. **#43 first.** Verification path is concrete (2025 MCWS historical data + issue comment table is the test fixture). Scope is contained: one new tie shape in one existing file. CWS in Omaha starts June 13, comfortable timeline.
+2. **#20 second.** Bigger calendar pressure (June 11), but design questions are still open (`LEAGUE_CONTEXTS` integration, `feeds_from` cross-source). Fresh context will help resolve them cleanly.
+
+## What's NOT done that might look like it should be
+
+- **No `feeds_from` between Phase 1 playoff source and Phase 2 (when it lands).** When Phase 2 adds `MCWS` to `KO_STAGES`, the existing `MCWS_F` tie's `feeds_from` will need rewiring (currently points to `BSB_SR` because that's the only earlier stage). The `_build_bracket` method handles this automatically — confirmed by reading `sources/bracket.py:328-345` — but worth double-checking once Phase 2 lands.
+
+- **No `enable_*` toggle split.** Both regular + playoff sources sit behind a single `enable_ncaa_baseball` / `enable_ncaa_softball` toggle (matching the MLB pattern). Phase 2 won't change this.
+
+- **No cleanup of the `LEAGUE_CONTEXTS["BSB"]` / `["SBL"]` regular-season comments** that still mention "CWS postseason bracket is not modeled in V1." Those are accurate for the regular-season threshold bands (which haven't changed) but stale on the "not modeled" claim. Low-priority follow-up if anyone cares.


### PR DESCRIPTION
Adds \`.planning/HANDOFF-issues-20-and-43.md\` so a fresh \`/build\` session picks up the two deferred substantive design pieces with full context.

Doc is the pointer + delta over what already lives in the issue bodies and #43's bracket-reconstruction comment. Includes session-discovered gotchas (ESPN season.type range, softball/baseball plurality, /appdata is a snapshot not a checkout, FD.org key permission quirk).

No code changes.