### PR TITLE
Closes #43: Phase 2b NCAA Baseball/Softball bracket sources

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -354,8 +354,8 @@ def _build_sources(settings: Dict[str, Any]):
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
-        NcaaBaseballRegularSource, NcaaBaseballPlayoffSource,
-        NcaaSoftballRegularSource, NcaaSoftballPlayoffSource,
+        NcaaBaseballRegularSource, NcaaBaseballPlayoffSource, NcaaBaseballPlayoffBracketSource,
+        NcaaSoftballRegularSource, NcaaSoftballPlayoffSource, NcaaSoftballPlayoffBracketSource,
         NcaaSoccerSource,
         NcaafSource, NcaamSource,
         NflPlayoffSource, NflRegularSource,
@@ -566,36 +566,49 @@ def _build_sources(settings: Dict[str, Any]):
 
     # NCAA Division I baseball. Free ESPN unofficial API + D1Baseball
     # poll. Regular-season win-count thresholds (30 / 35 / 40 / 45 / 50)
-    # drive the in-season importance signal. Postseason coverage is
-    # currently the cleanly-labeled best-of-3 stages (Super Regional,
-    # MCWS Finals); Regional double-elim + 8-team MCWS bracket are
-    # tracked in #43. Same pair-and-seed pattern as MLB: the playoff
-    # source borrows regular-season strengths from the regular source
-    # so postseason Poisson sampling reflects per-team scoring skill
-    # rather than the league-average prior.
+    # drive the in-season importance signal. Two playoff sources fan
+    # out under this single toggle:
+    #   - NcaaBaseballPlayoffSource: best-of-3 Super Regional + MCWS Final
+    #     (BSB_SR + MCWS_F). ESPN headlines carry game numbers, so the
+    #     BestOfNSeriesSource state machine fits.
+    #   - NcaaBaseballPlayoffBracketSource: 4-team Regional double-elim
+    #     + 8-team MCWS bracket (BSB_REG + MCWS). Uses chronological
+    #     inference + headline site labels for grouping.
+    # All three (regular + 2 playoff sources) share strength data so
+    # postseason Poisson sampling reflects per-team scoring skill.
     if settings.get("enable_ncaa_baseball", False):
         ncbsb_reg = NcaaBaseballRegularSource()
         sources.append(ncbsb_reg)
-        ncbsb_po = NcaaBaseballPlayoffSource()
         try:
-            ncbsb_po.set_regular_season_strengths(ncbsb_reg.estimate_strengths())
+            ncbsb_strengths = ncbsb_reg.estimate_strengths()
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[ncaa_baseball] could not seed playoff strengths: %s", exc)
+            logger.warning("[ncaa_baseball] could not estimate regular-season strengths: %s", exc)
+            ncbsb_strengths = {}
+        ncbsb_po = NcaaBaseballPlayoffSource()
+        ncbsb_po.set_regular_season_strengths(ncbsb_strengths)
         sources.append(ncbsb_po)
+        ncbsb_br = NcaaBaseballPlayoffBracketSource()
+        ncbsb_br.set_regular_season_strengths(ncbsb_strengths)
+        sources.append(ncbsb_br)
 
-    # NCAA Division I softball. Same structure as NCAA baseball — regular-
-    # season win-count + best-of-3 postseason (Super Regional, WCWS Finals)
-    # coverage. Regional double-elim + 8-team WCWS bracket are tracked in
-    # #43.
+    # NCAA Division I softball. Same two-playoff-source fan-out as
+    # baseball above — NcaaSoftballPlayoffSource owns the best-of-3
+    # stages (SB_SR + WCWS_F), NcaaSoftballPlayoffBracketSource owns
+    # the Regional + 8-team WCWS bracket (SB_REG + WCWS).
     if settings.get("enable_ncaa_softball", False):
         ncsbl_reg = NcaaSoftballRegularSource()
         sources.append(ncsbl_reg)
-        ncsbl_po = NcaaSoftballPlayoffSource()
         try:
-            ncsbl_po.set_regular_season_strengths(ncsbl_reg.estimate_strengths())
+            ncsbl_strengths = ncsbl_reg.estimate_strengths()
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[ncaa_softball] could not seed playoff strengths: %s", exc)
+            logger.warning("[ncaa_softball] could not estimate regular-season strengths: %s", exc)
+            ncsbl_strengths = {}
+        ncsbl_po = NcaaSoftballPlayoffSource()
+        ncsbl_po.set_regular_season_strengths(ncsbl_strengths)
         sources.append(ncsbl_po)
+        ncsbl_br = NcaaSoftballPlayoffBracketSource()
+        ncsbl_br.set_regular_season_strengths(ncsbl_strengths)
+        sources.append(ncsbl_br)
 
     # NCAA D1 men's + women's soccer. One source class
     # parametrized on gender — same structure / endpoints / threshold

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -14,8 +14,16 @@ from .ncaaw_basketball import (
     NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
 )
 from .nfl import NflPlayoffSource, NflRegularSource
-from .ncaa_baseball import NcaaBaseballPlayoffSource, NcaaBaseballRegularSource
-from .ncaa_softball import NcaaSoftballPlayoffSource, NcaaSoftballRegularSource
+from .ncaa_baseball import (
+    NcaaBaseballPlayoffBracketSource,
+    NcaaBaseballPlayoffSource,
+    NcaaBaseballRegularSource,
+)
+from .ncaa_softball import (
+    NcaaSoftballPlayoffBracketSource,
+    NcaaSoftballPlayoffSource,
+    NcaaSoftballRegularSource,
+)
 from .ncaa_soccer import NcaaSoccerSource
 from .ncaaf import NcaafSource
 from .ncaam import NcaamSource
@@ -35,8 +43,8 @@ __all__ = [
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",
-    "NcaaBaseballRegularSource", "NcaaBaseballPlayoffSource",
-    "NcaaSoftballRegularSource", "NcaaSoftballPlayoffSource",
+    "NcaaBaseballRegularSource", "NcaaBaseballPlayoffSource", "NcaaBaseballPlayoffBracketSource",
+    "NcaaSoftballRegularSource", "NcaaSoftballPlayoffSource", "NcaaSoftballPlayoffBracketSource",
     "NcaaSoccerSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -42,13 +42,14 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
 from .base import GameRow, MatchResult
-from .bracket import BestOfNSeriesSource
+from .bracket import BestOfNSeriesSource, DoubleEliminationSource
 from .points_based import PointsBasedSportSource
 from .._util import (
     extract_game_number_after_marker,
@@ -398,21 +399,78 @@ def _parse_baseball_playoff_headline(headline: str) -> Tuple[Optional[str], Opti
     return None, None
 
 
-class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
+class _BaseballPlayoffStrengthsMixin:
+    """Shared per-team Poisson strength tracking + sample_result for the
+    two NCAA Baseball playoff source classes (Super Regional + MCWS Finals
+    via BestOfNSeriesSource; Regional + 8-team MCWS bracket via
+    DoubleEliminationSource). Both pull regular-season strengths from
+    NcaaBaseballRegularSource via `set_regular_season_strengths` and use
+    the same Poisson sampling with extra-innings coin-flip tiebreak.
+    """
+
+    # Defined here so type-checkers know the attr exists; concrete
+    # subclasses initialize it in __init__ to avoid the class-level
+    # singleton pitfall.
+    _team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]],
+    ) -> None:
+        """Hook for plugin.py to seed per-team scoring/conceding rates
+        from the regular-season source."""
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_RUNS_FOR,
+            "pa_per_game": _DEFAULT_RUNS_AGAINST,
+        }
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        del state  # per-game classification only
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_runs = _poisson(lam_home, rng)
+        away_runs = _poisson(lam_away, rng)
+        # NCAA postseason has no draws — coin-flip the +1 to break the tie.
+        if home_runs == away_runs:
+            if rng.random() < 0.5:
+                home_runs += 1
+            else:
+                away_runs += 1
+        return MatchResult(home_goals=home_runs, away_goals=away_runs)
+
+
+class NcaaBaseballPlayoffSource(_BaseballPlayoffStrengthsMixin, BestOfNSeriesSource):
     """NCAA Baseball postseason: Super Regional + MCWS Finals.
 
     Both stages are best-of-3 (`SERIES_LENGTH = 3`) with ESPN headlines
     that carry the game number, so the BestOfNSeriesSource infrastructure
-    fits cleanly. The intermediate Regional (4-team double-elim per
-    site) and 8-team MCWS bracket in Omaha lack game-number metadata in
-    ESPN's data and require chronological inference — tracked in #43.
+    fits cleanly. The Regional (4-team double-elim per site) and 8-team
+    MCWS bracket stages are owned by NcaaBaseballPlayoffBracketSource
+    (sibling source), which extends DoubleEliminationSource and uses
+    chronological inference + headline site labels for grouping.
 
     The depth structure (BSB_REG=0 → BSB_SR=1 → MCWS=2 → MCWS_F=3 →
-    MCWS_W=4) lets #43 extend KO_STAGES without touching threshold
-    labels in LEAGUE_CONTEXTS["MCWS_PO"]. The `omaha_bound` band
-    (depth 2) fires for Super Regional WINNERS because
-    `_winner_advance_label("BSB_SR")` returns None → default
-    `stage_depth + 1` rule → winner gets depth 2 (= MCWS depth).
+    MCWS_W=4) is shared across the two playoff sources; this class
+    handles BSB_SR + MCWS_F, the sibling handles BSB_REG + MCWS.
 
     Strength sharing: pre-postseason, the plugin pulls regular-season
     strength estimates from NcaaBaseballRegularSource and seeds them
@@ -550,54 +608,6 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
             },
         )
 
-    # ---------- strengths (reused from regular season) ----------
-
-    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
-        if self._team_strengths_from_regular is not None:
-            return self._team_strengths_from_regular
-        return {}
-
-    def set_regular_season_strengths(
-        self, strengths: Dict[str, Dict[str, float]]
-    ) -> None:
-        """Hook for plugin.py to seed per-team scoring/conceding rates
-        from the regular-season source. Same shape as MlbPlayoffSource."""
-        self._team_strengths_from_regular = strengths
-
-    def _strength_for(
-        self, strengths: Dict[str, Dict[str, float]], team: str,
-    ) -> Dict[str, float]:
-        if team in strengths:
-            return strengths[team]
-        return {
-            "pf_per_game": _DEFAULT_RUNS_FOR,
-            "pa_per_game": _DEFAULT_RUNS_AGAINST,
-        }
-
-    # ---------- sample_result (per-game Poisson with extra-innings) ----------
-
-    def sample_result(
-        self,
-        state: Dict[str, Any],
-        match: GameRow,
-        strengths: Dict[str, Dict[str, float]],
-        rng: random.Random,
-    ) -> MatchResult:
-        del state  # per-game classification only
-        h = self._strength_for(strengths, match.home)
-        a = self._strength_for(strengths, match.away)
-        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
-        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
-        home_runs = _poisson(lam_home, rng)
-        away_runs = _poisson(lam_away, rng)
-        # NCAA postseason has no draws — coin-flip the +1 to break the tie.
-        if home_runs == away_runs:
-            if rng.random() < 0.5:
-                home_runs += 1
-            else:
-                away_runs += 1
-        return MatchResult(home_goals=home_runs, away_goals=away_runs)
-
     # ---------- bracket fetch ----------
 
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
@@ -693,4 +703,454 @@ class NcaaBaseballPlayoffSource(BestOfNSeriesSource):
             "status": status,
             "start_time": parse_iso_utc(event.get("date")),
             "extra": {"headline": headline},
+        }
+
+
+# =====================================================================
+# NcaaBaseballPlayoffBracketSource — Regional + 8-team MCWS double-elim
+# =====================================================================
+
+
+# Site name is everything between "NCAA Baseball Championship - " and
+# " Regional" — e.g., "Auburn Regional" from
+# "NCAA Baseball Championship - Auburn Regional - Game 1".
+_REGIONAL_SITE_REGEX = re.compile(
+    r"NCAA Baseball Championship - (?P<site>[^-]+? Regional)\b"
+)
+
+# Headline substrings that classify a postseason game as a stage of the
+# Regional double-elim. ESPN tags the same event multiple ways across
+# its event lifecycle:
+#   - "NCAA Baseball Championship - Auburn Regional - Game 1"
+#   - "NCAA Baseball Championship - Auburn Regional - Elimination Game"
+#   - "NCAA Baseball Championship - Auburn Regional - {team} advances to Super Regional"
+_REGIONAL_MARKERS = (
+    "Regional - Game ",
+    "Regional - Elimination Game",
+    "Regional - ",  # catch-all for "advances to" + future ESPN variants
+)
+
+# 8-team MCWS bracket headline substrings (the cleanly-labeled best-of-3
+# Championship Final is _FINALS_MARKER above; this set covers the
+# sub-bracket double-elim that precedes it).
+_MCWS_BRACKET_MARKERS = (
+    "Men's College World Series - Double Elimination Round",
+    "Men's College World Series - Elimination Game",
+    " advances to Championship Series",
+)
+
+
+def _parse_baseball_bracket_headline(headline: str) -> Tuple[Optional[str], Optional[str]]:
+    """Map an ESPN postseason headline to (stage, partial_grouping_key).
+
+    For Regional games, returns ("BSB_REG", "<site> Regional") — the
+    grouping_key is the site label parsed from the headline.
+
+    For 8-team MCWS bracket games, returns ("MCWS", None) — the
+    sub-bracket assignment can't be determined from one headline alone;
+    `_classify_mcws_sub_brackets` does the chronological grouping later
+    in `_fetch_bracket_games` once all MCWS events are collected.
+
+    Returns (None, None) for headlines that belong to the sibling
+    NcaaBaseballPlayoffSource (Super Regional + Final) or are
+    non-postseason / unclassifiable.
+
+    DO NOT collapse the Regional / MCWS branches into a single regex
+    — Regional headlines carry the site name in a structured position
+    that we can extract; MCWS bracket headlines don't have any
+    sub-bracket hint, so the partition is purely chronological.
+    """
+    if not headline:
+        return None, None
+    # Best-of-3 stages are owned by the sibling playoff source — explicitly
+    # skip them here so the bracket source doesn't try to claim them.
+    if _SUPER_REGIONAL_MARKER in headline or _FINALS_MARKER in headline:
+        return None, None
+    m = _REGIONAL_SITE_REGEX.search(headline)
+    if m and any(marker in headline for marker in _REGIONAL_MARKERS):
+        return "BSB_REG", m.group("site")
+    if any(marker in headline for marker in _MCWS_BRACKET_MARKERS):
+        return "MCWS", None
+    return None, None
+
+
+try:
+    from zoneinfo import ZoneInfo
+    _MCWS_VENUE_TZ = ZoneInfo("America/Chicago")  # Omaha (Charles Schwab Field)
+except ImportError:
+    _MCWS_VENUE_TZ = timezone.utc  # fallback; shouldn't fire on Py 3.9+
+
+
+def _classify_mcws_sub_brackets(
+    mcws_games: List[Dict[str, Any]],
+) -> Dict[str, str]:
+    """Assign each MCWS team to one of two sub-brackets based on the
+    opening-day pairings heuristic verified against 2025 MCWS data:
+
+      - Day 1's 2 games define sub-bracket 1 (the 4 teams that played
+        on the earliest MCWS local-time date in Omaha).
+      - Day 2's 2 games define sub-bracket 2 (the 4 teams that played
+        on the second-earliest local-time date).
+      - Day 3+ games are partitioned by which sub-bracket each team
+        was assigned to on its opening day. Teams that somehow appear
+        without an opening-day assignment (rained-out openers, etc.)
+        inherit their opponent's sub-bracket if known, otherwise are
+        dropped.
+
+    Returns a dict {team_name: "MCWS_sub1" | "MCWS_sub2"}.
+
+    DO NOT partition by UTC date — MCWS evening games in Omaha
+    (CT) routinely cross UTC midnight (a 7:30 PM CT game is 12:30 AM
+    UTC the next day), which would split a single MCWS broadcast day
+    across two UTC dates and put opening-day pairings into different
+    sub-brackets. Converting to America/Chicago first pins the partition
+    to the broadcast calendar regardless of DST or UTC roll-over.
+
+    The 2025 MCWS schedule had two games on Day 1 (Jun 13: Coastal
+    Carolina vs Arizona, Oregon State vs Louisville) and two on Day 2
+    (Jun 14: UCLA vs Murray State, Arkansas vs LSU). The partition
+    holds 100% on Day 3+ (Oregon State vs Coastal Carolina is sub-
+    bracket 1, LSU vs UCLA is sub-bracket 2).
+    """
+    games_sorted = sorted(
+        mcws_games,
+        key=lambda g: g.get("start_time") or datetime(2099, 1, 1, tzinfo=timezone.utc),
+    )
+    sub_bracket: Dict[str, str] = {}
+    days_seen: List[Any] = []   # ordered list of unique venue-local dates
+    for g in games_sorted:
+        ts = g.get("start_time")
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        d = ts.astimezone(_MCWS_VENUE_TZ).date()
+        if d not in days_seen:
+            days_seen.append(d)
+        home = g.get("home")
+        away = g.get("away")
+        if not home or not away:
+            continue
+        if d == days_seen[0]:
+            sub_bracket.setdefault(home, "MCWS_sub1")
+            sub_bracket.setdefault(away, "MCWS_sub1")
+        elif len(days_seen) >= 2 and d == days_seen[1]:
+            sub_bracket.setdefault(home, "MCWS_sub2")
+            sub_bracket.setdefault(away, "MCWS_sub2")
+        else:
+            # Day 3+: rely on prior assignments. If one team is
+            # classified and the other isn't, inherit from the
+            # classified one (defensive coverage for opening-day no-shows).
+            home_sb = sub_bracket.get(home)
+            away_sb = sub_bracket.get(away)
+            if home_sb and not away_sb:
+                sub_bracket[away] = home_sb
+            elif away_sb and not home_sb:
+                sub_bracket[home] = away_sb
+    return sub_bracket
+
+
+def _mcws_meta_from_raw_events(
+    raw_events: List[Tuple[Dict[str, Any], str, Optional[str]]],
+) -> List[Dict[str, Any]]:
+    """Pluck the (home, away, start_time) projection from raw ESPN
+    events tagged MCWS, suitable for feeding `_classify_mcws_sub_brackets`.
+    Shared between fetch_upcoming and _fetch_bracket_games so the
+    chronological-grouping projection lives in one place."""
+    out: List[Dict[str, Any]] = []
+    for event, stage, _key in raw_events:
+        if stage != "MCWS":
+            continue
+        comps = event.get("competitions") or []
+        if not comps:
+            continue
+        competitors = comps[0].get("competitors") or []
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            continue
+        out.append({
+            "home": _team_canonical_name(home.get("team") or {}),
+            "away": _team_canonical_name(away.get("team") or {}),
+            "start_time": parse_iso_utc(event.get("date")),
+        })
+    return out
+
+
+class NcaaBaseballPlayoffBracketSource(_BaseballPlayoffStrengthsMixin, DoubleEliminationSource):
+    """NCAA Baseball postseason BRACKET stages: 4-team Regional double-
+    elim (16 sites) and the 8-team MCWS bracket (modeled as two 4-team
+    sub-brackets). Sibling to NcaaBaseballPlayoffSource which handles
+    the cleanly-labeled best-of-3 stages.
+
+    Tie grouping_key:
+      - BSB_REG: site name from headline (e.g., "Auburn Regional").
+      - MCWS: "MCWS_sub1" / "MCWS_sub2" assigned by the day-partition
+        heuristic in `_classify_mcws_sub_brackets`.
+
+    The bracket source emits records for BSB_REG and MCWS only — the
+    best-of-3 BSB_SR and MCWS_F headlines are explicitly skipped so the
+    sibling source owns them without duplication.
+
+    Strength sharing: same hook as the sibling — the plugin seeds
+    per-team strengths via `set_regular_season_strengths` from the
+    regular-season source. Without seeding, the 6-runs-per-team
+    Poisson default applies.
+    """
+
+    KO_STAGES = ("BSB_REG", "MCWS")
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        now = datetime.now(timezone.utc)
+        self.season_year = (
+            season_year
+            if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAABSB"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Baseball Postseason"
+
+    def _league_context_code(self) -> str:
+        return "MCWS_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        # MCWS sub-bracket winner advances to MCWS_F (depth 3), handled by
+        # the sibling source. BSB_REG winner falls through to default
+        # `stage_depth + 1` → depth 1 = BSB_SR depth.
+        if stage == "MCWS":
+            return "MCWS_F"
+        return None
+
+    def _tie_grouping_key(self, game: Dict[str, Any]) -> Optional[str]:
+        return (game.get("extra") or {}).get("grouping_key")
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Pull next-N-day postseason games whose headline matches a
+        bracket stage (Regional or 8-team MCWS bracket). Sibling
+        NcaaBaseballPlayoffSource handles the best-of-3 Super Regional
+        + Final headlines.
+        """
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        # First sweep — collect ALL upcoming bracket events so MCWS
+        # sub-bracket grouping can use the full chronological context.
+        raw_events: List[Tuple[Dict[str, Any], str, Optional[str]]] = []
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                if not _is_postseason_event(event):
+                    continue
+                eid = event.get("id")
+                if eid in seen_ids:
+                    continue
+                comps = event.get("competitions") or []
+                if not comps:
+                    continue
+                headline = ""
+                for note in (comps[0].get("notes") or []):
+                    if note.get("type") == "event":
+                        headline = note.get("headline") or ""
+                        break
+                stage, partial_key = _parse_baseball_bracket_headline(headline)
+                if stage is None:
+                    continue
+                seen_ids.add(eid)
+                raw_events.append((event, stage, partial_key))
+
+        mcws_sub_by_team = _classify_mcws_sub_brackets(
+            _mcws_meta_from_raw_events(raw_events)
+        )
+        for event, stage, partial_key in raw_events:
+            row = self._event_to_game_row(event, stage, partial_key, mcws_sub_by_team)
+            if row is not None:
+                out.append(row)
+        return out
+
+    def _event_to_game_row(
+        self,
+        event: Dict[str, Any],
+        stage: str,
+        partial_key: Optional[str],
+        mcws_sub_by_team: Dict[str, str],
+    ) -> Optional[GameRow]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+        start = parse_iso_utc(event.get("date"))
+        if start is None:
+            return None
+
+        if stage == "BSB_REG":
+            grouping_key = partial_key
+        else:  # MCWS
+            grouping_key = mcws_sub_by_team.get(home_team) or mcws_sub_by_team.get(away_team)
+        if grouping_key is None:
+            return None
+
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+
+        return GameRow(
+            sport_prefix=self.sport_prefix,
+            sport_label=self.sport_label,
+            home=home_team,
+            away=away_team,
+            rank_home=None,
+            rank_away=None,
+            start_time=start,
+            extra={
+                "espn_event_id": event.get("id"),
+                "fd_competition_code": self._league_context_code(),
+                "stage": stage,
+                "grouping_key": grouping_key,
+                "headline": headline,
+            },
+        )
+
+    # ---------- bracket fetch (full-season for Monte Carlo) ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Sweep the postseason date window day-by-day. Emit bracket
+        per-game records with the `grouping_key` attached so the
+        DoubleEliminationSource base can group games into tie_metas."""
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        raw: List[Tuple[Dict[str, Any], str, Optional[str]]] = []
+        season_start = datetime(self.season_year, 5, 25, tzinfo=timezone.utc).date()
+        season_end = datetime(self.season_year, 7, 1, tzinfo=timezone.utc).date()
+        day = season_start
+        seen_ids: set = set()
+        while day <= season_end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    if not _is_postseason_event(event):
+                        continue
+                    eid = event.get("id")
+                    if eid in seen_ids:
+                        continue
+                    comps = event.get("competitions") or []
+                    if not comps:
+                        continue
+                    headline = ""
+                    for note in (comps[0].get("notes") or []):
+                        if note.get("type") == "event":
+                            headline = note.get("headline") or ""
+                            break
+                    stage, partial_key = _parse_baseball_bracket_headline(headline)
+                    if stage is None:
+                        continue
+                    seen_ids.add(eid)
+                    raw.append((event, stage, partial_key))
+            day += timedelta(days=1)
+
+        mcws_sub_by_team = _classify_mcws_sub_brackets(
+            _mcws_meta_from_raw_events(raw)
+        )
+
+        out: List[Dict[str, Any]] = []
+        for event, stage, partial_key in raw:
+            rec = self._event_to_bracket_record(event, stage, partial_key, mcws_sub_by_team)
+            if rec is not None:
+                out.append(rec)
+        self._bracket_games_cache = out
+        return out
+
+    def _event_to_bracket_record(
+        self,
+        event: Dict[str, Any],
+        stage: str,
+        partial_key: Optional[str],
+        mcws_sub_by_team: Dict[str, str],
+    ) -> Optional[Dict[str, Any]]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+
+        if stage == "BSB_REG":
+            grouping_key = partial_key
+        else:  # MCWS
+            grouping_key = mcws_sub_by_team.get(home_team) or mcws_sub_by_team.get(away_team)
+        if grouping_key is None:
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        if completed or state == "post":
+            status = "FINISHED"
+        else:
+            status = "SCHEDULED"
+        try:
+            hr = int(home.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            hr = None
+        try:
+            ar = int(away.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            ar = None
+        if status == "FINISHED" and (hr is None or ar is None):
+            status = "SCHEDULED"
+            hr = None
+            ar = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            "matchday": 1,    # double-elim has no fixed matchday; default 1
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hr,
+            "away_goals": ar,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"grouping_key": grouping_key},
         }

--- a/sources/ncaa_softball.py
+++ b/sources/ncaa_softball.py
@@ -40,13 +40,14 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
 from .base import GameRow, MatchResult
-from .bracket import BestOfNSeriesSource
+from .bracket import BestOfNSeriesSource, DoubleEliminationSource
 from .points_based import PointsBasedSportSource
 from .._util import (
     extract_game_number_after_marker,
@@ -329,18 +330,72 @@ def _parse_softball_playoff_headline(headline: str) -> Tuple[Optional[str], Opti
     return None, None
 
 
-class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
+class _SoftballPlayoffStrengthsMixin:
+    """Shared per-team Poisson strength tracking + sample_result for the
+    two NCAA Softball playoff source classes (Super Regional + WCWS Finals
+    via BestOfNSeriesSource; Regional + 8-team WCWS bracket via
+    DoubleEliminationSource). Both pull regular-season strengths from
+    NcaaSoftballRegularSource via `set_regular_season_strengths` and use
+    the same Poisson sampling with extra-innings coin-flip tiebreak.
+    """
+
+    _team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]],
+    ) -> None:
+        """Hook for plugin.py to seed per-team scoring/conceding rates
+        from the regular-season source."""
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_RUNS_FOR,
+            "pa_per_game": _DEFAULT_RUNS_AGAINST,
+        }
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        del state
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_runs = _poisson(lam_home, rng)
+        away_runs = _poisson(lam_away, rng)
+        if home_runs == away_runs:
+            if rng.random() < 0.5:
+                home_runs += 1
+            else:
+                away_runs += 1
+        return MatchResult(home_goals=home_runs, away_goals=away_runs)
+
+
+class NcaaSoftballPlayoffSource(_SoftballPlayoffStrengthsMixin, BestOfNSeriesSource):
     """NCAA Softball postseason: Super Regional + WCWS Finals.
 
     Both stages are best-of-3 (`SERIES_LENGTH = 3`). Regional double-elim
-    and the 8-team WCWS bracket in OKC carry no headline game-number
-    metadata in ESPN's data and require chronological inference —
-    tracked in #43.
+    and the 8-team WCWS bracket in OKC are owned by NcaaSoftballPlayoff
+    BracketSource (sibling source) which extends DoubleEliminationSource
+    and uses chronological inference + headline site labels for grouping.
 
     The depth structure (SB_REG=0 → SB_SR=1 → WCWS=2 → WCWS_F=3 →
-    WCWS_W=4) is set up so #43 can extend KO_STAGES without touching
-    threshold labels. The `okc_bound` band (depth 2) fires for Super
-    Regional WINNERS via the default `stage_depth + 1` advance rule.
+    WCWS_W=4) is shared across the two playoff sources; this class
+    handles SB_SR + WCWS_F, the sibling handles SB_REG + WCWS.
 
     Strength sharing: pre-postseason, the plugin pulls regular-season
     strengths from NcaaSoftballRegularSource and seeds them via
@@ -449,51 +504,6 @@ class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
             },
         )
 
-    # ---------- strengths ----------
-
-    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
-        if self._team_strengths_from_regular is not None:
-            return self._team_strengths_from_regular
-        return {}
-
-    def set_regular_season_strengths(
-        self, strengths: Dict[str, Dict[str, float]]
-    ) -> None:
-        self._team_strengths_from_regular = strengths
-
-    def _strength_for(
-        self, strengths: Dict[str, Dict[str, float]], team: str,
-    ) -> Dict[str, float]:
-        if team in strengths:
-            return strengths[team]
-        return {
-            "pf_per_game": _DEFAULT_RUNS_FOR,
-            "pa_per_game": _DEFAULT_RUNS_AGAINST,
-        }
-
-    # ---------- sample_result ----------
-
-    def sample_result(
-        self,
-        state: Dict[str, Any],
-        match: GameRow,
-        strengths: Dict[str, Dict[str, float]],
-        rng: random.Random,
-    ) -> MatchResult:
-        del state
-        h = self._strength_for(strengths, match.home)
-        a = self._strength_for(strengths, match.away)
-        lam_home = max(0.1, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
-        lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
-        home_runs = _poisson(lam_home, rng)
-        away_runs = _poisson(lam_away, rng)
-        if home_runs == away_runs:
-            if rng.random() < 0.5:
-                home_runs += 1
-            else:
-                away_runs += 1
-        return MatchResult(home_goals=home_runs, away_goals=away_runs)
-
     # ---------- bracket fetch ----------
 
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
@@ -584,4 +594,393 @@ class NcaaSoftballPlayoffSource(BestOfNSeriesSource):
             "status": status,
             "start_time": parse_iso_utc(event.get("date")),
             "extra": {"headline": headline},
+        }
+
+
+# =====================================================================
+# NcaaSoftballPlayoffBracketSource — Regional + 8-team WCWS double-elim
+# =====================================================================
+
+
+# Site name is everything between "NCAA Softball Championship - " and
+# " Regional" (e.g., "Lincoln Regional").
+_REGIONAL_SITE_REGEX = re.compile(
+    r"NCAA Softball Championship - (?P<site>[^-]+? Regional)\b"
+)
+
+# Headline substrings that classify a postseason game as a stage of the
+# Regional double-elim. Parallels the baseball patterns:
+#   - "NCAA Softball Championship - Lincoln Regional - Game 1"
+#   - "NCAA Softball Championship - Lincoln Regional - Elimination Game"
+#   - "NCAA Softball Championship - Lincoln Regional - {team} advances to Super Regional"
+_REGIONAL_MARKERS = (
+    "Regional - Game ",
+    "Regional - Elimination Game",
+    "Regional - ",
+)
+
+# 8-team WCWS bracket headline substrings. Note "Women's College World
+# Series" vs baseball's "Men's College World Series".
+_WCWS_BRACKET_MARKERS = (
+    "Women's College World Series - Double Elimination Round",
+    "Women's College World Series - Elimination Game",
+    " advances to Championship Series",
+)
+
+
+def _parse_softball_bracket_headline(headline: str) -> Tuple[Optional[str], Optional[str]]:
+    """Map an ESPN softball postseason headline to (stage, partial_grouping_key).
+
+    For Regional games, returns ("SB_REG", "<site> Regional"). For 8-team
+    WCWS bracket games, returns ("WCWS", None) — the sub-bracket
+    assignment is resolved chronologically by `_classify_wcws_sub_brackets`.
+
+    Returns (None, None) for best-of-3 SB_SR / WCWS_F headlines (owned by
+    the sibling NcaaSoftballPlayoffSource) and non-classifiable events.
+    """
+    if not headline:
+        return None, None
+    if _SUPER_REGIONAL_MARKER in headline or _FINALS_MARKER in headline:
+        return None, None
+    m = _REGIONAL_SITE_REGEX.search(headline)
+    if m and any(marker in headline for marker in _REGIONAL_MARKERS):
+        return "SB_REG", m.group("site")
+    if any(marker in headline for marker in _WCWS_BRACKET_MARKERS):
+        return "WCWS", None
+    return None, None
+
+
+try:
+    from zoneinfo import ZoneInfo
+    _WCWS_VENUE_TZ = ZoneInfo("America/Chicago")  # OKC (Devon Park)
+except ImportError:
+    _WCWS_VENUE_TZ = timezone.utc
+
+
+def _classify_wcws_sub_brackets(
+    wcws_games: List[Dict[str, Any]],
+) -> Dict[str, str]:
+    """Day-partition heuristic for the 8-team WCWS bracket in OKC. See
+    the baseball sibling docstring for verification details + the
+    UTC-vs-venue-local rationale (WCWS evening games in CT cross UTC
+    midnight, so partition MUST run in America/Chicago local time)."""
+    games_sorted = sorted(
+        wcws_games,
+        key=lambda g: g.get("start_time") or datetime(2099, 1, 1, tzinfo=timezone.utc),
+    )
+    sub_bracket: Dict[str, str] = {}
+    days_seen: List[Any] = []
+    for g in games_sorted:
+        ts = g.get("start_time")
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        d = ts.astimezone(_WCWS_VENUE_TZ).date()
+        if d not in days_seen:
+            days_seen.append(d)
+        home = g.get("home")
+        away = g.get("away")
+        if not home or not away:
+            continue
+        if d == days_seen[0]:
+            sub_bracket.setdefault(home, "WCWS_sub1")
+            sub_bracket.setdefault(away, "WCWS_sub1")
+        elif len(days_seen) >= 2 and d == days_seen[1]:
+            sub_bracket.setdefault(home, "WCWS_sub2")
+            sub_bracket.setdefault(away, "WCWS_sub2")
+        else:
+            home_sb = sub_bracket.get(home)
+            away_sb = sub_bracket.get(away)
+            if home_sb and not away_sb:
+                sub_bracket[away] = home_sb
+            elif away_sb and not home_sb:
+                sub_bracket[home] = away_sb
+    return sub_bracket
+
+
+def _wcws_meta_from_raw_events(
+    raw_events: List[Tuple[Dict[str, Any], str, Optional[str]]],
+) -> List[Dict[str, Any]]:
+    """(home, away, start_time) projection for WCWS events, shared
+    between fetch_upcoming and _fetch_bracket_games. See the baseball
+    sibling helper for context."""
+    out: List[Dict[str, Any]] = []
+    for event, stage, _key in raw_events:
+        if stage != "WCWS":
+            continue
+        comps = event.get("competitions") or []
+        if not comps:
+            continue
+        competitors = comps[0].get("competitors") or []
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            continue
+        out.append({
+            "home": _team_canonical_name(home.get("team") or {}),
+            "away": _team_canonical_name(away.get("team") or {}),
+            "start_time": parse_iso_utc(event.get("date")),
+        })
+    return out
+
+
+class NcaaSoftballPlayoffBracketSource(_SoftballPlayoffStrengthsMixin, DoubleEliminationSource):
+    """NCAA Softball postseason BRACKET stages: 4-team Regional double-
+    elim (16 sites) and the 8-team WCWS bracket (modeled as two 4-team
+    sub-brackets). Sibling to NcaaSoftballPlayoffSource which handles
+    the cleanly-labeled best-of-3 stages (Super Regional + WCWS Finals).
+
+    Tie grouping_key:
+      - SB_REG: site name from headline (e.g., "Lincoln Regional").
+      - WCWS: "WCWS_sub1" / "WCWS_sub2" assigned by the day-partition
+        heuristic in `_classify_wcws_sub_brackets`.
+    """
+
+    KO_STAGES = ("SB_REG", "WCWS")
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        now = datetime.now(timezone.utc)
+        self.season_year = (
+            season_year
+            if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+        self._initial_state_cache: Optional[Dict[str, Any]] = None
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAASBL"
+
+    @property
+    def sport_label(self) -> str:
+        return "NCAA Softball Postseason"
+
+    def _league_context_code(self) -> str:
+        return "WCWS_PO"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        # WCWS sub-bracket winner → advances to WCWS_F (depth 3, handled by
+        # sibling source). SB_REG winner falls through to default
+        # `stage_depth + 1` → depth 1 = SB_SR depth.
+        if stage == "WCWS":
+            return "WCWS_F"
+        return None
+
+    def _tie_grouping_key(self, game: Dict[str, Any]) -> Optional[str]:
+        return (game.get("extra") or {}).get("grouping_key")
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        raw_events: List[Tuple[Dict[str, Any], str, Optional[str]]] = []
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                if not _is_postseason_event(event):
+                    continue
+                eid = event.get("id")
+                if eid in seen_ids:
+                    continue
+                comps = event.get("competitions") or []
+                if not comps:
+                    continue
+                headline = ""
+                for note in (comps[0].get("notes") or []):
+                    if note.get("type") == "event":
+                        headline = note.get("headline") or ""
+                        break
+                stage, partial_key = _parse_softball_bracket_headline(headline)
+                if stage is None:
+                    continue
+                seen_ids.add(eid)
+                raw_events.append((event, stage, partial_key))
+
+        wcws_sub_by_team = _classify_wcws_sub_brackets(
+            _wcws_meta_from_raw_events(raw_events)
+        )
+
+        for event, stage, partial_key in raw_events:
+            row = self._event_to_game_row(event, stage, partial_key, wcws_sub_by_team)
+            if row is not None:
+                out.append(row)
+        return out
+
+    def _event_to_game_row(
+        self,
+        event: Dict[str, Any],
+        stage: str,
+        partial_key: Optional[str],
+        wcws_sub_by_team: Dict[str, str],
+    ) -> Optional[GameRow]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+        start = parse_iso_utc(event.get("date"))
+        if start is None:
+            return None
+
+        if stage == "SB_REG":
+            grouping_key = partial_key
+        else:  # WCWS
+            grouping_key = wcws_sub_by_team.get(home_team) or wcws_sub_by_team.get(away_team)
+        if grouping_key is None:
+            return None
+
+        headline = ""
+        for note in (comp.get("notes") or []):
+            if note.get("type") == "event":
+                headline = note.get("headline") or ""
+                break
+
+        return GameRow(
+            sport_prefix=self.sport_prefix,
+            sport_label=self.sport_label,
+            home=home_team,
+            away=away_team,
+            rank_home=None,
+            rank_away=None,
+            start_time=start,
+            extra={
+                "ncaasbl_game_id": event.get("id"),
+                "fd_competition_code": self._league_context_code(),
+                "stage": stage,
+                "grouping_key": grouping_key,
+                "headline": headline,
+            },
+        )
+
+    # ---------- bracket fetch (full-season for Monte Carlo) ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        raw: List[Tuple[Dict[str, Any], str, Optional[str]]] = []
+        season_start = datetime(self.season_year, 5, 15, tzinfo=timezone.utc).date()
+        season_end = datetime(self.season_year, 6, 15, tzinfo=timezone.utc).date()
+        day = season_start
+        seen_ids: set = set()
+        while day <= season_end:
+            data = _http_get(f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}")
+            if data:
+                for event in data.get("events") or []:
+                    if not _is_postseason_event(event):
+                        continue
+                    eid = event.get("id")
+                    if eid in seen_ids:
+                        continue
+                    comps = event.get("competitions") or []
+                    if not comps:
+                        continue
+                    headline = ""
+                    for note in (comps[0].get("notes") or []):
+                        if note.get("type") == "event":
+                            headline = note.get("headline") or ""
+                            break
+                    stage, partial_key = _parse_softball_bracket_headline(headline)
+                    if stage is None:
+                        continue
+                    seen_ids.add(eid)
+                    raw.append((event, stage, partial_key))
+            day += timedelta(days=1)
+
+        wcws_sub_by_team = _classify_wcws_sub_brackets(
+            _wcws_meta_from_raw_events(raw)
+        )
+
+        out: List[Dict[str, Any]] = []
+        for event, stage, partial_key in raw:
+            rec = self._event_to_bracket_record(event, stage, partial_key, wcws_sub_by_team)
+            if rec is not None:
+                out.append(rec)
+        self._bracket_games_cache = out
+        return out
+
+    def _event_to_bracket_record(
+        self,
+        event: Dict[str, Any],
+        stage: str,
+        partial_key: Optional[str],
+        wcws_sub_by_team: Dict[str, str],
+    ) -> Optional[Dict[str, Any]]:
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+        if home_team.upper() == "TBD" or away_team.upper() == "TBD":
+            return None
+
+        if stage == "SB_REG":
+            grouping_key = partial_key
+        else:  # WCWS
+            grouping_key = wcws_sub_by_team.get(home_team) or wcws_sub_by_team.get(away_team)
+        if grouping_key is None:
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        if completed or state == "post":
+            status = "FINISHED"
+        else:
+            status = "SCHEDULED"
+        try:
+            hr = int(home.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            hr = None
+        try:
+            ar = int(away.get("score")) if status == "FINISHED" else None
+        except (TypeError, ValueError):
+            ar = None
+        if status == "FINISHED" and (hr is None or ar is None):
+            status = "SCHEDULED"
+            hr = None
+            ar = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            "matchday": 1,
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hr,
+            "away_goals": ar,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"grouping_key": grouping_key},
         }

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2609,6 +2609,492 @@ class TestNcaaBaseballPostseasonFilter:
 
 
 # =====================================================================
+# #43 Phase 2b: NcaaBaseballPlayoffBracketSource
+# =====================================================================
+
+
+class TestBaseballBracketHeadlineParser:
+    """Verbatim ESPN headline patterns for the Regional + 8-team MCWS
+    bracket stages. The parser MUST stay aligned with ESPN's exact text;
+    pin every observed pattern as a regression test."""
+
+    def test_regional_game_n(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, key = _parse_baseball_bracket_headline(
+            "NCAA Baseball Championship - Auburn Regional - Game 1"
+        )
+        assert stage == "BSB_REG"
+        assert key == "Auburn Regional"
+
+    def test_regional_elimination_game(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, key = _parse_baseball_bracket_headline(
+            "NCAA Baseball Championship - Knoxville Regional - Elimination Game"
+        )
+        assert stage == "BSB_REG"
+        assert key == "Knoxville Regional"
+
+    def test_regional_advances_to_super_regional(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        # ESPN flags the Regional final with "advances to Super Regional".
+        stage, key = _parse_baseball_bracket_headline(
+            "NCAA Baseball Championship - Auburn Regional - Auburn advances to Super Regional"
+        )
+        assert stage == "BSB_REG"
+        assert key == "Auburn Regional"
+
+    def test_mcws_double_elimination_round(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, key = _parse_baseball_bracket_headline(
+            "Men's College World Series - Double Elimination Round"
+        )
+        assert stage == "MCWS"
+        # Partial key — sub-bracket resolution happens chronologically.
+        assert key is None
+
+    def test_mcws_elimination_game(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, _key = _parse_baseball_bracket_headline(
+            "Men's College World Series - Elimination Game"
+        )
+        assert stage == "MCWS"
+
+    def test_mcws_advances_to_championship_series(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        # Bracket-final terminal signal.
+        stage, _key = _parse_baseball_bracket_headline(
+            "Coastal Carolina advances to Championship Series"
+        )
+        assert stage == "MCWS"
+
+    def test_super_regional_headline_belongs_to_sibling_source(self):
+        # SUPER_REGIONAL headlines are owned by NcaaBaseballPlayoffSource,
+        # NOT the bracket source — the bracket parser must return None.
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, key = _parse_baseball_bracket_headline(
+            "NCAA Baseball Championship - Auburn Super Regional - Game 1"
+        )
+        assert stage is None
+        assert key is None
+
+    def test_finals_headline_belongs_to_sibling_source(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        stage, key = _parse_baseball_bracket_headline(
+            "Men's College World Series Championship Final - Game 1"
+        )
+        assert stage is None
+        assert key is None
+
+    def test_empty_and_unrelated_headlines_return_none(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        assert _parse_baseball_bracket_headline("") == (None, None)
+        assert _parse_baseball_bracket_headline("regular-season game") == (None, None)
+
+
+class TestMcwsSubBracketClassification:
+    """The 8-team MCWS bracket partitions into two 4-team sub-brackets
+    based on Day-1-vs-Day-2 opening pairings. Verified against the
+    2025 MCWS schedule documented in #43's issue comment."""
+
+    @staticmethod
+    def _g(home, away, ts):
+        return {"home": home, "away": away, "start_time": ts}
+
+    def test_2025_mcws_day_partition(self):
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        # 2025 MCWS schedule from issue #43 comment:
+        # Day 1 (06-13): CC vs Arizona, Oregon State vs Louisville → sub1
+        # Day 2 (06-14): UCLA vs Murray State, Arkansas vs LSU       → sub2
+        # Day 3+ partitions confirmed against actual 2025 games.
+        games = [
+            self._g("Coastal Carolina", "Arizona",
+                    datetime(2025, 6, 13, 18, 0, tzinfo=timezone.utc)),
+            self._g("Oregon State", "Louisville",
+                    datetime(2025, 6, 13, 23, 0, tzinfo=timezone.utc)),
+            self._g("UCLA", "Murray State",
+                    datetime(2025, 6, 14, 18, 0, tzinfo=timezone.utc)),
+            self._g("Arkansas", "LSU",
+                    datetime(2025, 6, 14, 23, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_mcws_sub_brackets(games)
+        # Sub 1 (Day 1 teams):
+        assert out["Coastal Carolina"] == "MCWS_sub1"
+        assert out["Arizona"] == "MCWS_sub1"
+        assert out["Oregon State"] == "MCWS_sub1"
+        assert out["Louisville"] == "MCWS_sub1"
+        # Sub 2 (Day 2 teams):
+        assert out["UCLA"] == "MCWS_sub2"
+        assert out["Murray State"] == "MCWS_sub2"
+        assert out["Arkansas"] == "MCWS_sub2"
+        assert out["LSU"] == "MCWS_sub2"
+
+    def test_day3_game_inherits_from_opening_day(self):
+        # Day 3 game (Oregon State vs Coastal Carolina) — both teams
+        # already classified to sub1 from Day 1, so the Day 3 game
+        # MUST stay sub1.
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        games = [
+            # Day 1 establishes sub1
+            self._g("Coastal Carolina", "Arizona",
+                    datetime(2025, 6, 13, 18, 0, tzinfo=timezone.utc)),
+            self._g("Oregon State", "Louisville",
+                    datetime(2025, 6, 13, 23, 0, tzinfo=timezone.utc)),
+            # Day 2 establishes sub2
+            self._g("UCLA", "Arkansas",
+                    datetime(2025, 6, 14, 18, 0, tzinfo=timezone.utc)),
+            # Day 3 rematch — both teams classified already.
+            self._g("Oregon State", "Coastal Carolina",
+                    datetime(2025, 6, 15, 23, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_mcws_sub_brackets(games)
+        assert out["Oregon State"] == "MCWS_sub1"
+        assert out["Coastal Carolina"] == "MCWS_sub1"
+
+    def test_empty_input_returns_empty_dict(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        assert _classify_mcws_sub_brackets([]) == {}
+
+    def test_missing_start_time_skipped(self):
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        games = [
+            self._g("UCLA", "Arkansas", None),  # skipped
+            self._g("Oregon State", "Louisville",
+                    datetime(2025, 6, 13, 23, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_mcws_sub_brackets(games)
+        assert "UCLA" not in out
+        assert out["Oregon State"] == "MCWS_sub1"
+
+    def test_day_partition_handles_utc_midnight_cross(self):
+        # Real MCWS schedule: Day 1 evening game in Omaha (CT) crosses
+        # UTC midnight. Pin the venue-local partition logic.
+        # Day 1 in Omaha = 2025-06-13 CT:
+        #   - 1 PM CT  = 2025-06-13 18:00 UTC
+        #   - 7 PM CT  = 2025-06-14 00:00 UTC   ← different UTC date
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        games = [
+            self._g("Coastal Carolina", "Arizona",
+                    datetime(2025, 6, 13, 18, 0, tzinfo=timezone.utc)),
+            # Second Day-1 game crosses to next UTC date.
+            self._g("Oregon State", "Louisville",
+                    datetime(2025, 6, 14, 0, 0, tzinfo=timezone.utc)),
+            # Day 2 first game.
+            self._g("UCLA", "Murray State",
+                    datetime(2025, 6, 14, 18, 0, tzinfo=timezone.utc)),
+            # Day 2 second game crosses.
+            self._g("Arkansas", "LSU",
+                    datetime(2025, 6, 15, 0, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_mcws_sub_brackets(games)
+        # All Day-1-in-CT teams in sub1.
+        for team in ("Coastal Carolina", "Arizona", "Oregon State", "Louisville"):
+            assert out[team] == "MCWS_sub1", f"{team} = {out.get(team)}"
+        # All Day-2-in-CT teams in sub2.
+        for team in ("UCLA", "Murray State", "Arkansas", "LSU"):
+            assert out[team] == "MCWS_sub2", f"{team} = {out.get(team)}"
+
+    def test_chronological_order_independent_of_input_order(self):
+        # Pass games out of chronological order; the classifier sorts
+        # by start_time internally.
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _classify_mcws_sub_brackets,
+        )
+        games = [
+            # Day 2 first in the list
+            self._g("UCLA", "Arkansas",
+                    datetime(2025, 6, 14, 18, 0, tzinfo=timezone.utc)),
+            # Day 1 second
+            self._g("Coastal Carolina", "Arizona",
+                    datetime(2025, 6, 13, 18, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_mcws_sub_brackets(games)
+        assert out["Coastal Carolina"] == "MCWS_sub1"
+        assert out["UCLA"] == "MCWS_sub2"
+
+
+class TestNcaaBaseballPlayoffBracketSource:
+    """End-to-end source class for BSB_REG + MCWS. Uses a patched
+    `_fetch_bracket_games` so no HTTP touches the test path."""
+
+    @staticmethod
+    def _src_with_games(games):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            NcaaBaseballPlayoffBracketSource,
+        )
+        src = NcaaBaseballPlayoffBracketSource()
+        src._bracket_games_cache = games
+        return src
+
+    def test_ko_stages_are_regional_and_mcws(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            NcaaBaseballPlayoffBracketSource,
+        )
+        assert NcaaBaseballPlayoffBracketSource.KO_STAGES == ("BSB_REG", "MCWS")
+
+    def test_league_context_code(self):
+        src = self._src_with_games([])
+        assert src._league_context_code() == "MCWS_PO"
+
+    def test_winner_advance_mcws_to_finals(self):
+        # MCWS sub-bracket winner advances to MCWS_F (depth 3, handled
+        # by sibling source). BSB_REG winner falls through to default.
+        src = self._src_with_games([])
+        assert src._winner_advance_label("MCWS") == "MCWS_F"
+        assert src._winner_advance_label("BSB_REG") is None
+
+    def test_supports_importance(self):
+        src = self._src_with_games([])
+        assert src.supports_importance is True
+
+    def test_strength_seeding_roundtrip(self):
+        src = self._src_with_games([])
+        s = {"LSU": {"pf_per_game": 7.5, "pa_per_game": 4.2}}
+        src.set_regular_season_strengths(s)
+        assert src.estimate_strengths() == s
+
+    def test_strength_default_for_unseeded_team(self):
+        src = self._src_with_games([])
+        # Default falls back to _DEFAULT_RUNS_FOR / AGAINST (6.0 each).
+        out = src._strength_for({}, "Unknown")
+        assert out == {"pf_per_game": 6.0, "pa_per_game": 6.0}
+
+
+class TestNcaaBaseballPlayoffBracketSourceFiltering:
+    """Make sure the bracket source DOES NOT step on the sibling
+    NcaaBaseballPlayoffSource's stages — best-of-3 BSB_SR + MCWS_F
+    headlines must be ignored by the bracket parser."""
+
+    def test_super_regional_excluded(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        for headline in [
+            "NCAA Baseball Championship - Knoxville Super Regional - Game 1",
+            "NCAA Baseball Championship - Auburn Super Regional - Game 3 (if necessary)",
+        ]:
+            stage, key = _parse_baseball_bracket_headline(headline)
+            assert (stage, key) == (None, None), f"bracket parser claimed {headline!r}"
+
+    def test_finals_excluded(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
+            _parse_baseball_bracket_headline,
+        )
+        for headline in [
+            "Men's College World Series Championship Final - Game 1",
+            "Men's College World Series Championship Final - Game 3 (if necessary)",
+        ]:
+            stage, key = _parse_baseball_bracket_headline(headline)
+            assert (stage, key) == (None, None), f"bracket parser claimed {headline!r}"
+
+
+# =====================================================================
+# #43 Phase 2b: NcaaSoftballPlayoffBracketSource
+# =====================================================================
+
+
+class TestSoftballBracketHeadlineParser:
+    def test_regional_game_n(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, key = _parse_softball_bracket_headline(
+            "NCAA Softball Championship - Lincoln Regional - Game 2"
+        )
+        assert stage == "SB_REG"
+        assert key == "Lincoln Regional"
+
+    def test_regional_elimination_game(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, key = _parse_softball_bracket_headline(
+            "NCAA Softball Championship - Tallahassee Regional - Elimination Game"
+        )
+        assert stage == "SB_REG"
+        assert key == "Tallahassee Regional"
+
+    def test_wcws_double_elimination_round(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, key = _parse_softball_bracket_headline(
+            "Women's College World Series - Double Elimination Round"
+        )
+        assert stage == "WCWS"
+        assert key is None
+
+    def test_wcws_elimination_game_if_necessary(self):
+        # Verbatim text from 2025 WCWS — "If Necessary" suffix is part
+        # of the elimination-game pattern.
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, _key = _parse_softball_bracket_headline(
+            "Women's College World Series - Elimination Game If Necessary"
+        )
+        assert stage == "WCWS"
+
+    def test_super_regional_belongs_to_sibling_source(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, key = _parse_softball_bracket_headline(
+            "NCAA Softball Championship - Lincoln Super Regional - Game 1"
+        )
+        assert (stage, key) == (None, None)
+
+    def test_wcws_finals_plural_belongs_to_sibling_source(self):
+        # Softball uses "Finals" plural (vs baseball's singular "Final");
+        # the parser must NOT swallow it.
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _parse_softball_bracket_headline,
+        )
+        stage, key = _parse_softball_bracket_headline(
+            "Women's College World Series Championship Finals - Game 1"
+        )
+        assert (stage, key) == (None, None)
+
+
+class TestWcwsSubBracketClassification:
+    """Same day-partition heuristic as MCWS — pinned by a representative
+    fixture using verbatim 2026 WCWS opening-day pairings."""
+
+    @staticmethod
+    def _g(home, away, ts):
+        return {"home": home, "away": away, "start_time": ts}
+
+    def test_empty_input_returns_empty_dict(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _classify_wcws_sub_brackets,
+        )
+        assert _classify_wcws_sub_brackets([]) == {}
+
+    def test_chronological_order_independent_of_input_order(self):
+        # Out-of-order input → classifier sorts by start_time internally.
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _classify_wcws_sub_brackets,
+        )
+        games = [
+            # Day 2 first in the list
+            self._g("UCLA", "Tennessee",
+                    datetime(2026, 5, 30, 22, 0, tzinfo=timezone.utc)),
+            # Day 1 second
+            self._g("Texas Tech", "Oklahoma",
+                    datetime(2026, 5, 29, 22, 0, tzinfo=timezone.utc)),
+        ]
+        out = _classify_wcws_sub_brackets(games)
+        assert out["Texas Tech"] == "WCWS_sub1"
+        assert out["UCLA"] == "WCWS_sub2"
+
+    def test_wcws_day_partition_across_utc_midnight(self):
+        # Real WCWS schedule: Day 1 evening games in OKC (CT) routinely
+        # cross UTC midnight. Pin the venue-local partition logic with
+        # a fixture that exercises this exact case.
+        # Day 1 in OKC = 2026-05-29 CT:
+        #   - 5 PM CT = 2026-05-29 22:00 UTC
+        #   - 7:30 PM CT = 2026-05-30 00:30 UTC   ← different UTC date!
+        # Day 2 in OKC = 2026-05-30 CT:
+        #   - 5 PM CT = 2026-05-30 22:00 UTC
+        #   - 7:30 PM CT = 2026-05-31 00:30 UTC
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            _classify_wcws_sub_brackets,
+        )
+        games = [
+            # Day 1 (May 29 CT) — first game stays in May 29 UTC.
+            self._g("Texas Tech", "Oklahoma",
+                    datetime(2026, 5, 29, 22, 0, tzinfo=timezone.utc)),
+            # Day 1 second game crosses into May 30 UTC.
+            self._g("UCLA", "Tennessee",
+                    datetime(2026, 5, 30, 0, 30, tzinfo=timezone.utc)),
+            # Day 2 (May 30 CT) first game.
+            self._g("Florida", "LSU",
+                    datetime(2026, 5, 30, 22, 0, tzinfo=timezone.utc)),
+            # Day 2 second game crosses into May 31 UTC.
+            self._g("Oregon", "Arkansas",
+                    datetime(2026, 5, 31, 0, 30, tzinfo=timezone.utc)),
+        ]
+        out = _classify_wcws_sub_brackets(games)
+        # All 4 Day-1-in-CT teams must land in sub1 even though their
+        # game times span 2 different UTC dates.
+        assert out["Texas Tech"] == "WCWS_sub1"
+        assert out["Oklahoma"] == "WCWS_sub1"
+        assert out["UCLA"] == "WCWS_sub1"
+        assert out["Tennessee"] == "WCWS_sub1"
+        # Day 2 teams in sub2.
+        assert out["Florida"] == "WCWS_sub2"
+        assert out["LSU"] == "WCWS_sub2"
+        assert out["Oregon"] == "WCWS_sub2"
+        assert out["Arkansas"] == "WCWS_sub2"
+
+
+class TestNcaaSoftballPlayoffBracketSource:
+    @staticmethod
+    def _src_with_games(games):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            NcaaSoftballPlayoffBracketSource,
+        )
+        src = NcaaSoftballPlayoffBracketSource()
+        src._bracket_games_cache = games
+        return src
+
+    def test_ko_stages_are_regional_and_wcws(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_softball import (
+            NcaaSoftballPlayoffBracketSource,
+        )
+        assert NcaaSoftballPlayoffBracketSource.KO_STAGES == ("SB_REG", "WCWS")
+
+    def test_league_context_code(self):
+        src = self._src_with_games([])
+        assert src._league_context_code() == "WCWS_PO"
+
+    def test_winner_advance_wcws_to_finals(self):
+        src = self._src_with_games([])
+        assert src._winner_advance_label("WCWS") == "WCWS_F"
+        assert src._winner_advance_label("SB_REG") is None
+
+    def test_strength_default_uses_softball_5_runs(self):
+        # Softball default is 5.0 runs (lower-scoring than baseball's 6.0).
+        src = self._src_with_games([])
+        out = src._strength_for({}, "Unknown")
+        assert out == {"pf_per_game": 5.0, "pa_per_game": 5.0}
+
+
+# =====================================================================
 # Phase O: NCAA Soccer (M's + W's parametrized on gender)
 # =====================================================================
 


### PR DESCRIPTION
Closes #43.

## Summary

Wires \`DoubleEliminationSource\` (#47) into both NCAA sports. Each \`enable_ncaa_baseball\` / \`enable_ncaa_softball\` toggle now spawns three sources sharing regular-season strengths:

- \`{Sport}RegularSource\` — regular-season win-count importance.
- \`{Sport}PlayoffSource\` — best-of-3 stages (Super Regional + MCWS/WCWS Finals) via BestOfNSeriesSource. Phase 1 behavior unchanged; extracted shared strength logic into a per-sport mixin.
- \`{Sport}PlayoffBracketSource\` — **new** — 4-team Regional double-elim (16 sites) + 8-team MCWS/WCWS bracket (modeled as two 4-team sub-brackets) via DoubleEliminationSource.

## Tie grouping_key strategy

- **Regional**: site name from ESPN headline (\`NCAA Baseball Championship - Auburn Regional\` → \`Auburn Regional\`).
- **8-team MCWS/WCWS bracket**: day-partition heuristic in venue-local time (Central Time for both Omaha and OKC). The two opening-day games (Day 1 in CT) define sub-bracket 1; the Day 2 games define sub-bracket 2; Day 3+ games inherit from opening-day classifications.

## Caught-and-fixed edge case: UTC midnight cross

WCWS evening games in OKC routinely cross UTC midnight (7:30 PM CT = 12:30 AM UTC the next day). Partitioning by UTC date would split a single broadcast day across two UTC dates and put opening-day pairings into different sub-brackets. The classifier now converts every timestamp to America/Chicago before partitioning. Test fixtures pin the midnight-cross case for both MCWS and WCWS.

## Live verification against 2025 MCWS data

Probed the deployed bracket source against ESPN's archived 2025 MCWS week:

\`\`\`
2025 MCWS bracket games fetched: 60
  BSB_REG: 48 games (16 sites × ~3 games avg double-elim)
  MCWS:    12 games  (sub1=6, sub2=6 — symmetric partition)

round_reached for the 8 MCWS teams:
  LSU              = 3  (= MCWS_F depth; sub-bracket winner)
  Coastal Carolina = 3  (= MCWS_F depth; sub-bracket winner)
  Arizona          = 2  Murray State = 2  Oregon State = 2  Louisville = 2
  UCLA             = 2  Arkansas    = 2

terminal_outcomes for the winners:
  LSU              = ['super_regional', 'omaha_bound', 'cws_final']
  Coastal Carolina = ['super_regional', 'omaha_bound', 'cws_final']
\`\`\`

Matches #43's acceptance criterion exactly: bracket winners reach MCWS depth, losers cap at MCWS depth, the \`omaha_bound\` + \`cws_final\` bands fire because a sub-bracket winner IS Omaha-bound (the structural advance from MCWS → MCWS_F is wired via \`_winner_advance_label\`).

## Test plan

- [x] 28 new unit tests covering headline parsers, sub-bracket classification (including the UTC-midnight-cross fix), source-class setup, strength defaults, and sibling-source non-collision.
- [x] Full regression suite still green: TestBestOfNSeriesSource (12), TestNcaaBaseballPlayoffSource (9), TestNcaaSoftballPlayoffSource (7), TestDoubleEliminationSource (22) — 50/50 pass after the strengths-mixin extraction.
- [x] Live verification against 2025 MCWS replay — bracket round_reached + terminal_outcomes match the structural expectations.
- [ ] **Visual artifact (Jake to verify)**: confirm the new Regional + MCWS bracket games appear in TiviMate / Plex / Jellyfin under the Top Matchups group when the WCWS / CWS bracket fires (WCWS: ~May 29-Jun 6; CWS: Jun 13-23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)