### PR TITLE
Strip archaeological and speculative cruft from comments + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,15 +49,15 @@ downstream is sport-agnostic.
 | `scoring.py` | `GameSignals`, `Weights`, `GameScore`. `score_game()` sums per-signal contributions, `_compress_to_10()` does the tanh squash. Helpers: `match_favorites`, `compute_match_importance` (Lahvička Monte Carlo), `format_channel_name`. League thresholds in `LEAGUE_CONTEXTS` dict (position, label, consequence_weight). |
 | `simulation.py` | Sport-agnostic Monte Carlo importance per Lahvička (2012). `monte_carlo_importance()` for single (team, outcome); `monte_carlo_importance_batch()` shares one set of N season simulations across K queries. `kendall_tau_c()` is the ordinal-association measure. |
 | `matcher.py` | `match_games_to_channels()` resolves cached `GameRow` → Dispatcharr channel via EPG `ProgramData`. Two-stage: regex (both team keywords in EPG title) → Claude batched fallback. |
-| `sources/base.py` | `GameRow` + `MatchResult` dataclasses + abstract `SportSource`. ABC declares the Phase C importance interface (`supports_importance` flag + 7 optional methods); sources opt in by overriding. |
-| `sources/bracket.py` | `BracketSportSource` shared state machine for all knockout/playoff sports (bracket inference, `_round_reached`, `terminal_outcomes` cascade). Three concrete tie shapes: `AggregateLegSource` (two-leg, used by `KnockoutSoccerSource`), `BestOfNSeriesSource` (best-of-N series, used by `NhlPlayoffSource`, `MlbPlayoffSource`, `NcaaBaseballPlayoffSource`, `NcaaSoftballPlayoffSource` for their Super Regional + Finals stages), and `DoubleEliminationSource` (4-team double-elim, target for NCAA Baseball / Softball Regional + 8-team MCWS/WCWS bracket — Phase 2a base class landed; Phase 2b plumbing pending under #43). `BestOfNSeriesSource._series_length_for_stage(stage)` hook lets each sport map stages to series lengths — NHL uses uniform 7; MLB uses 3/5/7/7 (WC/LDS/LCS/WS). |
+| `sources/base.py` | `GameRow` + `MatchResult` dataclasses + abstract `SportSource`. ABC declares the Monte Carlo importance interface (`supports_importance` flag + 7 optional methods); sources opt in by overriding. |
+| `sources/bracket.py` | `BracketSportSource` shared state machine for all knockout/playoff sports (bracket inference, `_round_reached`, `terminal_outcomes` cascade). Three concrete tie shapes: `AggregateLegSource` (two-leg, used by `KnockoutSoccerSource`), `BestOfNSeriesSource` (best-of-N series, used by `NhlPlayoffSource`, `MlbPlayoffSource`, `NcaaBaseballPlayoffSource`, `NcaaSoftballPlayoffSource` for their Super Regional + Finals stages), and `DoubleEliminationSource` (4-team double-elim base class for NCAA Baseball / Softball Regional + 8-team MCWS/WCWS bracket; plumbing into the sport sources is tracked in #43). `BestOfNSeriesSource._series_length_for_stage(stage)` hook lets each sport map stages to series lengths — NHL uses uniform 7; MLB uses 3/5/7/7 (WC/LDS/LCS/WS). |
 | `sources/points_based.py` | Shared Monte Carlo for round-robin point-scoring sports (NCAAF, NCAAM, NHL regular, MLB regular). Subclasses set `_count_field` to choose between `"wins"` (CFB/CBB/MLB) and `"standings_points"` (NHL) for terminal_outcomes bucketing. |
 | `sources/ncaaf.py` | CFBD `/rankings`, `/games`, `/lines` calls. CFBD uses **camelCase** (homeTeam, awayTeam) — easy gotcha. |
 | `sources/nhl.py` | api-web.nhle.com (official, no key). `NhlRegularSource` uses standings points (regulation win = 2, OT/SO loss = 1, regulation loss = 0). `NhlPlayoffSource` is a best-of-7 BracketSportSource. The two cross-feed: NhlPlayoffSource borrows regular-season strengths via `set_regular_season_strengths()` so cup-final sampling uses the 82-game baseline. |
 | `sources/mlb.py` | statsapi.mlb.com (official, no key). `MlbRegularSource` uses raw win count (no OT-loss bonus). `MlbPlayoffSource` is a BestOfNSeriesSource with per-stage series lengths (WC=3, LDS=5, LCS=7, WS=7). Same regular-season → playoff strength-sharing pattern as NHL. |
 | `sources/nba.py` | ESPN unofficial API (stats.nba.com is WAF-blocked from most homelab egress). `NbaRegularSource` uses raw win count. `NbaPlayoffSource` is a BestOfNSeriesSource with uniform SERIES_LENGTH=7 (R1 / CSF / CF / FINALS). Stage routing comes from parsing the ESPN headline ("East 1st Round - Game 3" etc.) — the only place ESPN exposes the playoff round. All-Star Tournament games (which ESPN tags `season.type=2` but `competition.type.abbreviation=ALLSTAR`) are filtered out so the regular-season team list stays at 30. |
-| `sources/mls.py` | ESPN unofficial API for the schedule + The Odds API (`soccer_usa_mls`) for closeness. V1 is intentionally thin: `MlsSource` does NOT inherit `PointsBasedSportSource` and `supports_importance=False`. MLS surfaces with favorite + closeness signals only; standings-based importance and the mixed-format MLS Cup bracket (best-of-3 R1 + single-leg subsequent rounds) are filed as a follow-up (#30). Team-name fuzzy matching reuses `_util.TEAM_SUFFIX_TOKENS` — never add "united" to that list (it's a substantive body word for Atlanta United / D.C. United / Minnesota United). |
-| `sources/soccer.py` | Football-Data.org for fixtures+standings, The Odds API for spreads. League position used as rank. `SoccerSource` is league-shaped (PL, ELC); `KnockoutSoccerSource` (Phase D.1) is bracket-shaped (UCL) — multi-inherits from `AggregateLegSource` (bracket state machine) + `SoccerSource` (FD.org fetch / strengths) with the MRO `K → AggregateLegSource → BracketSportSource → SoccerSource → SportSource`. Routed by `LEAGUE_CONTEXTS[fd_code].format`. |
+| `sources/mls.py` | ESPN unofficial API for the schedule + The Odds API (`soccer_usa_mls`) for closeness. Intentionally thin: `MlsSource` does NOT inherit `PointsBasedSportSource` and `supports_importance=False`. MLS surfaces with favorite + closeness signals only; standings-based importance and the mixed-format MLS Cup bracket (best-of-3 R1 + single-leg subsequent rounds) are tracked in #30. Team-name fuzzy matching reuses `_util.TEAM_SUFFIX_TOKENS` — never add "united" to that list (it's a substantive body word for Atlanta United / D.C. United / Minnesota United). |
+| `sources/soccer.py` | Football-Data.org for fixtures+standings, The Odds API for spreads. League position used as rank. `SoccerSource` is league-shaped (PL, ELC); `KnockoutSoccerSource` is bracket-shaped (UCL) — multi-inherits from `AggregateLegSource` (bracket state machine) + `SoccerSource` (FD.org fetch / strengths) with the MRO `K → AggregateLegSource → BracketSportSource → SoccerSource → SportSource`. Routed by `LEAGUE_CONTEXTS[fd_code].format`. |
 
 State (gitignored, lives in `<plugin_dir>/`):
 - `cache.json` — last refresh result (curated game list with score breakdowns)
@@ -91,17 +91,18 @@ differentiation in the typical 4-15 range.
 | Signal | Triggered when | Default weight |
 |---|---|---|
 | `rank_pair` | Both teams ranked / one ranked | 1.0 |
-| `favorite` | One of user's favorite teams plays | 6.0 (flat, Phase A) |
-| `close_game` | Coinflip-ness in [0, 1]: devigged h2h moneyline probabilities for soccer, normalized point spread for NCAAF / NCAAM | 3.0 (Phase B.3) |
-| **`importance`** | Lahvička Monte Carlo: \|Kendall tau-c\| × consequence weight, summed over playing teams AND in-league favorites' outcome bands. Soccer leagues (PL/ELC): title/UCL/Europa/relegation/promotion (format=`league`). UCL knockouts: round_of_16/QF/SF/F/winner (format=`knockout`). NCAAF/NCAAM: win-count bands (format=`win_count`). NHL regular season: standings-point bands (95+/100+/110+/125+, format=`points_count`). NHL Stanley Cup Playoffs: R2/Conf Final/Cup Final/Champion (format=`knockout`). Locked-in outcomes contribute 0 (mathematical elimination respected). | **3.0 (Phase C.3 / D.1 / E)** |
+| `favorite` | One of user's favorite teams plays | 6.0 (flat) |
+| `close_game` | Coinflip-ness in [0, 1]: devigged h2h moneyline probabilities for soccer, normalized point spread for NCAAF / NCAAM | 3.0 |
+| **`importance`** | Lahvička Monte Carlo: \|Kendall tau-c\| × consequence weight, summed over playing teams AND in-league favorites' outcome bands. Soccer leagues (PL/ELC): title/UCL/Europa/relegation/promotion (format=`league`). UCL knockouts: round_of_16/QF/SF/F/winner (format=`knockout`). NCAAF/NCAAM: win-count bands (format=`win_count`). NHL regular season: standings-point bands (95+/100+/110+/125+, format=`points_count`). NHL Stanley Cup Playoffs: R2/Conf Final/Cup Final/Champion (format=`knockout`). Locked-in outcomes contribute 0 (mathematical elimination respected). | **3.0** |
 | `tournament_stage` | Knockout cup game flat boost (R16 / QF / SF / FINAL). For UCL the importance signal already encodes round depth via consequence weights, so this is mostly redundant; kept for non-UCL cups not in LEAGUE_CONTEXTS yet. | 1.5 |
 | `narrative` | LLM-judged narrative score | 0.0 (off by default) |
 
-The legacy `stakes`, `impact_on_favorite`, and `_late_season_multiplier`
-signals were retired in Phase C.4 — the structural Monte Carlo importance
-signal subsumes all three (mathematical elimination, cross-team impact via
-the favorites-extended query path, and natural end-of-season leverage rise
-from tau-c growing as outcomes lock in).
+The structural Monte Carlo importance signal subsumes the old
+hand-rolled "stakes / impact_on_favorite / late_season_multiplier"
+signal family: mathematical elimination falls out for free,
+cross-team impact comes from extending each query batch to include
+in-league favorites, and natural end-of-season leverage rise emerges
+from tau-c growing as outcomes lock in.
 
 User asked us to default narrative weight to 0 because the structural
 `importance` signal covers what LLM narrative would surface anyway. Don't
@@ -150,9 +151,8 @@ buckets against the threshold cutoff.
 
 - **CFBD API is camelCase**: `homeTeam`, `awayTeam`, `startDate`,
   `neutralSite`, `excitementIndex`. We hit this once already — got 0 games
-  because we used `home_team`. Their `/games` response also has the goldmine
-  `excitementIndex` field for completed games (potential Phase 3+ training
-  signal).
+  because we used `home_team`. Their `/games` response also exposes
+  `excitementIndex` on completed games, which is interesting raw data.
 - **EPG self-matching bug**: matcher must exclude channels with our
   `tvg_id` prefix `ranked_matchups:` — otherwise it matches games against
   our own virtual channels (whose EPG titles literally contain the team
@@ -215,12 +215,12 @@ docker logs --since 5m dispatcharr 2>&1 | grep ranked_matchups | tail -30
 **Working:**
 - NCAAF source (CFBD) and NCAAM source (CollegeBasketballData) — both via
   the same Bearer token, both auto-skip during their respective offseason.
-  Phase D.2/D.3: both implement Monte Carlo importance via the shared
+  Both implement Monte Carlo importance via the shared
   `PointsBasedSportSource` base (Poisson on points, win-count outcome
   bands per LEAGUE_CONTEXTS["CFB"]/["CBB"]).
 - EPL + EFL Championship sources (Football-Data.org + Odds API, league-shaped)
-- UCL source (Phase D.1: `KnockoutSoccerSource`, bracket-shaped with ET +
-  penalty sampling and feeds_from-via-participant bracket inference)
+- UCL source (`KnockoutSoccerSource`, bracket-shaped with ET + penalty
+  sampling and feeds_from-via-participant bracket inference)
 - All scoring signals (rank, favorite, close_game, importance,
   tournament-stage, optional LLM narrative)
 - Today-first sort + channel renumbering, with auto / fixed virtual base

--- a/README.md
+++ b/README.md
@@ -68,31 +68,23 @@ descriptions) is sport-agnostic.
 
 ## Roadmap
 
-Sports / leagues on the to-do list (PRs welcome — see
-[CONTRIBUTING.md](CONTRIBUTING.md) for a step-by-step guide; for
-requests, [open an issue](../../issues/new/choose) and the form will
-collect everything needed to scope it):
+Open work is tracked in [GitHub issues](../../issues). Notable themes:
 
-- **NCAA Baseball** — no clean public API yet; options being evaluated:
-  D1Baseball.com scrape, ESPN's hidden API, or a future
-  CollegeBaseballData.com from the same author as CFBD/CBB.
-- **NCAA Soccer** — same author publishes CollegeSoccerData; needs an
-  adapter file + AP poll mapping.
-- **MLB / NBA / NFL** — would use The Odds API for spreads + a
-  rankings/standings source (TBD per sport).
-- **More European football leagues** — La Liga, Serie A, Bundesliga,
-  Ligue 1 are all on Football-Data.org's free tier. Each needs a
-  `LEAGUE_CONTEXTS` entry in `scoring.py` with the right thresholds
-  (UCL/Europa cutoff, relegation line) plus a one-line addition to the
-  `COMPETITIONS` dict in `sources/soccer.py`.
-- **Rivalry signal** — a `rivalries.json` shipped with the plugin (NCAA
-  rivalries are well-known) and/or an LLM "is this a rivalry?" call
-  cached per team-pair.
-- **Matcher v2** — soccer EPG match rate is currently low because UK
-  providers publish broadcast EPG only 24-48h ahead and team-name
-  variants ("Wrexham" / "Wrexham AFC" / "AFC Wrexham") trip the regex
-  pre-filter. Plan: team-alias dictionary, tighter time window, broader
-  fuzzy match.
+- **Rivalry signal** — the `weight_rivalry` weight is wired but no
+  source populates `is_rivalry`. See [#8](../../issues/8).
+- **Matcher v2** — soccer EPG match rate is low because UK providers
+  publish broadcast EPG only 24-48h ahead and team-name variants
+  ("Wrexham" / "Wrexham AFC" / "AFC Wrexham") trip the regex
+  pre-filter. See [#4](../../issues/4).
+- **NCAA Baseball / Softball postseason brackets** — Regional
+  double-elim and the 8-team MCWS/WCWS brackets need chronological
+  bracket inference. See [#43](../../issues/43).
+- **WC 2026 group stage importance** — group-stage games currently
+  read importance=0. See [#20](../../issues/20).
+
+PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for a step-by-step
+guide. For requests, [open an issue](../../issues/new/choose) and the
+form will collect everything needed to scope it.
 
 ## Install
 

--- a/llm_descriptions.py
+++ b/llm_descriptions.py
@@ -153,9 +153,10 @@ def build_llm_context(g: Dict[str, Any], tagline: str, boundary_summary: str = "
         for narrative in impact_narratives:
             lines.append(f"  - {narrative}")
 
-    # Phase C.4 renamed `stakes_thresholds_hit` → `importance_thresholds_hit`;
-    # accept either so a cache.json written by pre-C.4 code still produces
-    # a reasonable prompt during the one-cycle migration window.
+    # Older cache files stored the band list under `stakes_thresholds_hit`;
+    # accept either key so a cache.json written by an older plugin version
+    # still produces a reasonable prompt during the one-cycle migration
+    # window.
     thresholds_hit = (
         g.get("importance_thresholds_hit")
         or g.get("stakes_thresholds_hit")

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
   "version": "0.1.0",
-  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them by rank pair / favorites / spread (and Phase 3+: rivalry, narrative), matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
+  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
   "author": "Jake (with Claude)",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",
@@ -256,7 +256,7 @@
       "input_type": "password",
       "label": "CollegeFootballData.com API key",
       "default": "",
-      "help_text": "Register: https://collegefootballdata.com/key (free, 1k req/day). The same key works for collegebasketballdata.com — one key powers both NCAAF and NCAAM, including the Monte Carlo importance signal (Phase D.2/D.3)."
+      "help_text": "Register: https://collegefootballdata.com/key (free, 1k req/day). The same key works for collegebasketballdata.com — one key powers both NCAAF and NCAAM, including the Monte Carlo importance signal."
     },
     {
       "id": "football_data_api_key",
@@ -367,7 +367,7 @@
       "type": "number",
       "label": "Rivalry boost",
       "default": 2.0,
-      "help_text": "Flat points added for known rivalry games (future: rivalry DB)."
+      "help_text": "Flat points added when a source flags a game as a rivalry. No sources currently populate this signal (tracked in #8)."
     },
     {
       "id": "weight_tournament",
@@ -388,7 +388,7 @@
       "type": "number",
       "label": "Monte Carlo importance weight",
       "default": 3.0,
-      "help_text": "Multiplier on Lahvička match-importance: |Kendall tau-c| × consequence weight, summed across both playing teams' outcome bands AND any in-league favorites' outcome bands (so a non-favorite game that swings a favorite's relegation chance gets credit structurally). Only fires for sources that implement simulation (currently soccer). Phase C.4 retired the legacy stakes / impact-on-favorite / late-season-multiplier signal family — this signal replaces all three. Set to 0 to disable."
+      "help_text": "Multiplier on Lahvička match-importance: |Kendall tau-c| × consequence weight, summed across both playing teams' outcome bands AND any in-league favorites' outcome bands (so a non-favorite game that swings a favorite's relegation chance gets credit structurally). Set to 0 to disable."
     },
     {
       "id": "n_importance_sims",

--- a/plugin.py
+++ b/plugin.py
@@ -274,9 +274,8 @@ def _parse_favorites(raw: str) -> List[str]:
 def _build_weights(settings: Dict[str, Any]):
     # Source of truth for default values is scoring.Weights's dataclass
     # declaration. Do NOT duplicate the numbers here — when a default
-    # changes (e.g. Phase A bumped favorite 4.0 -> 6.0), the duplicate
-    # ALWAYS gets missed and the runtime silently uses the old value
-    # until somebody runs the tests.
+    # changes, the duplicate ALWAYS gets missed and the runtime silently
+    # uses the old value until somebody runs the tests.
     from .scoring import Weights
     d = Weights()
     return Weights(
@@ -335,7 +334,7 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("championship"))
     if settings.get("enable_ucl", False) and fd_key:
         sources.append(_make_soccer("ucl"))
-    # Phase H: top-flight European leagues. Same FD.org key as EPL etc.;
+    # Top-flight European leagues. Same FD.org key as EPL etc.;
     # _make_soccer routes each to SoccerSource because their LEAGUE_CONTEXTS
     # entries default to format="league".
     if settings.get("enable_bundesliga", False) and fd_key:
@@ -346,7 +345,7 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("serie_a"))
     if settings.get("enable_ligue_1", False) and fd_key:
         sources.append(_make_soccer("ligue_1"))
-    # Phase I: international tournaments. _make_soccer dispatches to
+    # International tournaments. _make_soccer dispatches to
     # KnockoutSoccerSource via the format="knockout" route. Group-stage
     # importance isn't modeled in V1; group games still surface via
     # fetch_upcoming with favorite + closeness signal only.
@@ -355,7 +354,7 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_euros", False) and fd_key:
         sources.append(_make_soccer("euros"))
 
-    # Phase Q: additional FD.org free-tier leagues. Same _make_soccer
+    # Additional FD.org free-tier leagues. Same _make_soccer
     # router; LEAGUE_CONTEXTS uses format="league" so dispatch goes
     # to SoccerSource (not KnockoutSoccerSource).
     if settings.get("enable_eredivisie", False) and fd_key:
@@ -453,7 +452,7 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_liga_mx", False):
         sources.append(LigaMxSource(odds_api_key=odds_key or ""))
 
-    # Phase R: field events (racing + golf). No two-team head-to-head;
+    # Field events (racing + golf). No two-team head-to-head;
     # each row is one race or tournament. Low event volume (~1/week)
     # means "surface if toggled" is the right product — no importance
     # ranking needed.
@@ -464,13 +463,13 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_golf", False):
         sources.append(GolfSource())
 
-    # Phase S: UFC. Same field-event shape — each fight card is one
+    # UFC. Same field-event shape — each fight card is one
     # row with home=card title ("UFC 309: Jones vs. Miocic"). PPVs
     # (numbered UFC events) get MAJOR tier, Fight Nights get EVENT.
     if settings.get("enable_ufc", False):
         sources.append(UfcSource())
 
-    # Phase T: Tennis. ESPN's tennis scoreboard returns whole
+    # Tennis. ESPN's tennis scoreboard returns whole
     # tournaments (one entry per active event), not individual
     # matches — so tennis fits the FieldEventSource model. Grand
     # Slams + year-end Finals get MAJOR; regular tour stops get
@@ -507,14 +506,15 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[ncaaw_basketball] could not seed playoff strengths: %s", exc)
         sources.append(ncaaw_po)
 
-    # Phase M / Phase O Phase 1: NCAA Division I baseball. Free ESPN
-    # unofficial API + D1Baseball poll. Regular-season win-count thresholds
-    # (30 / 35 / 40 / 45 / 50) drive the in-season importance signal.
-    # Phase O Phase 1 adds postseason coverage for the cleanly-labeled
-    # best-of-3 stages (Super Regional, MCWS Finals). Same pair-and-seed
-    # pattern as MLB: the playoff source borrows regular-season strengths
-    # from the regular source so postseason Poisson sampling reflects
-    # per-team scoring skill rather than the league-average prior.
+    # NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
+    # poll. Regular-season win-count thresholds (30 / 35 / 40 / 45 / 50)
+    # drive the in-season importance signal. Postseason coverage is
+    # currently the cleanly-labeled best-of-3 stages (Super Regional,
+    # MCWS Finals); Regional double-elim + 8-team MCWS bracket are
+    # tracked in #43. Same pair-and-seed pattern as MLB: the playoff
+    # source borrows regular-season strengths from the regular source
+    # so postseason Poisson sampling reflects per-team scoring skill
+    # rather than the league-average prior.
     if settings.get("enable_ncaa_baseball", False):
         ncbsb_reg = NcaaBaseballRegularSource()
         sources.append(ncbsb_reg)
@@ -525,11 +525,10 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[ncaa_baseball] could not seed playoff strengths: %s", exc)
         sources.append(ncbsb_po)
 
-    # Phase N / Phase O Phase 1: NCAA Division I softball. Same structure
-    # as NCAA baseball — regular-season win-count + best-of-3 postseason
-    # (Super Regional, WCWS Finals) coverage. Phase 2 (filed) will model
-    # the Regional double-elim + 8-team WCWS bracket via chronological
-    # inference.
+    # NCAA Division I softball. Same structure as NCAA baseball — regular-
+    # season win-count + best-of-3 postseason (Super Regional, WCWS Finals)
+    # coverage. Regional double-elim + 8-team WCWS bracket are tracked in
+    # #43.
     if settings.get("enable_ncaa_softball", False):
         ncsbl_reg = NcaaSoftballRegularSource()
         sources.append(ncsbl_reg)
@@ -540,7 +539,7 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[ncaa_softball] could not seed playoff strengths: %s", exc)
         sources.append(ncsbl_po)
 
-    # Phase O: NCAA D1 men's + women's soccer. One source class
+    # NCAA D1 men's + women's soccer. One source class
     # parametrized on gender — same structure / endpoints / threshold
     # semantics for both, only the ESPN URL slug differs. Standings
     # points (3 W / 1 D / 0 L) drive the importance signal because
@@ -567,7 +566,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     if not sources:
         return {"status": "error", "message": "No sport sources enabled."}
 
-    # 1. Fetch. Keep the (source, game) association — Phase C compute_match_importance
+    # 1. Fetch. Keep the (source, game) association — compute_match_importance
     # needs the source object per game to run the season-replay simulator. Plain
     # game rows lose the link to which adapter produced them, and reconstructing
     # it from extra["fd_competition_code"] only works for soccer.
@@ -594,16 +593,15 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
         _write_cache(cache)
         return {"status": "ok", "message": msg}
 
-    # 2. Score. The Lahvička Monte Carlo importance signal (Phase C)
-    # replaced the legacy stakes / impact_on_favorites / late_mult signal
-    # family in C.4 — the structural importance value covers all three:
+    # 2. Score. The Lahvička Monte Carlo importance signal covers three
+    # related concerns structurally:
     #   - stakes for the playing teams → home + away queries in the batch
     #   - impact_on_favorites for non-playing favorites → favorite queries
     #     in the same batch (one season replay per match shared across all
     #     queries via monte_carlo_importance_batch)
     #   - late-season amplification → emerges naturally from the
     #     contingency table getting sharper as elimination drops more
-    #     outcomes out of contention. No multiplier hack needed.
+    #     outcomes out of contention.
     from .scoring import (
         match_favorites, LEAGUE_CONTEXTS, build_impact_narratives,
         compute_match_importance,
@@ -645,13 +643,12 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
             favs_with_standings, standings_table,
         )
 
-        # Phase C Monte Carlo importance. Queries cover the two playing
-        # teams' outcome bands AND any in-league favorites' outcome
-        # bands (so a non-favorite game that swings a favorite's
-        # relegation chance gets credit structurally — the impact_on_
-        # favorites case from issue #11). weight_importance=0 disables
-        # the per-game cost entirely. Catches any exception so a flaky
-        # source can't take down the entire refresh.
+        # Monte Carlo importance. Queries cover the two playing teams'
+        # outcome bands AND any in-league favorites' outcome bands
+        # (so a non-favorite game that swings a favorite's relegation
+        # chance gets credit structurally). weight_importance=0
+        # disables the per-game cost entirely. Catches any exception
+        # so a flaky source can't take down the entire refresh.
         importance_pts: float = 0.0
         importance_notes: List[str] = []
         importance_thresholds_hit: List[str] = []
@@ -919,7 +916,7 @@ def _resolve_virtual_base(settings: Dict[str, Any], highest_non_virtual: float) 
     """Resolve the starting channel number for our virtual channels.
 
     `virtual_channel_base` setting:
-      - Positive int → use that as the base (legacy: 9000)
+      - Positive int → use that as the base.
       - 0 (sentinel) → auto: pick (highest existing non-virtual channel) + 1,
         so virtuals slot in just after the user's real channels.
       - Anything unparseable → treat as auto.
@@ -945,28 +942,23 @@ def _resolve_virtual_base(settings: Dict[str, Any], highest_non_virtual: float) 
 def _resolve_park_base(target_base: int, num_games: int) -> int:
     """Pick a parking range that's guaranteed past every target number we'll
     write. Parking + writing happens in one transaction within our own group,
-    so we only need to clear our own target range — +1000 slack is safety
-    margin against future-us reusing the parking range for something else."""
+    so we only need to clear our own target range; +1000 slack keeps the
+    parking range comfortably out of any plausible target_base growth."""
     return target_base + max(num_games, 0) + 1000
 
 
 def _build_signals_score_from_payload(g: Dict[str, Any]):
     """Reconstruct GameSignals + GameScore from cache.json payload.
 
-    Phase C.4 retired GameSignals.stakes_a/_b, stakes_thresholds_hit,
-    season_progress, and impact_on_favorites — the Monte Carlo importance
-    signal subsumes all four. A cache.json written before C.4 still
-    contains those keys; they're ignored here. The reader degrades
-    gracefully: missing importance_thresholds_hit (pre-C.4) falls back to
-    the legacy `stakes_thresholds_hit` if present, so the first post-C.4
-    apply against a stale cache still gets a tagline.
+    Cache files written by older versions of this plugin used a different
+    key for the tagline thresholds (`stakes_thresholds_hit` instead of
+    `importance_thresholds_hit`) and may carry retired fields that the
+    current GameSignals doesn't accept (stakes_a/_b, season_progress,
+    impact_on_favorites). Reading both keys gives a one-cycle migration
+    window so the first apply against a stale cache still produces a
+    tagline; the retired fields are simply ignored.
     """
     from .scoring import GameSignals, GameScore
-    # Pre-C.4 caches stored thresholds under `stakes_thresholds_hit`; the
-    # post-C.4 key is `importance_thresholds_hit`. Reading both supports a
-    # one-cycle migration window where apply runs against a refresh that
-    # was generated by the previous code. After the first post-C.4
-    # refresh writes a fresh cache, the legacy key disappears.
     thresholds_hit = (
         g.get("importance_thresholds_hit")
         or g.get("stakes_thresholds_hit")
@@ -981,8 +973,9 @@ def _build_signals_score_from_payload(g: Dict[str, Any]):
         spread=g.get("spread"),
         closeness=g.get("closeness"),
         tournament_stage=g.get("tournament_stage"),
-        # Phase C: pre-weight importance roundtrip. Missing from pre-C.3
-        # caches → defaults (0.0 / []) preserve graceful degradation.
+        # Cache files predating this signal default to 0.0 / [] — graceful
+        # degradation: the importance block in score_game just contributes
+        # nothing for that entry.
         importance_points=float(g.get("importance_points") or 0.0),
         importance_notes=list(g.get("importance_notes") or []),
         importance_thresholds_hit=list(thresholds_hit),
@@ -1007,13 +1000,13 @@ def _close_game_descriptor(
     closeness: Optional[float], spread: Optional[float]
 ) -> Optional[str]:
     """Map the close-game signal to a human-readable label. Prefers the
-    B.3 closeness measure (devigged probabilities, [0,1]) when present;
-    falls back to the legacy point-spread thresholds otherwise.
+    closeness measure (devigged probabilities, [0,1]) when present; falls
+    back to point-spread thresholds otherwise.
 
     Soccer's `closeness >= 0.7` (each side ≥35% of a 3-way market) is the
     coinflip-magnitude analog of NCAAF's `spread <= 3`. The two bands
-    were calibrated so that a Phase-A EPL toss-up and a Phase-A NCAAF
-    toss-up produce the same label.
+    are calibrated so an EPL toss-up and an NCAAF toss-up produce the
+    same label.
     """
     if closeness is not None:
         if closeness >= 0.7:
@@ -1356,9 +1349,9 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         for cache_idx, g in enumerate(games):
             # channel_ids is the full list of matched provider channels (e.g.
             # multiple regional/quality variants of the same fixture). Falls
-            # back to legacy single channel_id for cache entries written by
-            # an older plugin version. Primary (first) drives the channel
-            # logo and EPG context.
+            # back to the single-channel `channel_id` key for cache entries
+            # written by an older plugin version. Primary (first) drives
+            # the channel logo and EPG context.
             source_ids = list(g.get("channel_ids") or [])
             if not source_ids:
                 primary_id = g.get("channel_id")

--- a/scoring.py
+++ b/scoring.py
@@ -5,15 +5,14 @@ sum of per-signal contributions, each visible in the cache. When the user says
 "this game should be ranked higher", they can see exactly which signal needs
 to be tuned.
 
-Signals (Phase 1 — rank + favorites only):
+Signals:
   - rank_pair: both teams ranked → score from sum_of_ranks (lower = higher score)
   - one_ranked: one team ranked, one unranked → score from the ranked team's rank
   - favorite: at least one favorite team involved → flat boost
-
-Signals added in Phase 3:
   - close_game: tight betting spread → score inversely proportional to spread
   - rivalry: known rivalry game → flat boost
   - narrative: LLM-judged narrative score (playoff race, history, stakes)
+  - importance: Lahvička Monte Carlo standings leverage (see compute_match_importance)
 """
 
 from __future__ import annotations
@@ -55,15 +54,12 @@ class Weights:
     rivalry: float = 2.0
     tournament: float = 1.5      # knockout-stage cup games
     narrative: float = 0.0       # LLM narrative score (disabled by default)
-    # Phase C: Lahvička Monte Carlo importance. Per-game raw points are
+    # Lahvička Monte Carlo importance. Per-game raw points are
     # sum_over_(team,outcome) of leverage × consequence_weight (leverage in
     # [0,1] from Kendall tau-c, weight from LEAGUE_CONTEXTS thresholds —
-    # relegation=5, UCL=4, title=5, etc.). C.4 calibration target: 3.0.
-    # That matches the typical "high-leverage relegation game" magnitude
-    # (0.5 leverage × 5 weight × 2 teams = 5 raw, times 3.0 weight = 15
-    # raw — the same order as a Phase-A relegation six-pointer with the
-    # legacy stakes signal). Replaces the legacy stakes + impact_favorite
-    # + _late_season_multiplier signal family (Phase C.4 cutover).
+    # relegation=5, UCL=4, title=5, etc.). 3.0 calibrates such that a
+    # typical high-leverage relegation six-pointer reads ~15 raw points
+    # (0.5 leverage × 5 weight × 2 teams = 5, × 3.0 = 15).
     importance: float = 3.0
 
 
@@ -88,18 +84,13 @@ class GameSignals:
     is_rivalry: bool = False
     narrative_score: Optional[float] = None  # 0-10 from LLM (last)
 
-    # Phase C: Lahvička Monte Carlo importance, pre-weight. The plugin's
-    # _action_refresh calls compute_match_importance for sources that
-    # support it (currently SoccerSource only) and stashes the result here.
-    # Sources that don't support importance leave the points at 0.0 and
-    # score_game's importance block falls through without contributing.
-    #
+    # Lahvička Monte Carlo importance, pre-weight. Sources that don't
+    # implement compute_match_importance leave these at 0 / empty; the
+    # importance block in score_game then contributes nothing.
     # `importance_thresholds_hit` is the deduped list of outcome bands
     # with nonzero leverage on any queried team (the playing teams plus
     # in-league favorites). pick_tagline uses it for editorial taglines
-    # ("relegation race" / "title race"). Replaces the pre-C.4
-    # stakes_thresholds_hit field which was derived from the legacy
-    # proximity heuristic.
+    # ("relegation race" / "title race").
     importance_points: float = 0.0
     importance_notes: List[str] = field(default_factory=list)
     importance_thresholds_hit: List[str] = field(default_factory=list)
@@ -153,9 +144,9 @@ class LeagueContext:
 KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # UEFA cup soccer (UCL / UEL / UECL):
     "PLAYOFFS":        0,  # UCL play-off round (pos 9-24 entrants)
-    # International tournaments (Phase I) use LAST_32 as the entry-level
-    # knockout round in the new 48-team World Cup 2026 format. Same depth
-    # as PLAYOFFS because both are "before LAST_16"; no competition uses
+    # International tournaments use LAST_32 as the entry-level knockout
+    # round in the 48-team World Cup 2026 format. Same depth as
+    # PLAYOFFS because both are "before LAST_16"; no competition uses
     # both stages, so they don't collide in the bracket cascade.
     "LAST_32":         0,
     "LAST_16":         1,
@@ -169,31 +160,30 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "CONF_FINAL":      2,  # Conference finals (2 series)
     "CUP_FINAL":       3,  # Stanley Cup Final (1 series)
     "CUP_WINNER":      4,  # Stanley Cup champion
-    # MLB postseason (Phase F): Wild Card best-of-3 (6 series across both
-    # leagues), Division Series best-of-5 (4 series), LCS best-of-7 (2
-    # series), World Series best-of-7. WC and LDS depths differ — a team
-    # that wins the WC reaches LDS, etc.
+    # MLB postseason: Wild Card best-of-3 (6 series across both leagues),
+    # Division Series best-of-5 (4 series), LCS best-of-7 (2 series),
+    # World Series best-of-7. WC and LDS depths differ — a team that
+    # wins the WC reaches LDS, etc.
     "WC":              0,  # Wild Card Series (entry round)
     "LDS":             1,  # Division Series
     "LCS":             2,  # League Championship Series
     "WS":              3,  # World Series
     "WS_WINNER":       4,  # World Series champion
-    # NBA playoffs (Phase G): 4 rounds, best-of-7 each. R1 depth 0 is
-    # already populated by NHL above; that's fine — the bracket source's
-    # `terminal_outcomes` reads per-league band cutoffs, so R1 sharing a
-    # depth label across NHL and NBA doesn't cause cross-contamination.
+    # NBA playoffs: 4 rounds, best-of-7 each. R1 depth 0 is shared with
+    # NHL above — terminal_outcomes reads per-league band cutoffs so
+    # there's no cross-contamination.
     "CSF":             1,  # Conference Semifinals (4 series)
     "CF":              2,  # Conference Finals (2 series)
     "FINALS":          3,  # NBA Finals (1 series) / WNBA Finals (1 series)
     "FINALS_WINNER":   4,  # NBA Champion
-    # WNBA playoffs (Phase K): 3 rounds, mixed series lengths.
-    # R1 (depth 0) and FINALS (depth 3) reuse the labels already in
-    # this table — terminal_outcomes reads per-league bands so no
-    # cross-contamination. SF needs its own depth between R1 and FINALS.
+    # WNBA playoffs: 3 rounds, mixed series lengths. R1 (depth 0) and
+    # FINALS (depth 3) reuse labels already above — terminal_outcomes
+    # reads per-league bands so no cross-contamination. SF needs its
+    # own depth between R1 and FINALS.
     "SF":              1,  # WNBA Semifinals (between R1 and FINALS)
     "WNBA_WINNER":     4,  # WNBA Champion (same synthetic depth as FINALS_WINNER)
-    # NCAA Women's March Madness (Phase L): 6 rounds, all single-game
-    # elimination. SERIES_LENGTH=1 per stage; first to 1 win clinches.
+    # NCAA Women's March Madness: 6 rounds, all single-game elimination.
+    # SERIES_LENGTH=1 per stage; first to 1 win clinches.
     "R64":             0,  # 1st Round (32 games)
     "R32":             1,  # 2nd Round (16 games)
     "S16":             2,  # Sweet 16 (8 games)
@@ -201,39 +191,29 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "F4":              4,  # Final Four (2 games)
     "NCG":             5,  # National Championship Game
     "NCG_WINNER":      6,  # National Champion
-    # NFL playoffs (Phase P): 4 rounds, single-game elimination.
-    # SERIES_LENGTH=1 per stage; clinches at 1 win. The "WC" label
-    # entry above (depth 0) is shared between MLB Wild Card Series
-    # and NFL Wild Card Playoffs — both happen to be at depth 0 in
-    # their respective brackets, and terminal_outcomes reads
-    # per-league bands so there's no cross-contamination (same
-    # pattern as R1 shared across NHL and NBA, FINALS shared across
-    # NBA and WNBA).
+    # NFL playoffs: 4 rounds, single-game elimination. The "WC" label
+    # above (depth 0) is shared with MLB Wild Card Series — both happen
+    # to be at depth 0 in their respective brackets, and
+    # terminal_outcomes reads per-league bands.
     "DIV":             1,  # Divisional Playoffs
     "CONF":            2,  # Conference Championship
     "SB":              3,  # Super Bowl
     "SB_WINNER":       4,  # Super Bowl Champion
-    # NCAA Baseball College World Series (Phase O Phase 1: super-regional
-    # + finals only — both are cleanly-labeled best-of-3 in ESPN data).
-    # DO NOT treat the BSB_REG / MCWS depths as reachable yet: Phase 1
-    # only emits BSB_SR and MCWS_F ties, so a team caps at MCWS_F depth
-    # (advancing winners → MCWS_W). The intermediate depths exist in
-    # this table so the LEAGUE_CONTEXTS thresholds can label them with
-    # forward-compatible names; Phase 2 (#43) wires the regional
-    # double-elim and 8-team MCWS bracket via chronological inference
-    # so those depths actually fire.
-    "BSB_REG":         0,  # Regional (16 sites × 4 teams, double-elim; Phase 2)
+    # NCAA Baseball College World Series. Only the cleanly-labeled
+    # best-of-3 stages (BSB_SR, MCWS_F) are currently emitted as ties;
+    # BSB_REG and MCWS are forward-compat depth placeholders that #43
+    # wires up via chronological inference of the double-elim brackets.
+    "BSB_REG":         0,  # Regional (16 sites × 4 teams, double-elim; #43)
     "BSB_SR":          1,  # Super Regional (8 sites × 2 teams, best-of-3)
-    "MCWS":            2,  # 8-team double-elim in Omaha (Phase 2)
+    "MCWS":            2,  # 8-team double-elim in Omaha (#43)
     "MCWS_F":          3,  # Championship Final (best-of-3)
     "MCWS_W":          4,  # MCWS Champion
-    # NCAA Softball Women's College World Series (Phase O Phase 1):
-    # parallel to baseball above. Same Phase 1 limitation — only SB_SR
-    # and WCWS_F are emitted by the source; the intermediate stages are
-    # forward-compat placeholders for Phase 2.
-    "SB_REG":          0,  # Regional (Phase 2)
+    # NCAA Softball Women's College World Series. Parallel to baseball:
+    # only SB_SR and WCWS_F are currently emitted; SB_REG and WCWS are
+    # forward-compat placeholders for #43.
+    "SB_REG":          0,  # Regional (#43)
     "SB_SR":           1,  # Super Regional (best-of-3)
-    "WCWS":            2,  # 8-team double-elim in OKC (Phase 2)
+    "WCWS":            2,  # 8-team double-elim in OKC (#43)
     "WCWS_F":          3,  # Championship Finals (best-of-3)
     "WCWS_W":          4,  # WCWS Champion
 }
@@ -270,7 +250,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R16 → QF → SF → Final → Champion",
     ),
-    # Phase H: top-flight European leagues. Slot semantics differ by league:
+    # Top-flight European leagues. Slot semantics differ by league:
     #   - UCL slots: Bundesliga 4, La Liga 4, Serie A 4, Ligue 1 3 (one
     #     fewer; FL1's 4th place enters UEL/UECL playoff).
     #   - Bundesliga: 16th plays relegation playoff vs Bundesliga 2's 3rd;
@@ -322,7 +302,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
-    # Phase Q: Eredivisie (Netherlands). 18 teams, 34 matchdays. Top 1
+    # Eredivisie (Netherlands). 18 teams, 34 matchdays. Top 1
     # direct UCL group stage; 2-3 UCL qualifying; 4-5 Europa/Conference
     # qualifying; bottom 1 direct relegation, 16-17 relegation playoff
     # (we use cutoff=15 to fire the relegation band for 16/17/18 like
@@ -337,7 +317,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
-    # Phase Q: Primeira Liga (Portugal). 18 teams, 34 matchdays. Same
+    # Primeira Liga (Portugal). 18 teams, 34 matchdays. Same
     # slot semantics as Eredivisie — 2 direct UCL spots, 3rd UCL
     # qualifying, 4-5 Europa, bottom 3 relegation.
     "PPL": LeagueContext(
@@ -350,7 +330,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
-    # Phase Q: Brazilian Série A. 20 teams, 38 matchdays. Different
+    # Brazilian Série A. 20 teams, 38 matchdays. Different
     # slot semantics from Euro leagues — continental qualifications
     # are for Copa Libertadores (top 6 in modern era) and Copa
     # Sudamericana (7-12). No UCL line. Bottom 4 relegated to Série B.
@@ -364,7 +344,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Top 6 → Libertadores · 7-12 → Sudamericana · bottom 4 → relegation",
     ),
-    # Phase I: international tournaments.
+    # International tournaments.
     #
     # World Cup 2026 onward uses the 48-team format: 12 groups of 4, top
     # 2 + best 8 third-place advance to a LAST_32 round. Pre-2026 World
@@ -406,7 +386,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R16 → QF → SF → Final → Champion (UEFA EURO)",
     ),
-    # Phase M: NCAA Division I baseball regular season. Win-count
+    # NCAA Division I baseball regular season. Win-count
     # thresholds tuned against historical NCAA Tournament selection
     # criteria — ~35 wins is the rough at-large cutoff, 45+ wins puts
     # a team in national-seed (top 16) contention. Seasons run Feb-June
@@ -424,16 +404,15 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="30+ wins → tournament bubble · 35+ → at-large lock · 45+ → national seed",
     ),
-    # Phase O Phase 1: NCAA Baseball postseason. Only the cleanly-labeled
-    # best-of-3 stages (Super Regional, MCWS Finals) are modeled. Regional
-    # double-elim and the 8-team MCWS bracket lack game-level metadata in
-    # ESPN's data and require chronological inference (Phase 2: #43).
-    # Threshold weights match the existing MLB_PO scale: each round-deeper
-    # reach roughly doubles consequence. The "omaha_bound" band fires for
-    # teams that win their Super Regional (depth 2 reached via the
-    # _winner_advance_label hop on MCWS_F), even though Phase 1 doesn't
-    # actually model the 8-team MCWS bracket — the depth label captures
-    # the structural reality that a Super Regional winner IS Omaha-bound.
+    # NCAA Baseball postseason. The cleanly-labeled best-of-3 stages
+    # (Super Regional, MCWS Finals) are modeled. Regional double-elim
+    # and the 8-team MCWS bracket lack game-level ESPN metadata and
+    # require chronological inference — tracked in #43. Threshold
+    # weights match the MLB_PO scale: each round-deeper reach roughly
+    # doubles consequence. The "omaha_bound" band fires for Super
+    # Regional winners (depth 2 reached via the _winner_advance_label
+    # hop on BSB_SR → MCWS), capturing the structural reality that a
+    # Super Regional winner IS Omaha-bound.
     "MCWS_PO": LeagueContext(
         code="MCWS_PO", matchdays_total=0, format="knockout",
         thresholds=[
@@ -444,7 +423,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Super Regional → Omaha → CWS Final → Champion",
     ),
-    # Phase O: NCAA Division I soccer (Men's and Women's). Standings-points
+    # NCAA Division I soccer (Men's and Women's). Standings-points
     # format (3 W / 1 D / 0 L) because draws are common in college soccer
     # and a draw-heavy team's WIN count understates their tournament
     # position. A team going 13-3-8 has 13 wins but 47 standings points
@@ -474,7 +453,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="25+ pts → bubble · 35+ → at-large lock · 45+ → top regional · 50+ → national seed (Women's)",
     ),
-    # Phase D.2 / D.3: NCAA football and men's basketball. Format is
+    # NCAA football and men's basketball. Format is
     # "win_count" — threshold cutoffs are MINIMUM win counts rather than
     # position cutoffs (the SoccerSource interpretation). The points-
     # based source's `terminal_outcomes` assigns a label when a team's
@@ -499,7 +478,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="15+ wins → NIT bubble · 20+ → NCAA bid · 25+ → elite",
     ),
-    # Phase E: NHL regular season uses STANDINGS POINTS (regulation win = 2,
+    # NHL regular season uses STANDINGS POINTS (regulation win = 2,
     # OT/SO loss = 1, regulation loss = 0) rather than raw wins because the
     # OT-loss bonus point makes a team with many OTLs look bubble-bound by
     # win count when they are actually playoff-locked. Bands chosen against
@@ -515,7 +494,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="95+ pts → playoff bubble · 100+ → comfortable · 110+ → div lead · 125+ → Presidents'",
     ),
-    # Phase E: NHL Stanley Cup Playoffs (4 rounds, best-of-7 each).
+    # NHL Stanley Cup Playoffs (4 rounds, best-of-7 each).
     # Round structure is identical across both conferences: 16 teams in,
     # 1 champion out. Weights ramp aggressively into the Cup Final because
     # a Game 6 / Game 7 SCF is the single highest-leverage game any NHL
@@ -530,7 +509,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R1 → R2 → Conf Final → Cup Final → Champion",
     ),
-    # Phase F: MLB regular season. 162-game season; the playoff bubble has
+    # MLB regular season. 162-game season; the playoff bubble has
     # historically settled around 85-86 wins (3rd Wild Card cutoff post-
     # 2022 expansion), with division winners typically in the 90-100 win
     # range. 105+ has been a "best record in baseball" outlier most years.
@@ -545,7 +524,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="85+ wins → bubble · 90+ → comfortable · 95+ → div lead · 105+ → elite",
     ),
-    # Phase F: MLB postseason. Series lengths vary (WC=3, LDS=5, LCS=7,
+    # MLB postseason. Series lengths vary (WC=3, LDS=5, LCS=7,
     # WS=7), so the leverage ramp into the World Series is sharper than
     # NHL's Stanley Cup ramp — fewer total games means each single game
     # carries more series-decision weight. Weights tuned to put a Game 7
@@ -563,7 +542,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="WC → LDS → LCS → WS → Champion",
     ),
-    # Phase G: NBA regular season. 82-game season; play-in tournament
+    # NBA regular season. 82-game season; play-in tournament
     # (since 2020) opens 9th and 10th seeds onto the bracket via a
     # mini-playoff, but the play-in is structurally between the
     # regular season and the bracket — we treat it as separate from
@@ -583,7 +562,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="40+ wins → play-in · 50+ → comfortable · 55+ → top seed · 65+ → elite",
     ),
-    # Phase G: NBA playoffs. 4 rounds (R1 / CSF / CF / FINALS),
+    # NBA playoffs. 4 rounds (R1 / CSF / CF / FINALS),
     # best-of-7 each. Same structural shape as NHL Stanley Cup
     # Playoffs — weights mirror NHL's ramp because the
     # consequence-weight calibration is consistent across pro
@@ -598,7 +577,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R1 → Conf Semis → Conf Finals → NBA Finals → Champion",
     ),
-    # Phase K: WNBA regular season. 40-game season; 8 of 12-13 teams
+    # WNBA regular season. 40-game season; 8 of 12-13 teams
     # make playoffs (since 2022's expansion). The playoff bubble has
     # historically settled around 19-21 wins; top seed pace is ~28-32
     # in the current era. Thresholds are tighter than NBA's because
@@ -614,7 +593,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="20+ wins → bubble · 25+ → comfortable · 30+ → top seed · 35+ → elite",
     ),
-    # Phase K: WNBA playoffs. Three rounds with variable series
+    # WNBA playoffs. Three rounds with variable series
     # lengths (R1=3, SF=5, FINALS=5 in 2024 or 7 in 2025+). Weights
     # mirror NBA's playoff ramp; bracket structure differs (no
     # conference reseeding, fewer total games).
@@ -627,7 +606,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R1 → Semis → WNBA Finals → Champion",
     ),
-    # Phase L: NCAA Women's Basketball regular season. ~32-game D1 season;
+    # NCAA Women's Basketball regular season. ~32-game D1 season;
     # 64 teams make the NCAA Tournament. Threshold bands cover the
     # selection / seeding lines: 20 wins is the rough at-large bubble
     # for power-conf teams, 25+ is a comfortable at-large lock, 28+
@@ -642,7 +621,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="20+ wins → bubble · 25+ → at-large lock · 28+ → top-4 seed · 32+ → #1 seed",
     ),
-    # Phase L: NCAA Women's March Madness. 6 rounds, single-game
+    # NCAA Women's March Madness. 6 rounds, single-game
     # elimination at each step. Weights ramp steeper than the pro
     # bracket leagues because single-game elim concentrates leverage
     # — every game IS the series for the round.
@@ -658,7 +637,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="R64 → R32 → Sweet 16 → Elite 8 → Final Four → NCG → Champion",
     ),
-    # Phase N: NCAA Division I Softball regular season. ~55-game season,
+    # NCAA Division I Softball regular season. ~55-game season,
     # 64-team NCAA Tournament. Selection bands mirror BSB but tuned
     # slightly tighter — softball's RPI bar tends to clear at lower
     # win totals because the field is smaller / more concentrated.
@@ -675,10 +654,10 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="30+ wins → bubble · 35+ → at-large lock · 40+ → top regional · 45+ → national seed · 50+ → #1 overall",
     ),
-    # Phase O Phase 1: NCAA Softball WCWS. Parallel to MCWS_PO above.
-    # Only Super Regional + WCWS Finals (best-of-3 stages with ESPN
-    # game numbers) are modeled. Regional double-elim and 8-team WCWS
-    # bracket games are Phase 2.
+    # NCAA Softball WCWS. Parallel to MCWS_PO above. The cleanly-
+    # labeled best-of-3 stages (Super Regional + WCWS Finals) are
+    # modeled; Regional double-elim and 8-team WCWS bracket are
+    # tracked in #43.
     "WCWS_PO": LeagueContext(
         code="WCWS_PO", matchdays_total=0, format="knockout",
         thresholds=[
@@ -689,7 +668,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="Super Regional → OKC → WCWS Final → Champion",
     ),
-    # Phase P: NFL regular season. 17-game season since 2021;
+    # NFL regular season. 17-game season since 2021;
     # 14 teams make playoffs (7 per conference, including a 7th seed
     # added in 2020). 9 wins has been the modern playoff bubble line;
     # 11 wins typically locks a division; 13+ is #1-seed pace.
@@ -703,10 +682,10 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="7+ wins → bubble · 9+ → comfortable · 11+ → division · 13+ → #1 seed",
     ),
-    # Phase P: NFL playoffs. 4 rounds, single-game elimination.
+    # NFL playoffs. 4 rounds, single-game elimination.
     # Weights ramp aggressively because single-elim concentrates
     # leverage — a Wild Card upset eliminates a 12-win team in one
-    # game. Same shape as March Madness (Phase L) but 4 rounds
+    # game. Same shape as March Madness above but 4 rounds
     # instead of 6 because the field is 14 teams (7 per conference)
     # not 64.
     "NFL_PO": LeagueContext(
@@ -882,14 +861,13 @@ def score_game(signals: GameSignals, weights: Weights) -> GameScore:
             "ROUND_OF_16": 1.5, "LAST_16": 1.5,
             "ROUND_OF_32": 1.0, "LAST_32": 1.0,
             "PLAYOFF_ROUND": 1.0, "PLAYOFFS": 1.0,
-            # Phase R: field events (F1 GP, NASCAR race, golf tour
-            # weekly events). These have no two-team head-to-head
+            # Field events (F1 GP, NASCAR race, golf tour weekly
+            # events). These have no two-team head-to-head
             # structure so the rank / favorite / closeness signals
             # don't apply — the tournament_stage band is what gets
             # them into the guide at all. "MAJOR" is for golf's four
             # majors (Masters / PGA / US Open / British Open) and
-            # any future marquee racing event we want bumped above
-            # the regular tour.
+            # marquee racing events the source flags as MAJOR.
             "EVENT": 1.5,
             "MAJOR": 4.5,
         }.get(ts, 0.0)
@@ -907,13 +885,11 @@ def score_game(signals: GameSignals, weights: Weights) -> GameScore:
         breakdown["narrative"] = round(narr_pts, 2)
         notes.append(f"LLM narrative score: {signals.narrative_score:.1f}/10")
 
-    # Phase C: Monte Carlo importance (Lahvička). Already pre-weighted by
+    # Monte Carlo importance (Lahvička). Already pre-weighted by
     # consequence inside compute_match_importance; multiply only by the
-    # user's weight_importance tunable here. Sources that don't support
-    # importance (NCAAFSource, NCAAMSource, knockout-only soccer) leave
-    # importance_points at 0.0 and this block falls through. Gating BOTH
-    # the points AND the weight keeps the breakdown clean when the user
-    # disables the signal via weight_importance=0 — no 0.0 stub entries.
+    # user's weight_importance tunable here. Gating BOTH the points AND
+    # the weight keeps the breakdown clean when the user disables the
+    # signal via weight_importance=0 — no 0.0 stub entries.
     if signals.importance_points > 0 and weights.importance > 0:
         imp_pts = signals.importance_points * weights.importance
         breakdown["importance"] = round(imp_pts, 2)
@@ -949,9 +925,7 @@ def compute_match_importance(
       - Every favorite in `favorites_in_league` who ISN'T already in the
         match (cross-team importance — this match's result affects the
         favorite's standings outcome, even though the favorite isn't
-        playing). Restores the impact-on-favorites signal structurally —
-        the legacy `compute_impact_on_favorites` proximity heuristic is
-        retired in Phase C.4 because Monte Carlo handles it correctly.
+        playing).
 
     Returns `(raw_points, notes, thresholds_hit)` where:
       - `raw_points` is the sum of (leverage × weight) over all queries.

--- a/sources/base.py
+++ b/sources/base.py
@@ -4,10 +4,10 @@ A SportSource fetches the upcoming games for one sport/league and the current
 ranks (if any) and returns GameRow records. The plugin then scores each row
 and matches it to a Dispatcharr channel via EPG.
 
-Phase C adds an OPTIONAL Monte Carlo importance interface — 7 methods plus a
-`supports_importance` flag. Sources that implement them get importance-aware
-scoring (Lahvička 2012); sources that don't keep the legacy stakes/impact
-path. The simulator inspects the flag before calling. See simulation.py.
+Sources optionally implement a Monte Carlo importance interface (Lahvička
+2012) — 7 methods plus a `supports_importance` flag. Sources that flip the
+flag MUST override all 7; the simulator (simulation.py) inspects the flag
+before calling and falls through gracefully when it's false.
 """
 
 from __future__ import annotations
@@ -30,8 +30,8 @@ class GameRow:
     rank_away: Optional[int]
     start_time: datetime        # when the game starts (UTC)
     venue: Optional[str] = None
-    spread: Optional[float] = None      # absolute pre-game spread (Phase 3+)
-    # B.3 close-game signal: bookmaker-implied coinflip-ness in [0, 1].
+    spread: Optional[float] = None      # absolute pre-game spread
+    # Close-game signal: bookmaker-implied coinflip-ness in [0, 1].
     # 1.0 = pick'em (both teams equally likely to win); 0.0 = blowout.
     # Soccer populates this from the h2h moneyline market (devigged
     # probabilities, then 2 * min(p_home, p_away)). NCAAF / NCAAM still
@@ -40,7 +40,7 @@ class GameRow:
     # is None on every GameRow. DO NOT set both — keeps the contract
     # "closeness wins if present, fall back to spread otherwise" honest.
     closeness: Optional[float] = None
-    is_rivalry: bool = False             # known rivalry (Phase 3+)
+    is_rivalry: bool = False             # known rivalry
     extra: dict = field(default_factory=dict)  # source-specific metadata
 
 
@@ -48,12 +48,11 @@ class GameRow:
 class MatchResult:
     """One sampled match outcome. Used by the Monte Carlo importance simulator.
 
-    For soccer / NCAAF / NCAAM we always have integer goals/points; ties
-    (draws) are encoded as home_goals == away_goals (legal in soccer,
-    vanishingly rare in NCAAF — sources that ban draws should never sample
-    one). Sub-game state (penalty shootouts in cup knockouts, OT in CFB) is
-    encoded in `extra` per source; the simulator core only reads the goal
-    counts.
+    Integer goals/points; ties (draws) are encoded as home_goals == away_goals
+    (legal in soccer, vanishingly rare in NCAAF — sources that ban draws
+    should never sample one). Sub-game state (penalty shootouts in cup
+    knockouts, OT in CFB) is encoded in `extra` per source; the simulator
+    core only reads the goal counts.
     """
     home_goals: int
     away_goals: int
@@ -63,14 +62,10 @@ class MatchResult:
 class SportSource(ABC):
     """Adapter contract."""
 
-    # ---------- Phase C: Monte Carlo importance opt-in ----------
-    # Sources that implement the 7 importance methods below set this to True.
-    # The simulator (simulation.py) checks this flag before calling the
-    # methods; falsy → caller skips importance for this source's games and
-    # falls back to legacy stakes/impact signals.
-    #
-    # Class-level default is False so existing sources (NCAAFSource,
-    # NCAAMSource, etc.) opt out without needing a code change.
+    # Monte Carlo importance opt-in. Sources that implement the 7 importance
+    # methods below flip this to True; the simulator (simulation.py) checks
+    # the flag before calling the methods and contributes zero importance
+    # points for this source's games when it's false.
     supports_importance: bool = False
 
     @property
@@ -88,7 +83,7 @@ class SportSource(ABC):
         """Return upcoming games in the next `days_ahead` days. Empty list during
         offseason. Caller does not need to filter by date."""
 
-    # ---------- Phase C: Monte Carlo importance interface ----------
+    # ---------- Monte Carlo importance interface ----------
     # All 7 default to NotImplementedError. Sources that flip
     # `supports_importance = True` MUST override all of them; the simulator
     # calls each one per sim iteration.

--- a/sources/bracket.py
+++ b/sources/bracket.py
@@ -781,11 +781,11 @@ class DoubleEliminationSource(BracketSportSource):
         idempotent under multiple calls with the same winner — each
         loser still caps at `stage_depth`, the winner is still set to
         `winner_depth` via `max()`.
-      - Phase 2a is SOURCE-DRIVEN ONLY: `_emit_remaining_games_for_tie`
-        emits the source-published games (in chronological order) that
-        haven't been applied yet. It does NOT synthesize speculative
-        future games from the double-elim game tree — that's a Phase 2b
-        responsibility once live source data is being wired in.
+      - Source-driven only: `_emit_remaining_games_for_tie` emits the
+        source-published games (in chronological order) that haven't
+        been applied yet. It does NOT synthesize speculative future
+        games from the double-elim game tree — that's a #43 follow-up
+        once live source data is wired in.
 
     Subclass contract: implement `_fetch_bracket_games` (inherited) AND
     `_tie_grouping_key(game)` (new). Set `KO_STAGES` and
@@ -878,7 +878,7 @@ class DoubleEliminationSource(BracketSportSource):
         """Group games by (stage, _tie_grouping_key(game)) into tie_meta
         records carrying the full participant set. feeds_from wiring is
         intentionally empty for double-elim: each sub-bracket tie is an
-        entry tie at its stage (Phase 2a doesn't connect Regional →
+        entry tie at its stage (this class doesn't connect Regional →
         Super Regional structurally — that handoff lives in the
         regular-season-strength sharing already on the playoff sources).
         """

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -4,16 +4,16 @@ Racing and golf don't fit the team-based GameRow model because they're
 field events: one race or tournament with 20+ competitors and a
 finishing order, not a head-to-head outcome between two teams.
 
-V1 design (Phase R)
+Design:
 
   - Emit one GameRow per scheduled event, with `home = event_name`
     (e.g., "Heineken Chinese GP", "The Masters") and `away = "Field"`
     as a sentinel.
   - Tag with `tournament_stage = "EVENT"` (regular tour stop) or
-    `"MAJOR"` (golf majors / future marquee racing events). The
-    scoring layer's `tournament` signal handles the rest; both labels
-    map to non-zero stage_score so field events always surface in the
-    guide when toggled on.
+    `"MAJOR"` (golf majors / marquee racing events the source flags
+    as MAJOR). The scoring layer's `tournament` signal handles the
+    rest; both labels map to non-zero stage_score so field events
+    always surface in the guide when toggled on.
   - No importance simulation, no closeness, no rank — the rarity of
     these events (~1/week) means just-show-it-up is the right product.
     The matcher fuzzy-matches the event name against EPG titles.
@@ -53,14 +53,14 @@ class FieldEventSource(SportSource):
       - `SPORT_PREFIX`: short channel-name prefix.
       - `SPORT_LABEL`: human-readable label.
       - `FD_COMPETITION_CODE`: arbitrary string carried through extra
-        for future routing.
+        for downstream routing (e.g., score-breakdown attribution).
       - `MAJOR_REGEX`: optional compiled regex; when an event name
         matches, the event is tagged tournament_stage="MAJOR"
         (otherwise "EVENT"). Default None means everything is "EVENT".
     """
 
     # supports_importance left at the SportSource default (False).
-    # Field events surface via the tournament signal alone in V1.
+    # Field events surface via the tournament signal alone.
 
     ESPN_SLUG: str = ""
     SPORT_PREFIX: str = ""
@@ -169,7 +169,7 @@ class F1Source(FieldEventSource):
 class NascarSource(FieldEventSource):
     """NASCAR Cup Series — ~36 races per year, including the Daytona
     500 (season opener) and the Coca-Cola 600. Both are 'crown jewels'
-    but for V1 every race is EVENT-tier."""
+    but currently every race is EVENT-tier (no MAJOR_REGEX set)."""
 
     ESPN_SLUG = "racing/nascar-premier"
     SPORT_PREFIX = "NASCAR"

--- a/sources/liga_mx.py
+++ b/sources/liga_mx.py
@@ -1,7 +1,7 @@
 """Liga MX source — ESPN unofficial + Odds API closeness.
 
-Same V1 minimal pattern as MlsSource (Phase J): schedule + closeness
-only, no standings-based importance or Liguilla playoff bracket.
+Same minimal pattern as MlsSource: schedule + closeness only. No
+standings-based importance or Liguilla playoff bracket (#30).
 
 Liga MX runs two seasons per calendar year (Apertura ≈ Jul-Dec,
 Clausura ≈ Jan-May), each followed by a 12-team Liguilla playoff.

--- a/sources/mlb.py
+++ b/sources/mlb.py
@@ -34,7 +34,7 @@ API quirks captured here:
     endpoint — use full name as the canonical key.
 
 The plugin opts into MLB via the `enable_mlb` boolean in `plugin.json`.
-Off by default; baseball coverage is new in Phase F.
+Off by default.
 """
 
 from __future__ import annotations

--- a/sources/mls.py
+++ b/sources/mls.py
@@ -1,8 +1,8 @@
 """MLS source — ESPN's unofficial `site.api.espn.com` for the schedule
-+ The Odds API for closeness. No standings-based importance simulation
-in V1; MLS games surface with `favorite + closeness` scoring only.
++ The Odds API for closeness. MLS games surface with `favorite +
+closeness` scoring only; standings-based importance is filed as #30.
 
-V1 scope (Phase J)
+Scope:
 
   - `fetch_upcoming` returns the next-N-day MLS schedule (regular
     season AND playoffs, undifferentiated). Game records carry
@@ -11,8 +11,8 @@ V1 scope (Phase J)
   - **No** `supports_importance` flag. MLS Cup playoff bracket is
     structurally awkward (best-of-3 first round, single-leg subsequent
     rounds — neither BestOfNSeriesSource nor AggregateLegSource fits
-    cleanly) and conference-standings importance needs its own
-    bands. Both are filed as Phase J follow-ups.
+    cleanly); conference-standings importance needs its own bands.
+    Both are tracked in #30.
   - The Odds API sport key is `soccer_usa_mls`. The Odds API team
     names ("LA Galaxy") often drop the FC/SC tag ESPN includes
     ("LA Galaxy" → "LA Galaxy", but "New York Red Bulls" vs ESPN's
@@ -136,17 +136,16 @@ def _h2h_to_closeness(
 
 
 class MlsSource(SportSource):
-    """MLS schedule + closeness signal. V1 omits standings-based
-    importance and the MLS Cup playoff bracket — see follow-up issues
-    filed under Phase J.
+    """MLS schedule + closeness signal. Standings-based importance and
+    MLS Cup playoff bracket modeling are tracked in #30.
 
     Class attrs `_ESPN_SLUG`, `_ODDS_SPORT_KEY`, `_FD_CODE`,
-    `_SPORT_PREFIX`, `_SPORT_LABEL` parameterize the league. Phase Q
-    NwslSource and LigaMxSource subclass this and override these
-    five attrs — the rest of the fetch/closeness machinery is shared.
+    `_SPORT_PREFIX`, `_SPORT_LABEL` parameterize the league. NwslSource
+    and LigaMxSource subclass this and override these five attrs — the
+    rest of the fetch/closeness machinery is shared.
     """
 
-    # NOT supports_importance: the importance simulator skips MLS in V1.
+    # NOT supports_importance: the importance simulator skips MLS.
     # Importance comes from `favorite` + `closeness` only.
 
     # Per-league configuration (subclasses override):
@@ -224,12 +223,12 @@ class MlsSource(SportSource):
                 closeness = self._lookup_closeness(closeness_by_pair, home, away)
                 # ESPN exposes the season/playoff stage in
                 # `event.season.slug`. Carry it through as
-                # `extra.season_slug` so future importance work can
-                # route on it without re-fetching. MLS values:
-                # "regular-season", "mls-cup", "mls-cup-playoffs".
-                # NWSL: "regular-season", "nwsl-playoffs", etc.
-                # Liga MX: "torneo-apertura", "torneo-clausura",
-                # "liguilla" (the Apertura/Clausura playoff).
+                # `extra.season_slug` for downstream consumers (the
+                # importance simulator filed under #30 will route on
+                # it). MLS values: "regular-season", "mls-cup",
+                # "mls-cup-playoffs". NWSL: "regular-season",
+                # "nwsl-playoffs", etc. Liga MX: "torneo-apertura",
+                # "torneo-clausura", "liguilla".
                 season_slug = ((event.get("season") or {}).get("slug") or "")
                 out.append(GameRow(
                     sport_prefix=self.sport_prefix,

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -10,12 +10,13 @@ Two source classes ship under the `enable_ncaa_baseball` toggle:
   - `NcaaBaseballRegularSource(PointsBasedSportSource)`: regular-season
     win-count importance. Tournament-bubble through national-seed bands
     (see LEAGUE_CONTEXTS["BSB"]).
-  - `NcaaBaseballPlayoffSource(BestOfNSeriesSource)`: postseason. Phase 1
-    ships the cleanly-labeled best-of-3 stages — Super Regional and the
-    MCWS Championship Final. Regional (4-team double-elim per site) and
-    the 8-team MCWS bracket in Omaha are Phase 2 (#43): ESPN headlines
-    on those stages carry no game-number or bracket-position metadata,
-    so chronological inference is needed and that's a separate design.
+  - `NcaaBaseballPlayoffSource(BestOfNSeriesSource)`: postseason.
+    Currently models the best-of-3 stages — Super Regional and MCWS
+    Championship Final — both of which carry clean ESPN game-number
+    metadata. Regional (4-team double-elim per site) and the 8-team
+    MCWS bracket in Omaha are tracked in #43: ESPN headlines on those
+    stages carry no game-number or bracket-position metadata, requiring
+    chronological inference.
 
 API endpoints used:
   - /apis/site/v2/sports/baseball/college-baseball/scoreboard
@@ -114,10 +115,9 @@ def _is_postseason_event(event: Dict[str, Any]) -> bool:
       - 6: Championship Finals (best-of-3 in Omaha / OKC).
 
     The regular-season source filters these out; the playoff source
-    filters them in. Headline parsing further narrows to the stages we
-    actually model (Phase 1: SUPER_REGIONAL + FINALS only — the others
-    are headline-metadata-poor and require chronological inference for
-    Phase 2).
+    filters them in. Headline parsing further narrows to the stages
+    actually modeled (SUPER_REGIONAL + FINALS); the Regional and 8-team
+    MCWS bracket stages are headline-metadata-poor and tracked in #43.
 
     DO NOT use the `notes[].headline` "Championship" substring as a
     postseason discriminator — D1 conference tournaments in May use
@@ -361,7 +361,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
 
 
 # =====================================================================
-# NcaaBaseballPlayoffSource — Phase 1 best-of-3 stages
+# NcaaBaseballPlayoffSource — best-of-3 stages (Super Regional + MCWS Final)
 # =====================================================================
 
 
@@ -378,11 +378,11 @@ _FINALS_MARKER = "Championship Final - Game "
 
 
 def _parse_baseball_playoff_headline(headline: str) -> Tuple[Optional[str], Optional[int]]:
-    """Map an ESPN postseason headline to (stage, game_index) for the
-    Phase 1 best-of-3 stages. Returns (None, None) for Regional games
-    (no game number, no bracket position — Phase 2) and the MCWS bracket
-    games ("Men's College World Series - Double Elimination Round" /
-    "Elimination Game", also Phase 2).
+    """Map an ESPN postseason headline to (stage, game_index). Returns
+    (None, None) for Regional games (no game number, no bracket position)
+    and MCWS 8-team bracket games ("Men's College World Series - Double
+    Elimination Round" / "Elimination Game") — those stages are tracked
+    in #43.
 
     Patterns observed in 2025-2026 ESPN data:
       - "NCAA Baseball Championship - Auburn Super Regional - Game 1"
@@ -399,20 +399,20 @@ def _parse_baseball_playoff_headline(headline: str) -> Tuple[Optional[str], Opti
 
 
 class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
-    """NCAA Baseball postseason — Phase 1: Super Regional + MCWS Finals.
+    """NCAA Baseball postseason: Super Regional + MCWS Finals.
 
     Both stages are best-of-3 (`SERIES_LENGTH = 3`) with ESPN headlines
     that carry the game number, so the BestOfNSeriesSource infrastructure
     fits cleanly. The intermediate Regional (4-team double-elim per
     site) and 8-team MCWS bracket in Omaha lack game-number metadata in
-    ESPN's data and require chronological inference — Phase 2 (#43).
+    ESPN's data and require chronological inference — tracked in #43.
 
-    The forward-compatible depth structure (BSB_REG=0 → BSB_SR=1 → MCWS=2
-    → MCWS_F=3 → MCWS_W=4) means Phase 2 can extend KO_STAGES without
-    touching threshold labels in LEAGUE_CONTEXTS["MCWS_PO"]. The
-    `omaha_bound` band (depth 2) fires for Super Regional WINNERS in
-    Phase 1 because `_winner_advance_label("BSB_SR")` returns None →
-    default `stage_depth + 1` rule → winner gets depth 2 (= MCWS depth).
+    The depth structure (BSB_REG=0 → BSB_SR=1 → MCWS=2 → MCWS_F=3 →
+    MCWS_W=4) lets #43 extend KO_STAGES without touching threshold
+    labels in LEAGUE_CONTEXTS["MCWS_PO"]. The `omaha_bound` band
+    (depth 2) fires for Super Regional WINNERS because
+    `_winner_advance_label("BSB_SR")` returns None → default
+    `stage_depth + 1` rule → winner gets depth 2 (= MCWS depth).
 
     Strength sharing: pre-postseason, the plugin pulls regular-season
     strength estimates from NcaaBaseballRegularSource and seeds them
@@ -456,7 +456,7 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
     def _winner_advance_label(self, stage: str) -> Optional[str]:
         # MCWS Final winner → MCWS_W (depth 4). Super Regional winner
         # advances via the default `stage_depth + 1` rule → depth 2,
-        # which is the placeholder MCWS depth (8-team bracket; Phase 2).
+        # which is the MCWS bracket depth (modeled in #43).
         if stage == "MCWS_F":
             return "MCWS_W"
         return None
@@ -467,17 +467,17 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
         """Pull next-N-day postseason games. Same per-day scoreboard
         sweep as the regular-season source but with `_is_postseason_event`
         flipped (filter IN postseason). Headlines are then parsed via
-        `_parse_baseball_playoff_headline`; only stages Phase 1 models
+        `_parse_baseball_playoff_headline`; only the modeled stages
         (Super Regional + MCWS Finals) survive — Regional and 8-team
         MCWS bracket games are silently dropped here AND from the
-        regular-season source's sibling fetch. They are entirely absent
-        from the curated guide until Phase 2 ships.
+        regular-season source's sibling fetch. Those stages are tracked
+        in #43.
 
-        DO NOT lift the headline filter without also implementing
-        Phase 2 chronological inference: doing so would emit Regional
-        games with `fd_competition_code="MCWS_PO"` and the importance
-        simulator would see them with no upstream feeders, producing
-        an under-informed leverage signal that's worse than no signal.
+        DO NOT lift the headline filter without also implementing the
+        #43 chronological inference: doing so would emit Regional games
+        with `fd_competition_code="MCWS_PO"` and the importance simulator
+        would see them with no upstream feeders, producing an under-
+        informed leverage signal that's worse than no signal.
         """
         today = datetime.now(timezone.utc).date()
         out: List[GameRow] = []
@@ -602,8 +602,8 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
 
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
         """Sweep the postseason date window day-by-day, filter to
-        season.type=3 events with a Phase 1 stage headline, and emit
-        the bracket per-game record shape.
+        postseason events whose headline matches a modeled stage, and
+        emit the bracket per-game record shape.
 
         Window: May 25 (selection day; Regional play starts Friday of
         Memorial Day weekend) through July 1 (worst-case Finals slip).
@@ -633,7 +633,8 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
         """Convert one ESPN postseason event into the bracket per-game
         record shape (`game_id`, `stage`, `matchday`, `home`, `away`,
         `home_goals`, `away_goals`, `status`, `start_time`, `extra`).
-        Returns None for stages we don't model in Phase 1.
+        Returns None for stages whose headlines don't match a modeled
+        stage marker (Regional + 8-team MCWS bracket; see #43).
         """
         comps = event.get("competitions") or []
         if not comps:

--- a/sources/ncaa_soccer.py
+++ b/sources/ncaa_soccer.py
@@ -15,11 +15,11 @@ men's, 2025) has only 13 wins but 47 standings points — without the
 draws credit the win-count thresholds would misclassify them as
 bubble when they're a national seed contender.
 
-College Cup postseason bracket is NOT modeled in V1. Filed as
-follow-up; same shape as the WC / EURO knockout (single-leg
-elimination), so the existing KnockoutSoccerSource machinery can
-absorb it later. fetch_upcoming still surfaces postseason games via
-rank + favorite signals.
+College Cup postseason bracket is NOT modeled — same shape as the
+WC / EURO knockout (single-leg elimination), so the existing
+KnockoutSoccerSource machinery can absorb it when wired up.
+fetch_upcoming still surfaces postseason games via rank + favorite
+signals.
 """
 
 from __future__ import annotations

--- a/sources/ncaa_softball.py
+++ b/sources/ncaa_softball.py
@@ -4,13 +4,14 @@ No API key required.
 Two source classes ship under the `enable_ncaa_softball` toggle:
   - `NcaaSoftballRegularSource(PointsBasedSportSource)`: regular-season
     win-count importance (LEAGUE_CONTEXTS["SBL"]).
-  - `NcaaSoftballPlayoffSource(BestOfNSeriesSource)`: postseason. Phase 1
-    ships the cleanly-labeled best-of-3 stages — Super Regional and
-    WCWS Championship Finals. Regional (4-team double-elim per site)
-    and the 8-team WCWS bracket in OKC are Phase 2 (#43): ESPN
-    headlines on those stages are "Women's College World Series -
-    Double Elimination Round" with no game-number or bracket-position
-    metadata, so chronological inference is needed.
+  - `NcaaSoftballPlayoffSource(BestOfNSeriesSource)`: postseason.
+    Currently models the best-of-3 stages — Super Regional and WCWS
+    Championship Finals — both with clean ESPN game-number metadata.
+    Regional (4-team double-elim per site) and the 8-team WCWS bracket
+    in OKC are tracked in #43: ESPN headlines on those stages are
+    "Women's College World Series - Double Elimination Round" with no
+    game-number or bracket-position metadata, so chronological
+    inference is needed.
 
 API path: ESPN groups college softball under the `baseball` sport
 namespace (NOT `softball`). The scoreboard endpoint:
@@ -298,7 +299,7 @@ class NcaaSoftballRegularSource(PointsBasedSportSource):
 
 
 # =====================================================================
-# NcaaSoftballPlayoffSource — Phase 1 best-of-3 stages
+# NcaaSoftballPlayoffSource — best-of-3 stages (Super Regional + WCWS Finals)
 # =====================================================================
 
 
@@ -310,10 +311,9 @@ _FINALS_MARKER = "Championship Finals - Game "
 
 
 def _parse_softball_playoff_headline(headline: str) -> Tuple[Optional[str], Optional[int]]:
-    """Map an ESPN softball postseason headline to (stage, game_index)
-    for the Phase 1 best-of-3 stages. Returns (None, None) for stages
-    we don't model (Regional, 8-team WCWS bracket — both lack game
-    metadata in ESPN's data and are Phase 2).
+    """Map an ESPN softball postseason headline to (stage, game_index).
+    Returns (None, None) for unmodeled stages (Regional, 8-team WCWS
+    bracket — both lack headline game metadata in ESPN's data; see #43).
 
     Patterns observed in 2025-2026 ESPN data:
       - "NCAA Softball Championship - Lincoln Super Regional - Game 1"
@@ -330,17 +330,17 @@ def _parse_softball_playoff_headline(headline: str) -> Tuple[Optional[str], Opti
 
 
 class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
-    """NCAA Softball postseason — Phase 1: Super Regional + WCWS Finals.
+    """NCAA Softball postseason: Super Regional + WCWS Finals.
 
     Both stages are best-of-3 (`SERIES_LENGTH = 3`). Regional double-elim
     and the 8-team WCWS bracket in OKC carry no headline game-number
     metadata in ESPN's data and require chronological inference —
-    Phase 2 (#43).
+    tracked in #43.
 
     The depth structure (SB_REG=0 → SB_SR=1 → WCWS=2 → WCWS_F=3 →
-    WCWS_W=4) is forward-compatible with Phase 2. The `okc_bound`
-    band (depth 2) fires for Super Regional WINNERS in Phase 1 via
-    the default `stage_depth + 1` advance rule.
+    WCWS_W=4) is set up so #43 can extend KO_STAGES without touching
+    threshold labels. The `okc_bound` band (depth 2) fires for Super
+    Regional WINNERS via the default `stage_depth + 1` advance rule.
 
     Strength sharing: pre-postseason, the plugin pulls regular-season
     strengths from NcaaSoftballRegularSource and seeds them via
@@ -497,9 +497,9 @@ class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
     # ---------- bracket fetch ----------
 
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
-        """Sweep the WCWS date window day-by-day, filter to
-        season.type=3 events with a Phase 1 stage headline, emit the
-        bracket per-game record shape.
+        """Sweep the WCWS date window day-by-day, filter to postseason
+        events whose headline matches a modeled stage, emit the bracket
+        per-game record shape.
 
         Window: May 15 (Regional play opens the postseason; we start a
         few days early to catch any timezone wraparound) through

--- a/sources/ncaaf.py
+++ b/sources/ncaaf.py
@@ -96,7 +96,7 @@ class NcaafSource(PointsBasedSportSource):
                     "neutral": g.get("neutralSite", False),
                     "conference_game": g.get("conferenceGame", False),
                     "excitement_index": g.get("excitementIndex"),
-                    # Phase D.2: importance signal lookup key. The plugin's
+                    # Importance signal lookup key. The plugin's
                     # compute_match_importance reads this to find the
                     # LEAGUE_CONTEXTS entry that carries the win-count
                     # thresholds and consequence weights.
@@ -194,7 +194,7 @@ class NcaafSource(PointsBasedSportSource):
                     continue
         return out
 
-    # ---------- Phase D.2: Monte Carlo importance ----------
+    # ---------- Monte Carlo importance ----------
 
     def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
         """Return all FBS-classified regular-season games for the current

--- a/sources/ncaam.py
+++ b/sources/ncaam.py
@@ -108,7 +108,7 @@ class NcaamSource(PointsBasedSportSource):
                     "conference_game": g.get("conferenceGame", False),
                     "excitement_index": g.get("excitement"),
                     "tournament": g.get("tournament"),
-                    # Phase D.3: importance lookup key for LEAGUE_CONTEXTS.
+                    # Importance lookup key for LEAGUE_CONTEXTS.
                     "fd_competition_code": self.league_context_code,
                 },
             ))
@@ -215,7 +215,7 @@ class NcaamSource(PointsBasedSportSource):
                     continue
         return out
 
-    # ---------- Phase D.3: Monte Carlo importance ----------
+    # ---------- Monte Carlo importance ----------
 
     def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
         """Return the current regular-season game list filtered to games
@@ -226,12 +226,11 @@ class NcaamSource(PointsBasedSportSource):
         which keeps per-refresh importance cost in the seconds, not
         minutes.
 
-        Limitation: a non-AP favorite team's games against non-AP
-        opponents won't be in the cache, so the simulator will miss
-        those wins when computing the favorite's win-count outcomes. The
+        Known limitation: a non-AP favorite team's games against non-AP
+        opponents aren't in the cache, so the simulator misses those
+        wins when computing the favorite's win-count outcomes. The
         plugin's `favorites_in_league` mechanism still queries those
-        teams but the leverage is biased low. Future fix: extend the
-        filter to also include all FAVORITE teams' direct opponents.
+        teams but the leverage is biased low.
         """
         if not self.api_key:
             return []

--- a/sources/nfl.py
+++ b/sources/nfl.py
@@ -6,7 +6,7 @@ Two source classes:
     7 / 9 / 11 / 13 wins.
   - `NflPlayoffSource(BestOfNSeriesSource)`: single-game elimination
     bracket, SERIES_LENGTH=1 per stage. Stages: WC -> DIV -> CONF ->
-    SB. Same architectural shape as March Madness (Phase L).
+    SB. Same architectural shape as the NCAA March Madness bracket.
 
 API patterns:
   - /scoreboard?dates=YYYYMMDD for per-day games.

--- a/sources/nhl.py
+++ b/sources/nhl.py
@@ -29,8 +29,8 @@ API quirks captured here:
     stable key when iterating per-team schedules.
 
 The plugin opts into NHL via the `enable_nhl` boolean in `plugin.json`.
-Off by default: NHL coverage is new in Phase E and a user who's only
-watching football shouldn't see hockey channels appear.
+Off by default so users who only watch football don't get hockey
+channels appearing unsolicited.
 """
 
 from __future__ import annotations

--- a/sources/nwsl.py
+++ b/sources/nwsl.py
@@ -1,10 +1,9 @@
 """NWSL source — ESPN unofficial + Odds API closeness.
 
-Same V1 minimal pattern as MlsSource (Phase J): schedule from ESPN +
-closeness from The Odds API. No standings-based importance and no
-playoff bracket — both are follow-ups. NWSL playoff format mirrors
-MLS Cup (mixed best-of-3 and single-leg rounds) and would benefit
-from the same bracket work.
+Same minimal pattern as MlsSource: schedule from ESPN + closeness
+from The Odds API. No standings-based importance and no playoff
+bracket — NWSL playoff format mirrors MLS Cup (mixed best-of-3 and
+single-leg rounds), tracked under #30.
 
 NWSL Odds API key: `soccer_usa_nwsl`. ESPN slug: `soccer/usa.nwsl`.
 """

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -147,7 +147,7 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         use_position_as_rank=False,  # group/knockout standings don't map cleanly
         # total_matchdays=0 — knockout, not a fixed-length season
     ),
-    # Phase H: top-flight European league competitions. All available on
+    # Top-flight European league competitions. All available on
     # Football-Data.org's free tier (verified 2026-05-25). Each is a
     # standard round-robin league; SoccerSource handles them with no
     # subclass needed. Threshold structures live in scoring.LEAGUE_CONTEXTS
@@ -186,9 +186,9 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         rank_cap=18,
         total_matchdays=34,
     ),
-    # Phase I: international tournaments. Both pure knockout (group stage
-    # not modeled in importance — see Phase I follow-up). LEAGUE_CONTEXTS
-    # routes them to KnockoutSoccerSource via format="knockout".
+    # International tournaments. Both pure knockout (group-stage
+    # importance is tracked in #20). LEAGUE_CONTEXTS routes them to
+    # KnockoutSoccerSource via format="knockout".
     "world_cup": SoccerCompetitionConfig(
         fd_code="WC",
         sport_prefix="WC",
@@ -203,11 +203,11 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         odds_sport_key="soccer_uefa_european_championship",
         use_position_as_rank=False,
     ),
-    # Phase Q: additional Football-Data.org free-tier leagues. Same
-    # config shape as Phase H's BL1/PD/SA/FL1 — pure data additions, no
-    # source code changes. UEFA Europa League and Conference League are
-    # NOT on the FD.org free tier (only Champions League is), so they're
-    # not included here despite being on the original Phase Q wishlist.
+    # Additional Football-Data.org free-tier leagues. Same config
+    # shape as the top-flight European leagues above — pure data
+    # additions, no source code changes. UEFA Europa League and
+    # Conference League are NOT on the FD.org free tier (only Champions
+    # League is), so they're not included here.
     "eredivisie": SoccerCompetitionConfig(
         fd_code="DED",
         sport_prefix="Eredivisie",
@@ -238,11 +238,11 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
 class SoccerSource(SportSource):
     """Adapter for one Football-Data.org competition."""
 
-    # Phase C: SoccerSource implements the Monte Carlo importance interface.
-    # Requires a full-season fixtures fetch (done lazily on first call).
-    # UCL etc. set use_position_as_rank=False; they have no league table, so
-    # the importance simulator can't run on them. The lazy cache populates
-    # only for the configs where LEAGUE_CONTEXTS has thresholds defined.
+    # SoccerSource implements the Monte Carlo importance interface
+    # (requires a full-season fixtures fetch, done lazily on first call).
+    # UCL etc. set use_position_as_rank=False; they have no league table,
+    # so the importance simulator can't run on them. The lazy cache
+    # populates only for configs where LEAGUE_CONTEXTS has thresholds.
     supports_importance = True
 
     # Pre-season fallback per-team strength (rolling-window estimate has no
@@ -260,8 +260,8 @@ class SoccerSource(SportSource):
         self.fd_api_key = fd_api_key
         self.odds_api_key = odds_api_key
         # Importance-mode cache (lazy). Populated by _ensure_importance_cache
-        # on first call to any of the Phase C methods. None means uninitialized;
-        # an empty list / dict means we tried and got nothing back.
+        # on first call. None means uninitialized; an empty list / dict
+        # means we tried and got nothing back.
         self._all_matches_cache: Optional[List[Dict]] = None
         self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
         self._initial_state_cache: Optional[Dict[str, Any]] = None
@@ -555,7 +555,7 @@ class SoccerSource(SportSource):
                 return v
         return None
 
-    # ---------- Phase C: Monte Carlo importance ----------
+    # ---------- Monte Carlo importance ----------
 
     def _fetch_all_season_matches(self) -> List[Dict]:
         """All matches for the current competition season — finished AND
@@ -616,8 +616,8 @@ class SoccerSource(SportSource):
 
         Teams with zero finished matches (newly promoted, pre-season) get
         league-average defaults via `_DEFAULT_STRENGTH_*`. The pre-season
-        seed already handles position-based ranks (Phase B.2); strengths are
-        the goals-side fallback.
+        seed handles position-based ranks separately; strengths are the
+        goals-side fallback.
         """
         if self._strengths_cache is not None:
             return self._strengths_cache

--- a/sources/wnba.py
+++ b/sources/wnba.py
@@ -1,6 +1,6 @@
 """WNBA source — ESPN's unofficial `site.api.espn.com` API. No key required.
 
-Two source classes mirroring the NBA pattern (Phase G), with WNBA-specific
+Two source classes mirroring the NBA pattern, with WNBA-specific
 adjustments:
 
   - `WnbaRegularSource(PointsBasedSportSource)`: 40-game regular season,


### PR DESCRIPTION
## Summary

Per Jake's reminder: code, manifests, and docs should describe what IS (and sometimes WHY), not what once was or what might exist later. Speculative \"(and Phase 3+: rivalry, narrative)\" cruft on \`plugin.json\` was the specific call-out; this PR audits the broader codebase for the same shape.

22 files touched (-375/+328 net). Heavy hitter is \`scoring.py\` (stripped Phase X section labels from KNOCKOUT_ROUND_DEPTH + LEAGUE_CONTEXTS comments) and per-sport \`sources/*.py\` (Phase markers in file/class docstrings).

Filed-issue references are kept — they're grounding, not speculation:
- \`#43\` for NCAA Baseball / Softball Regional + 8-team MCWS/WCWS bracket
- \`#30\` for MLS / NWSL / Liga MX standings + bracket follow-ups
- \`#20\` for WC 2026 group stage importance
- \`#8\` for the unpopulated rivalry signal
- \`#4\` for matcher v2

Load-bearing comments preserved unchanged where \"legacy\" grounds active backward-compat:
- \`_OWNED_TVG_ID_LEGACY_MARKERS\` (still-active cleanup path for old tvg_id schemes)
- \`_build_signals_score_from_payload\` older-cache-schema fallback reader (reworded to describe current behavior without naming retired internal phase labels)

## Verification

- All 22 \`TestDoubleEliminationSource\` tests still pass via the smoke harness.
- All 28 existing bracket tests (\`TestBestOfNSeriesSource\`, \`TestNcaaBaseballPlayoffSource\`, \`TestNcaaSoftballPlayoffSource\`) still pass.
- Only comment-string content was touched; no function signatures, control flow, or class hierarchies changed.
- \`python3 -m py_compile\` clean on all 22 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)