### PR TITLE
Closes #20: GroupStageSoccerSource — international-tournament group importance

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -349,7 +349,7 @@ def _build_weights(settings: Dict[str, Any]):
 
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
-        KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
+        GroupStageSoccerSource, KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
         MlsSource, NwslSource, LigaMxSource,
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
@@ -403,14 +403,23 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(_make_soccer("serie_a"))
     if settings.get("enable_ligue_1", False) and fd_key:
         sources.append(_make_soccer("ligue_1"))
-    # International tournaments. _make_soccer dispatches to
-    # KnockoutSoccerSource via the format="knockout" route. Group-stage
-    # importance isn't modeled in V1; group games still surface via
-    # fetch_upcoming with favorite + closeness signal only.
+    # International tournaments. Each toggle fans out to TWO sources
+    # sharing the same FD.org competition fetch:
+    #   - KnockoutSoccerSource via _make_soccer (KO_STAGES bracket); its
+    #     fetch_upcoming filters GROUP_STAGE out so it doesn't double
+    #     up with the group-stage source.
+    #   - GroupStageSoccerSource for the per-group "advance / eliminated"
+    #     importance signal (top 2 per group).
     if settings.get("enable_world_cup", False) and fd_key:
         sources.append(_make_soccer("world_cup"))
+        sources.append(GroupStageSoccerSource(
+            "world_cup", fd_api_key=fd_key, odds_api_key=odds_key,
+        ))
     if settings.get("enable_euros", False) and fd_key:
         sources.append(_make_soccer("euros"))
+        sources.append(GroupStageSoccerSource(
+            "euros", fd_api_key=fd_key, odds_api_key=odds_key,
+        ))
 
     # Additional FD.org free-tier leagues. Same _make_soccer
     # router; LEAGUE_CONTEXTS uses format="league" so dispatch goes

--- a/scoring.py
+++ b/scoring.py
@@ -30,6 +30,15 @@ from ._util import GENERIC_TEAM_SECOND_WORDS, TEAM_SUFFIX_TOKENS
 # to a clearly worst value but doesn't dominate finite scoring.
 UNRANKED = 26
 
+# Sentinel value used in the `cutoff` slot of LEAGUE_CONTEXTS thresholds
+# for group-stage contexts (WC_GS, EC_GS). The cutoff is unused by
+# compute_match_importance for group_advance format — advancement is
+# decided by top-N-per-group sort in GroupStageSoccerSource.terminal_
+# outcomes, not by a flat threshold comparator. The sentinel exists so
+# accidental code that DOES try to compare against this value raises a
+# loud TypeError instead of silently producing 0 importance.
+_GROUP_ADVANCE_SENTINEL = "_group_advance"
+
 
 @dataclass
 class Weights:
@@ -358,11 +367,6 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # WC Final / Winner outweigh UCL equivalents (5.0 / 10.0) because
     # the WC happens once every 4 years vs UCL every year, concentrating
     # consequence.
-    #
-    # NB: GROUP_STAGE importance isn't modeled in V1 — the bracket
-    # source only tracks knockout-round eligibility. Group-stage
-    # "survive and advance" games still pick up favorite + closeness
-    # signal but importance reads 0. Filed as follow-up.
     "WC": LeagueContext(
         code="WC", matchdays_total=0, format="knockout",
         thresholds=[
@@ -385,6 +389,34 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             ("WINNER",         "winner",       10.0),
         ],
         boundary_summary="R16 → QF → SF → Final → Champion (UEFA EURO)",
+    ),
+    # Group-stage advancement contexts for the two international
+    # tournaments above. GroupStageSoccerSource consumes these; the
+    # cutoff field is unused (advancement is decided by top-N-per-group
+    # sort in terminal_outcomes, not by a flat threshold). Each tuple's
+    # label + consequence_weight are what compute_match_importance reads.
+    # The `format="group_advance"` tag isn't pattern-matched anywhere
+    # yet — it's documentation that distinguishes this from "league" /
+    # "knockout" / "win_count" / "points_count" formats so a future
+    # refactor doesn't accidentally route a group-stage context into
+    # one of the threshold-cascade code paths.
+    #
+    # WC 2026 weights run higher than EURO because the WC carries more
+    # global stake; the +1 weight differential mirrors the knockout-bands
+    # gap above.
+    "WC_GS": LeagueContext(
+        code="WC_GS", matchdays_total=3, format="group_advance",
+        thresholds=[
+            (_GROUP_ADVANCE_SENTINEL, "advance", 4.0),
+        ],
+        boundary_summary="Top 2 per group → LAST_32 (FIFA World Cup group stage)",
+    ),
+    "EC_GS": LeagueContext(
+        code="EC_GS", matchdays_total=3, format="group_advance",
+        thresholds=[
+            (_GROUP_ADVANCE_SENTINEL, "advance", 3.0),
+        ],
+        boundary_summary="Top 2 per group → LAST_16 (UEFA EURO group stage)",
     ),
     # NCAA Division I baseball regular season. Win-count
     # thresholds tuned against historical NCAA Tournament selection

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -30,6 +30,7 @@ from .ncaam import NcaamSource
 from .nhl import NhlPlayoffSource, NhlRegularSource
 from .soccer import (
     COMPETITIONS as SOCCER_COMPETITIONS,
+    GroupStageSoccerSource,
     KnockoutSoccerSource,
     SoccerSource,
 )
@@ -49,5 +50,5 @@ __all__ = [
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",
     "NflRegularSource", "NflPlayoffSource",
-    "SoccerSource", "KnockoutSoccerSource", "SOCCER_COMPETITIONS",
+    "SoccerSource", "KnockoutSoccerSource", "GroupStageSoccerSource", "SOCCER_COMPETITIONS",
 ]

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -936,6 +936,25 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
             return "WINNER"
         return None
 
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Drop GROUP_STAGE fixtures so they're owned exclusively by the
+        sibling GroupStageSoccerSource. Knockout fixtures (PLAYOFFS,
+        LAST_32 / LAST_16 / QF / SF / FINAL / THIRD_PLACE) pass through.
+
+        Safe for non-tournament competitions (UCL, UEL, UECL) — their
+        FD.org fixtures never carry stage="GROUP_STAGE" so the filter
+        is a no-op there. The filter is keyed off `extra.stage` set by
+        SoccerSource.fetch_upcoming, NOT off `self.KO_STAGES` — that
+        keeps the filter robust even if FD.org introduces a knockout
+        stage label we haven't seen yet (better to over-emit a new
+        knockout stage than to under-emit a known one).
+        """
+        rows = super().fetch_upcoming(days_ahead)
+        return [
+            r for r in rows
+            if (r.extra or {}).get("stage") != "GROUP_STAGE"
+        ]
+
     # ---------- FD.org → canonical bracket-game adapter ----------
 
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
@@ -1103,3 +1122,210 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
             h += int(rng.random() < 0.70)
             a += int(rng.random() < 0.70)
         return "HOME" if h > a else "AWAY"
+
+
+# =====================================================================
+# GroupStageSoccerSource — international-tournament group importance
+# =====================================================================
+
+
+# Top-N advancement per group. EURO format and the OLD WC 32-team format
+# both advance the top 2. WC 2026's 48-team format technically advances
+# top 2 + 8-best-3rd-place across 12 groups; the 3rd-place tiebreaker is
+# a follow-up (see GroupStageSoccerSource docstring).
+_GROUP_ADVANCE_TOP_N = 2
+
+
+class GroupStageSoccerSource(SoccerSource):
+    """Group-stage Monte Carlo importance for international tournaments
+    (WC, EURO). Sibling to KnockoutSoccerSource for the same competition:
+    KnockoutSoccerSource models the post-group bracket, this source
+    models the group-stage mini-leagues.
+
+    Each tournament has N parallel groups of 4 teams, each playing 6
+    games (each team plays 3 games). `terminal_outcomes` classifies
+    each team as `"advance"` (top 2 in its group) or `"eliminated"`.
+    Outcome labels are intentionally hardcoded — the group-stage
+    classification ("did I finish top-2 in MY group") doesn't fit the
+    flat-position-threshold shape that league sources use, so we bypass
+    LEAGUE_CONTEXTS.thresholds' cutoff field and provide our own
+    advancement logic.
+
+    Cross-source `feeds_from` to KnockoutSoccerSource (a group winner
+    structurally faces a different LAST_16 opponent than a runner-up)
+    is NOT modeled — the simulator doesn't currently support cross-
+    source advancement chains. The two sources run independently, so
+    group-stage leverage covers the advance/eliminate decision only,
+    not the downstream knockout-path differential. Tracked in #53.
+
+    WC 2026 48-team format limitation: the top 2 + 8-best-3rd-place
+    advancement rule isn't modeled — only top-2-per-group counts as
+    advance. Teams who would advance via the 3rd-place tiebreaker
+    (points → goal diff → goals scored → fair play) read as
+    eliminated. Materially: 8 of 32 advancing teams (~25%) are
+    misclassified for the 2026 WC. Tracked in #52.
+
+    Wiring expectation: the plugin instantiates GroupStageSoccerSource
+    for the same `config_key` as KnockoutSoccerSource for tournaments
+    that have a group stage, and KnockoutSoccerSource filters
+    GROUP_STAGE matches out of its own `fetch_upcoming` so no
+    double-emission occurs.
+    """
+
+    supports_importance = True
+
+    # ---------- fetch_upcoming: filter to GROUP_STAGE ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Only emit group-stage fixtures — knockout fixtures are owned
+        by the sibling KnockoutSoccerSource for the same competition.
+
+        Remaps `extra.fd_competition_code` from the base "WC" / "EC"
+        (which routes to LEAGUE_CONTEXTS' knockout entries) to
+        "WC_GS" / "EC_GS" (the group-stage contexts whose `advance`
+        threshold this source's terminal_outcomes resolves against).
+        """
+        rows = super().fetch_upcoming(days_ahead)
+        gs_code = self._group_stage_context_code()
+        out: List[GameRow] = []
+        for r in rows:
+            if (r.extra or {}).get("stage") != "GROUP_STAGE":
+                continue
+            if isinstance(r.extra, dict):
+                r.extra["fd_competition_code"] = gs_code
+            out.append(r)
+        return out
+
+    def _group_stage_context_code(self) -> str:
+        """LEAGUE_CONTEXTS key for this competition's group-stage entry.
+        Convention: `<base_code>_GS` (e.g., WC → WC_GS, EC → EC_GS)."""
+        return f"{self.config.fd_code}_GS"
+
+    # ---------- group membership lookup ----------
+
+    def _team_group_map(self) -> Dict[str, str]:
+        """Build {team_name: group_letter} from the full-season fixtures.
+        Cached on the instance via `_team_group_cache`. A team's group is
+        whatever group label appears on any of its GROUP_STAGE fixtures
+        (every game involves teams from the same group, so a single
+        observation suffices)."""
+        cache: Optional[Dict[str, str]] = getattr(self, "_team_group_cache", None)
+        if cache is not None:
+            return cache
+        out: Dict[str, str] = {}
+        for m in self._fetch_all_season_matches():
+            if m.get("stage") != "GROUP_STAGE":
+                continue
+            group = m.get("group")
+            if not group:
+                continue
+            for side in ("homeTeam", "awayTeam"):
+                name = (m.get(side) or {}).get("name")
+                if name and name not in out:
+                    out[name] = group
+        self._team_group_cache = out
+        return out
+
+    # ---------- importance interface ----------
+
+    @property
+    def outcome_labels(self) -> List[str]:
+        return ["advance", "eliminated"]
+
+    def initial_state(self) -> Dict[str, Any]:
+        """Group-stage-only standings snapshot. Same shape as
+        SoccerSource.initial_state plus a "_team_group" lookup so
+        terminal_outcomes can sort within each group.
+        """
+        if self._initial_state_cache is not None:
+            return self._initial_state_cache
+        team_group = self._team_group_map()
+        matches = self._fetch_all_season_matches()
+        state: Dict[str, Any] = {
+            "_applied": frozenset(),
+            "_team_group": team_group,
+        }
+        applied: List[Any] = []
+        # Seed every group-stage participant with a zero row so apply_result
+        # doesn't need to defensively create rows.
+        for team in team_group:
+            state[team] = {"played": 0, "points": 0, "gf": 0, "ga": 0}
+        # Apply FINISHED group-stage matches.
+        for m in matches:
+            if m.get("stage") != "GROUP_STAGE":
+                continue
+            if m.get("status") != "FINISHED":
+                continue
+            ft = (m.get("score") or {}).get("fullTime") or {}
+            hg = ft.get("home")
+            ag = ft.get("away")
+            if hg is None or ag is None:
+                continue
+            home = (m.get("homeTeam") or {}).get("name")
+            away = (m.get("awayTeam") or {}).get("name")
+            fd_id = m.get("id")
+            if not home or not away or fd_id is None:
+                continue
+            if home not in state or away not in state:
+                continue  # defensive — team_group_map should have covered them
+            applied.append(fd_id)
+            self._mutate_apply(state, home, away, int(hg), int(ag))
+        state["_applied"] = frozenset(applied)
+        self._initial_state_cache = state
+        return state
+
+    def remaining_matches(self, state: Dict[str, Any]) -> List[GameRow]:
+        """Only emit GROUP_STAGE matches the simulator hasn't applied yet."""
+        applied = state.get("_applied", frozenset())
+        out: List[GameRow] = []
+        for m in self._fetch_all_season_matches():
+            if m.get("stage") != "GROUP_STAGE":
+                continue
+            fd_id = m.get("id")
+            if fd_id is None or fd_id in applied:
+                continue
+            home = (m.get("homeTeam") or {}).get("name")
+            away = (m.get("awayTeam") or {}).get("name")
+            start = parse_iso_utc(m.get("utcDate"))
+            if not home or not away or start is None:
+                continue
+            out.append(GameRow(
+                sport_prefix=self.config.sport_prefix,
+                sport_label=self.config.sport_label,
+                home=home,
+                away=away,
+                rank_home=None,
+                rank_away=None,
+                start_time=start,
+                extra={"fd_id": fd_id, "matchday": m.get("matchday")},
+            ))
+        return out
+
+    def terminal_outcomes(self, state: Dict[str, Any]) -> Dict[str, List[str]]:
+        """Top-N-per-group advancement. Within each group, sort by
+        (points desc, goal_diff desc, goals_for desc) — FIFA's standard
+        group-stage tiebreaker, minus the head-to-head and fair-play
+        layers that we don't track here. Top _GROUP_ADVANCE_TOP_N teams
+        get "advance"; the rest get "eliminated".
+        """
+        from collections import defaultdict
+        team_group = state.get("_team_group", {})
+        by_group: Dict[str, List[Tuple[str, Dict[str, int]]]] = defaultdict(list)
+        for team, row in state.items():
+            if team in ("_applied", "_team_group"):
+                continue
+            group = team_group.get(team)
+            if group is None:
+                continue
+            by_group[group].append((team, row))
+
+        outcomes: Dict[str, List[str]] = {}
+        for group, teams in by_group.items():
+            teams.sort(key=lambda kv: (
+                -kv[1]["points"],
+                -(kv[1]["gf"] - kv[1]["ga"]),
+                -kv[1]["gf"],
+            ))
+            for i, (team, _row) in enumerate(teams):
+                outcomes[team] = ["advance"] if i < _GROUP_ADVANCE_TOP_N else ["eliminated"]
+        return outcomes

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -6167,3 +6167,358 @@ class TestDoubleEliminationSource:
         })
         for game_index in (1, 2, 3, 4, 5, 6, 7):
             assert src._is_decisive_game(tie, game_index, games_in_tie=7) is True
+
+
+# =====================================================================
+# #20: GroupStageSoccerSource
+# =====================================================================
+
+
+class TestGroupStageSoccerSource:
+    """End-to-end importance source for international-tournament group
+    stages (WC, EURO). Uses a patched `_fetch_all_season_matches` so no
+    HTTP touches the test path."""
+
+    @staticmethod
+    def _make_source(matches):
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        src = GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+        src._all_matches_cache = matches
+        src._team_group_cache = None
+        src._initial_state_cache = None
+        src._strengths_cache = None
+        return src
+
+    @staticmethod
+    def _match(fd_id, group, home, away, hg=None, ag=None, status="SCHEDULED", date="2026-06-11T19:00:00Z"):
+        return {
+            "id": fd_id,
+            "stage": "GROUP_STAGE",
+            "group": group,
+            "matchday": 1,
+            "homeTeam": {"name": home},
+            "awayTeam": {"name": away},
+            "status": status,
+            "utcDate": date,
+            "score": {"fullTime": {"home": hg, "away": ag}} if status == "FINISHED" else {},
+        }
+
+    @staticmethod
+    def _ko_match(fd_id, stage, home, away):
+        return {
+            "id": fd_id, "stage": stage,
+            "homeTeam": {"name": home}, "awayTeam": {"name": away},
+            "status": "SCHEDULED",
+            "utcDate": "2026-07-01T19:00:00Z",
+            "score": {},
+        }
+
+    # ---------- outcome_labels ----------
+
+    def test_outcome_labels_are_advance_and_eliminated(self):
+        src = self._make_source([])
+        assert src.outcome_labels == ["advance", "eliminated"]
+
+    # ---------- _team_group_map ----------
+
+    def test_team_group_map_builds_from_fixtures(self):
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa"),
+            self._match(2, "GROUP_A", "Argentina", "Chile"),
+            self._match(3, "GROUP_B", "Germany", "Scotland"),
+        ]
+        src = self._make_source(matches)
+        out = src._team_group_map()
+        assert out["Mexico"] == "GROUP_A"
+        assert out["South Africa"] == "GROUP_A"
+        assert out["Argentina"] == "GROUP_A"
+        assert out["Chile"] == "GROUP_A"
+        assert out["Germany"] == "GROUP_B"
+        assert out["Scotland"] == "GROUP_B"
+
+    def test_team_group_map_ignores_knockout_matches(self):
+        # Knockout fixtures don't carry a group field. Make sure they're
+        # filtered out — including them would put a Group A winner into
+        # "no group" classification when the knockout schedule resolves.
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa"),
+            self._ko_match(99, "LAST_32", "Mexico", "Germany"),
+        ]
+        src = self._make_source(matches)
+        out = src._team_group_map()
+        # Mexico's group stays GROUP_A despite the LAST_32 fixture.
+        assert out["Mexico"] == "GROUP_A"
+        assert "Germany" not in out  # KO-only opponent isn't in group map
+
+    # ---------- initial_state ----------
+
+    def test_initial_state_seeds_zero_rows_for_every_group_team(self):
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa"),
+            self._match(2, "GROUP_A", "Argentina", "Chile"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        for team in ("Mexico", "South Africa", "Argentina", "Chile"):
+            assert state[team] == {"played": 0, "points": 0, "gf": 0, "ga": 0}
+        assert state["_applied"] == frozenset()
+        assert state["_team_group"]["Mexico"] == "GROUP_A"
+
+    def test_initial_state_applies_finished_group_matches(self):
+        matches = [
+            # Mexico 3-1 South Africa
+            self._match(1, "GROUP_A", "Mexico", "South Africa",
+                        hg=3, ag=1, status="FINISHED"),
+            # Argentina 2-0 Chile
+            self._match(2, "GROUP_A", "Argentina", "Chile",
+                        hg=2, ag=0, status="FINISHED"),
+            # Knockout match — must NOT be applied.
+            self._ko_match(99, "LAST_32", "Mexico", "Germany"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        assert state["Mexico"] == {"played": 1, "points": 3, "gf": 3, "ga": 1}
+        assert state["South Africa"] == {"played": 1, "points": 0, "gf": 1, "ga": 3}
+        assert state["Argentina"] == {"played": 1, "points": 3, "gf": 2, "ga": 0}
+        assert state["Chile"] == {"played": 1, "points": 0, "gf": 0, "ga": 2}
+        assert state["_applied"] == frozenset({1, 2})
+
+    def test_initial_state_skips_knockout_matches(self):
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa",
+                        hg=3, ag=1, status="FINISHED"),
+            # A FINISHED knockout match must NOT update group standings.
+            {
+                "id": 99, "stage": "LAST_32",
+                "homeTeam": {"name": "Mexico"}, "awayTeam": {"name": "Germany"},
+                "status": "FINISHED",
+                "utcDate": "2026-07-01T19:00:00Z",
+                "score": {"fullTime": {"home": 10, "away": 0}},
+            },
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        assert state["Mexico"]["points"] == 3  # ONLY the group match counts
+        assert state["Mexico"]["gf"] == 3
+        # Germany isn't in the group map → no row at all.
+        assert "Germany" not in state
+
+    # ---------- remaining_matches ----------
+
+    def test_remaining_matches_filters_to_group_stage(self):
+        matches = [
+            # Scheduled group matches
+            self._match(1, "GROUP_A", "Mexico", "South Africa"),
+            self._match(2, "GROUP_A", "Argentina", "Chile"),
+            # Knockout — should NOT be in remaining_matches
+            self._ko_match(99, "LAST_32", "Mexico", "Germany"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        rem = src.remaining_matches(state)
+        assert {m.extra["fd_id"] for m in rem} == {1, 2}
+
+    def test_remaining_matches_excludes_already_applied(self):
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa",
+                        hg=3, ag=1, status="FINISHED"),
+            self._match(2, "GROUP_A", "Argentina", "Chile"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        rem = src.remaining_matches(state)
+        assert {m.extra["fd_id"] for m in rem} == {2}
+
+    # ---------- terminal_outcomes ----------
+
+    def test_terminal_outcomes_top_2_per_group_advance(self):
+        # Group A finished: Mexico 9pts, Argentina 6pts, Chile 3pts, SA 0pts.
+        # Top 2 (Mexico, Argentina) advance; Chile + SA eliminated.
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa", 3, 0, "FINISHED"),
+            self._match(2, "GROUP_A", "Argentina", "Chile", 2, 0, "FINISHED"),
+            self._match(3, "GROUP_A", "Mexico", "Chile", 2, 1, "FINISHED"),
+            self._match(4, "GROUP_A", "Argentina", "South Africa", 4, 0, "FINISHED"),
+            self._match(5, "GROUP_A", "Mexico", "Argentina", 1, 0, "FINISHED"),
+            self._match(6, "GROUP_A", "Chile", "South Africa", 2, 1, "FINISHED"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        outcomes = src.terminal_outcomes(state)
+        assert outcomes["Mexico"] == ["advance"]
+        assert outcomes["Argentina"] == ["advance"]
+        assert outcomes["Chile"] == ["eliminated"]
+        assert outcomes["South Africa"] == ["eliminated"]
+
+    def test_terminal_outcomes_ties_break_on_goal_diff_then_goals_for(self):
+        # 2 teams tied on points (3 each): GD decides.
+        # Mexico 1-0 SA, SA 0-1 Argentina, Mexico 0-3 Argentina, Argentina 2-0 Chile,
+        # Chile 2-1 Mexico, SA 1-1 Chile
+        # Standings:
+        #   Argentina: 3 wins = 9pts, GF=6, GA=0, GD=+6
+        #   Mexico:    1W 2L  = 3pts, GF=2, GA=6, GD=-4
+        #   Chile:     1W 1D 1L = 4pts, GF=3, GA=3, GD=0
+        #   SA:        0W 1D 2L = 1pt,  GF=1, GA=3, GD=-2
+        # Final order: Argentina > Chile > SA > Mexico
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa", 1, 0, "FINISHED"),
+            self._match(2, "GROUP_A", "South Africa", "Argentina", 0, 1, "FINISHED"),
+            self._match(3, "GROUP_A", "Mexico", "Argentina", 0, 3, "FINISHED"),
+            self._match(4, "GROUP_A", "Argentina", "Chile", 2, 0, "FINISHED"),
+            self._match(5, "GROUP_A", "Chile", "Mexico", 2, 1, "FINISHED"),
+            self._match(6, "GROUP_A", "South Africa", "Chile", 1, 1, "FINISHED"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        outcomes = src.terminal_outcomes(state)
+        assert outcomes["Argentina"] == ["advance"]
+        assert outcomes["Chile"] == ["advance"]
+        assert outcomes["South Africa"] == ["eliminated"]
+        assert outcomes["Mexico"] == ["eliminated"]
+
+    def test_terminal_outcomes_handles_multiple_groups_independently(self):
+        # Group A: Mexico/Argentina advance; Chile/SA eliminated.
+        # Group B: Germany/France advance; Brazil/Spain eliminated.
+        matches = [
+            self._match(1, "GROUP_A", "Mexico", "South Africa", 3, 0, "FINISHED"),
+            self._match(2, "GROUP_A", "Argentina", "Chile", 2, 0, "FINISHED"),
+            self._match(3, "GROUP_B", "Germany", "Spain", 4, 0, "FINISHED"),
+            self._match(4, "GROUP_B", "France", "Brazil", 2, 1, "FINISHED"),
+        ]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        outcomes = src.terminal_outcomes(state)
+        # Group A
+        assert outcomes["Mexico"] == ["advance"]
+        assert outcomes["Argentina"] == ["advance"]
+        assert outcomes["Chile"] == ["eliminated"]
+        assert outcomes["South Africa"] == ["eliminated"]
+        # Group B
+        assert outcomes["Germany"] == ["advance"]
+        assert outcomes["France"] == ["advance"]
+        assert outcomes["Brazil"] == ["eliminated"]
+        assert outcomes["Spain"] == ["eliminated"]
+
+    def test_terminal_outcomes_empty_state_returns_empty(self):
+        src = self._make_source([])
+        state = src.initial_state()
+        outcomes = src.terminal_outcomes(state)
+        assert outcomes == {}
+
+    # ---------- apply_result threads through immutably ----------
+
+    def test_apply_result_does_not_mutate_input_state(self):
+        from dispatcharr_ranked_matchups.sources.base import GameRow, MatchResult
+        matches = [self._match(1, "GROUP_A", "Mexico", "South Africa")]
+        src = self._make_source(matches)
+        state = src.initial_state()
+        snap_mex = dict(state["Mexico"])
+        snap_sa = dict(state["South Africa"])
+        snap_applied = set(state["_applied"])
+
+        match = GameRow(
+            sport_prefix="WC", sport_label="FIFA World Cup",
+            home="Mexico", away="South Africa",
+            rank_home=None, rank_away=None,
+            start_time=None, extra={"fd_id": 1},
+        )
+        result = MatchResult(home_goals=3, away_goals=1)
+        new_state = src.apply_result(state, match, result)
+        # Original untouched.
+        assert state["Mexico"] == snap_mex
+        assert state["South Africa"] == snap_sa
+        assert set(state["_applied"]) == snap_applied
+        # New state has the result.
+        assert new_state["Mexico"]["points"] == 3
+        assert new_state["Mexico"]["gf"] == 3
+        assert 1 in new_state["_applied"]
+
+
+class TestKnockoutSoccerSourceSkipsGroupStage:
+    """Once GroupStageSoccerSource owns group-stage fixtures, the sibling
+    KnockoutSoccerSource MUST filter them out of its own fetch_upcoming
+    so the plugin doesn't double-emit group games as both a knockout
+    and a group-stage GameRow."""
+
+    def test_fetch_upcoming_drops_group_stage_extras(self):
+        # Build a fake KnockoutSoccerSource and monkey-patch the parent
+        # SoccerSource.fetch_upcoming to return a mix of stages.
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        from dispatcharr_ranked_matchups.sources.soccer import (
+            KnockoutSoccerSource, SoccerSource,
+        )
+
+        rows = [
+            GameRow(sport_prefix="WC", sport_label="FIFA World Cup",
+                    home="Mexico", away="SA", rank_home=None, rank_away=None,
+                    start_time=None, extra={"fd_id": 1, "stage": "GROUP_STAGE"}),
+            GameRow(sport_prefix="WC", sport_label="FIFA World Cup",
+                    home="Brazil", away="Germany", rank_home=None, rank_away=None,
+                    start_time=None, extra={"fd_id": 2, "stage": "LAST_32"}),
+            GameRow(sport_prefix="WC", sport_label="FIFA World Cup",
+                    home="France", away="Spain", rank_home=None, rank_away=None,
+                    start_time=None, extra={"fd_id": 3, "stage": "FINAL"}),
+        ]
+        src = KnockoutSoccerSource("world_cup", fd_api_key="x")
+        # Monkey-patch the parent's fetch_upcoming to return our fixture.
+        original = SoccerSource.fetch_upcoming
+        try:
+            SoccerSource.fetch_upcoming = lambda self, days_ahead=7: list(rows)
+            out = src.fetch_upcoming()
+        finally:
+            SoccerSource.fetch_upcoming = original
+        out_ids = {r.extra["fd_id"] for r in out}
+        # The GROUP_STAGE row must be filtered out; the two KO rows pass through.
+        assert out_ids == {2, 3}
+
+    def test_filter_no_op_for_competitions_without_group_stage(self):
+        # UCL fixtures don't carry stage="GROUP_STAGE" — the filter is a
+        # safe no-op, ALL rows pass through.
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        from dispatcharr_ranked_matchups.sources.soccer import (
+            KnockoutSoccerSource, SoccerSource,
+        )
+        rows = [
+            GameRow(sport_prefix="UCL", sport_label="UEFA Champions League",
+                    home="A", away="B", rank_home=None, rank_away=None,
+                    start_time=None, extra={"fd_id": 1, "stage": "LAST_16"}),
+            GameRow(sport_prefix="UCL", sport_label="UEFA Champions League",
+                    home="C", away="D", rank_home=None, rank_away=None,
+                    start_time=None, extra={"fd_id": 2, "stage": "QUARTER_FINALS"}),
+        ]
+        src = KnockoutSoccerSource("ucl", fd_api_key="x")
+        original = SoccerSource.fetch_upcoming
+        try:
+            SoccerSource.fetch_upcoming = lambda self, days_ahead=7: list(rows)
+            out = src.fetch_upcoming()
+        finally:
+            SoccerSource.fetch_upcoming = original
+        assert {r.extra["fd_id"] for r in out} == {1, 2}
+
+
+class TestGroupStageContextCodes:
+    """LEAGUE_CONTEXTS entries for WC_GS / EC_GS must exist with the
+    `advance` outcome label so the GroupStageSoccerSource's
+    fetch_upcoming-remapped `fd_competition_code` routes correctly."""
+
+    def test_wc_gs_context_has_advance_threshold(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS.get("WC_GS")
+        assert ctx is not None, "WC_GS missing from LEAGUE_CONTEXTS"
+        labels = [t[1] for t in ctx.thresholds]
+        assert "advance" in labels
+
+    def test_ec_gs_context_has_advance_threshold(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS.get("EC_GS")
+        assert ctx is not None, "EC_GS missing from LEAGUE_CONTEXTS"
+        labels = [t[1] for t in ctx.thresholds]
+        assert "advance" in labels
+
+    def test_wc_gs_weight_is_higher_than_ec_gs(self):
+        # WC carries more global stake than EURO; the group-stage
+        # advance weight should mirror the knockout-bands weighting.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        wc_weight = next(w for _, lbl, w in LEAGUE_CONTEXTS["WC_GS"].thresholds if lbl == "advance")
+        ec_weight = next(w for _, lbl, w in LEAGUE_CONTEXTS["EC_GS"].thresholds if lbl == "advance")
+        assert wc_weight > ec_weight


### PR DESCRIPTION
Closes #20. Follow-ups filed as #52 (WC 48-team 3rd-place rule) and #53 (cross-source feeds_from to knockout opponent).

## Summary

\`KnockoutSoccerSource\` shipped earlier modeled only the post-group bracket; group games (WC 2026 = 72 games, EURO = 36 games) carried importance=0. This PR adds a sibling \`GroupStageSoccerSource\` that provides the Monte Carlo \"did I make it out of my group\" signal.

Each \`enable_world_cup\` / \`enable_euros\` toggle now fans out to two sources:
- \`KnockoutSoccerSource\` — knockout bracket (PLAYOFFS / LAST_32 / LAST_16 / QF / SF / FINAL). \`fetch_upcoming\` now filters GROUP_STAGE out so it doesn't double-emit alongside the group source.
- \`GroupStageSoccerSource\` — group-stage advancement importance. Top-N-per-group sort → \`advance\` / \`eliminated\` outcome labels. Inherits FD.org fetch + Poisson sampling + apply_result from SoccerSource; overrides the importance interface.

Two new LEAGUE_CONTEXTS entries: \`WC_GS\` (weight 4.0) and \`EC_GS\` (weight 3.0). The cutoff slot is unused for \`group_advance\` format — \`terminal_outcomes\` does the per-group sort instead.

## Live verification

### EURO 2024 (completed full data)

All 6 groups classified correctly per top-2-per-group:

| Group | Advance | Eliminated |
|---|---|---|
| A | Germany, Switzerland | Hungary, Scotland |
| B | Spain, Italy | Croatia, Albania |
| C | England, Slovenia | Denmark, Serbia |
| D | Austria, France | Netherlands, Poland |
| E | Romania, Belgium | Slovakia, Ukraine |
| F | Portugal, Turkey | Georgia, Czechia |

### WC 2026 Mexico vs South Africa, MD1 (80 sims):

\`\`\`
LEAGUE_CONTEXTS lookup: WC_GS
raw_importance=3.627
notes:
  Mexico advance:        0.51 leverage × 4.0 = 2.04
  South Africa advance:  0.40 leverage × 4.0 = 1.58
\`\`\`

Issue acceptance criterion: nonzero leverage on \`advance\` for both teams. ✓ Today these reported 0.

## Test plan

- [x] 18 new unit tests covering source class behavior, LEAGUE_CONTEXTS entries, and the KnockoutSoccerSource GROUP_STAGE filter.
- [x] Regression: KnockoutSoccerSource non-tournament competitions (UCL) unaffected by the filter — verified via test + EURO 2024 live data.
- [x] Live verification against EURO 2024 + WC 2026 fixtures (above).
- [ ] **Visual artifact (Jake to verify)**: confirm the WC 2026 group games surface in TiviMate / Plex / Jellyfin with elevated importance scores once WC kicks off June 11. Should see games like \"Mexico vs South Africa\" and other MD1 openers in the Top Matchups group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)