### PR TITLE
Closes #1: per-matchup channel logos via TheSportsDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ downstream is sport-agnostic.
 | `sources/nba.py` | ESPN unofficial API (stats.nba.com is WAF-blocked from most homelab egress). `NbaRegularSource` uses raw win count. `NbaPlayoffSource` is a BestOfNSeriesSource with uniform SERIES_LENGTH=7 (R1 / CSF / CF / FINALS). Stage routing comes from parsing the ESPN headline ("East 1st Round - Game 3" etc.) — the only place ESPN exposes the playoff round. All-Star Tournament games (which ESPN tags `season.type=2` but `competition.type.abbreviation=ALLSTAR`) are filtered out so the regular-season team list stays at 30. |
 | `sources/mls.py` | ESPN unofficial API for the schedule + The Odds API (`soccer_usa_mls`) for closeness. Intentionally thin: `MlsSource` does NOT inherit `PointsBasedSportSource` and `supports_importance=False`. MLS surfaces with favorite + closeness signals only; standings-based importance and the mixed-format MLS Cup bracket (best-of-3 R1 + single-leg subsequent rounds) are tracked in #30. Team-name fuzzy matching reuses `_util.TEAM_SUFFIX_TOKENS` — never add "united" to that list (it's a substantive body word for Atlanta United / D.C. United / Minnesota United). |
 | `sources/soccer.py` | Football-Data.org for fixtures+standings, The Odds API for spreads. League position used as rank. `SoccerSource` is league-shaped (PL, ELC); `KnockoutSoccerSource` is bracket-shaped (UCL) — multi-inherits from `AggregateLegSource` (bracket state machine) + `SoccerSource` (FD.org fetch / strengths) with the MRO `K → AggregateLegSource → BracketSportSource → SoccerSource → SportSource`. Routed by `LEAGUE_CONTEXTS[fd_code].format`. |
+| `logos.py` | TheSportsDB matchup-thumbnail resolver. Looks up the curated game via `searchevents.php` (team-name pair, date-tolerance ±2 days, sport-hint disambiguation), downloads the 960x540 graphic to `/data/logos/ranked_matchups_<sha1>.jpg`, and registers a `Logo` row pointing at it. Persistent per-marker cache (`sportsdb_thumb_cache.json`, 14d positive TTL / 1d negative TTL) means apply only HTTP-probes each fixture once. Field-event sources (`away=="Field"`) and dry_run short-circuit the lookup. Stale-file sweep at the end of each apply prunes JPGs whose marker isn't in the live set. |
 
 State (gitignored, lives in `<plugin_dir>/`):
 - `cache.json` — last refresh result (curated game list with score breakdowns)
@@ -229,6 +230,11 @@ docker logs --since 5m dispatcharr 2>&1 | grep ranked_matchups | tail -30
 - Multi-time scheduler (`scheduled_times = "0400,1000,1600,2200"`)
 - Both file-based and settings-based API keys (settings preferred, masked UI)
 - Description includes kickoff time + WHY breakdown
+- Per-matchup channel logos from TheSportsDB (`logos.py`): each virtual
+  channel gets a pre-rendered 960x540 graphic showing both team crests +
+  league badge, replacing the inherited source-channel logo. Free public
+  test tier (`api_key="3"`) is the default; falls back to source-channel
+  logo for offseason / untracked-league / field-event fixtures.
 
 **Known limitations & open work:** tracked as GitHub issues so they don't
 drift. Quick map (most user-facing first):
@@ -243,8 +249,6 @@ drift. Quick map (most user-facing first):
   weight knobs)](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/issues/9)
 - [#10 — Standings deltas in EPG description (data is in
   `cache.json`, just not surfaced)](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/issues/10)
-- [#1 — Per-channel matchup JPG as virtual channel
-  logo](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/issues/1)
 - [#3 — Label catch-up matchdays (40-of-46 rendering on a backlog
   fixture)](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/issues/3)
 

--- a/logos.py
+++ b/logos.py
@@ -1,0 +1,341 @@
+"""TheSportsDB matchup-thumbnail resolver and local-cache writer.
+
+TheSportsDB pre-renders 960x540 matchup graphics (both team crests, league
+wordmark, country/region backdrop) for every event in its database. This
+module looks up a curated game's matchup thumb, downloads it once, and
+points a Dispatcharr Logo row at the local file. Used by plugin.py's
+apply pipeline to give each virtual channel a per-game logo instead of
+inheriting the source channel's logo.
+
+DO NOT swap to a remote-URL-only path. Dispatcharr's logo cache reads
+/data/<path> directly off disk when the Logo URL starts with /data, and
+proxies remote URLs through an in-memory HTTP cache that doesn't survive
+a container restart. Local storage is both faster and resilient to
+SportsDB outages or CDN URL rotations.
+
+API docs: https://www.thesportsdb.com/api.php
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import urllib.parse
+import urllib.request
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_URL = "https://www.thesportsdb.com/api/v1/json/{key}/searchevents.php?e={q}"
+_HTTP_TIMEOUT_S = 10.0
+_DOWNLOAD_TIMEOUT_S = 15.0
+_USER_AGENT = "dispatcharr_ranked_matchups"
+
+# SportsDB returns a date string; allow ±2 days to absorb timezone wobble between
+# the kickoff UTC we have and the league-local date SportsDB indexes.
+_DATE_TOLERANCE_DAYS = 2
+
+# Re-probe positive cache entries every 14 days (SportsDB rarely changes thumb
+# URLs but does occasionally rebuild). Re-probe negatives every 1 day because
+# events get indexed late and a miss now can be a hit tomorrow.
+_POSITIVE_TTL = timedelta(days=14)
+_NEGATIVE_TTL = timedelta(days=1)
+
+# Files we own under /data/logos/. The filename prefix is the cleanup signature.
+LOGO_DIR = "/data/logos"
+LOGO_FILENAME_PREFIX = "ranked_matchups_"
+
+# Trailing club-qualifier tokens that SportsDB drops from its event names
+# (Manchester City vs Aston Villa, not Manchester City FC vs Aston Villa FC).
+# Matters for European soccer where Football-Data.org returns the long form.
+_TRAILING_CLUB_QUALIFIERS = ("FC", "AFC", "CF", "SC", "FK", "AC")
+_TRAILING_QUALIFIER_RE = re.compile(
+    r"\s+(" + "|".join(_TRAILING_CLUB_QUALIFIERS) + r")$", re.IGNORECASE
+)
+
+# Sentinel `away` value used by field-event sources (F1, golf, UFC, tennis,
+# NASCAR). These have no home/away matchup so SportsDB lookup is skipped.
+_FIELD_AWAY_SENTINEL = "Field"
+
+# Plugin sport_prefix -> substring that must appear in SportsDB's strLeague or
+# strSport for the result to be accepted. Disambiguates same-name cross-sport
+# collisions (e.g. "Alabama vs Auburn" is both a football and basketball
+# fixture). Missing entries mean no disambiguation — date filter alone.
+_SPORT_HINT: dict[str, str] = {
+    "CFB": "NCAA",
+    "CBB": "NCAA",
+    "CWBB": "NCAA",
+    "NCAAB": "NCAA",
+    "NCAAS": "NCAA",
+    "NCAAMS": "NCAA",
+    "NCAAWS": "NCAA",
+    "NFL": "NFL",
+    "NHL": "NHL",
+    "MLB": "MLB",
+    "NBA": "NBA",
+    "WNBA": "WNBA",
+    "MLS": "Major League Soccer",
+    "NWSL": "NWSL",
+    "LigaMX": "Mexican",
+    "EPL": "English Premier League",
+    "EFL": "English League Championship",
+    "UCL": "Champions League",
+    "BL1": "Bundesliga",
+    "LaLiga": "Spanish La Liga",
+    "SerieA": "Italian Serie A",
+    "Ligue1": "French Ligue 1",
+    "WC": "FIFA World Cup",
+    "EURO": "UEFA European Championship",
+    "Eredivisie": "Eredivisie",
+    "PrimeiraLiga": "Portuguese",
+    "BSA": "Brazilian",
+}
+
+
+def _strip_trailing_qualifier(name: str) -> str:
+    """Strip trailing FC/AFC/CF/SC/FK/AC qualifiers iteratively.
+
+    "Manchester City FC" -> "Manchester City"
+    "Manchester City"    -> "Manchester City"  (no-op)
+    """
+    n = (name or "").strip()
+    while True:
+        nxt = _TRAILING_QUALIFIER_RE.sub("", n).strip()
+        if nxt == n:
+            return n
+        n = nxt
+
+
+def _build_search_query(home: str, away: str) -> str:
+    """SportsDB searchevents accepts 'Home vs Away' (case-insensitive)."""
+    return f"{_strip_trailing_qualifier(home)} vs {_strip_trailing_qualifier(away)}"
+
+
+def marker_to_filename(marker: str) -> str:
+    """Map a game marker (e.g. 'ranked_matchups:EPL:fd_535345') to a stable,
+    filesystem-safe filename inside LOGO_DIR.
+
+    SHA1 keeps the path short and avoids worrying about marker characters that
+    aren't filesystem-safe (the marker contains ':' which works on Linux but
+    is hostile on Windows-mounted /data shares).
+    """
+    digest = hashlib.sha1(marker.encode("utf-8")).hexdigest()[:16]
+    return f"{LOGO_FILENAME_PREFIX}{digest}.jpg"
+
+
+def _date_in_tolerance(event_date_str: str, expected_dt: datetime) -> bool:
+    """SportsDB's dateEvent is YYYY-MM-DD in the league-local timezone.
+
+    Expected_dt is plugin-supplied UTC. ±2 days catches Australian /
+    European fixtures whose local date is a day off from UTC midnight.
+    """
+    try:
+        ev_date = date.fromisoformat(event_date_str)
+    except (TypeError, ValueError):
+        return False
+    return abs((ev_date - expected_dt.date()).days) <= _DATE_TOLERANCE_DAYS
+
+
+def _hint_matches(event: dict, sport_prefix: Optional[str]) -> bool:
+    """Verify the SportsDB event matches the expected sport, if we have a hint.
+
+    Falls open (returns True) when the prefix isn't in the hint map — better
+    to accept a slightly-wrong match than to miss every game from an unmapped
+    sport.
+    """
+    if not sport_prefix:
+        return True
+    hint = _SPORT_HINT.get(sport_prefix)
+    if not hint:
+        return True
+    haystack = (
+        (event.get("strLeague") or "") + " " + (event.get("strSport") or "")
+    ).lower()
+    return hint.lower() in haystack
+
+
+def _http_get_json(url: str) -> Optional[dict]:
+    """Single-shot JSON GET. Returns None on any failure (network, parse, HTTP)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            if resp.status != 200:
+                return None
+            return json.load(resp)
+    except Exception as e:
+        logger.debug("sportsdb GET %s failed: %s", url, e)
+        return None
+
+
+def resolve_thumb_url(
+    home: str,
+    away: str,
+    expected_dt: datetime,
+    sport_prefix: Optional[str],
+    api_key: str = "3",
+) -> Optional[str]:
+    """Search SportsDB for a matchup event and return its strThumb URL.
+
+    Returns None when:
+      - away == "Field" (field-event sentinel — no h2h matchup)
+      - the search returns no events
+      - no event matches both the date tolerance AND the sport hint
+      - the matched event has no strThumb
+
+    `api_key`: "3" is SportsDB's free test tier. Patreon keys
+    (https://www.thesportsdb.com/api.php) unlock higher rate limits.
+    """
+    if not home or not away:
+        return None
+    if away == _FIELD_AWAY_SENTINEL:
+        return None
+
+    q = _build_search_query(home, away)
+    url = _SEARCH_URL.format(
+        key=urllib.parse.quote(api_key or "3"),
+        q=urllib.parse.quote(q),
+    )
+    payload = _http_get_json(url)
+    if not payload:
+        return None
+
+    events = payload.get("event") or []
+    for ev in events:
+        if not _date_in_tolerance(ev.get("dateEvent", ""), expected_dt):
+            continue
+        if not _hint_matches(ev, sport_prefix):
+            continue
+        thumb = ev.get("strThumb")
+        if thumb:
+            return thumb
+    return None
+
+
+def download_thumb(thumb_url: str, dest_path: str) -> bool:
+    """Download a thumb URL to dest_path atomically. Returns True on success.
+
+    Atomic via tmp-file + os.replace so a partial download never leaves a
+    half-written JPG that Dispatcharr's logo cache would serve as broken.
+    """
+    if not thumb_url:
+        return False
+    req = urllib.request.Request(thumb_url, headers={"User-Agent": _USER_AGENT})
+    tmp_path = f"{dest_path}.tmp.{os.getpid()}"
+    try:
+        with urllib.request.urlopen(req, timeout=_DOWNLOAD_TIMEOUT_S) as resp:
+            if resp.status != 200:
+                return False
+            with open(tmp_path, "wb") as f:
+                while True:
+                    chunk = resp.read(64 * 1024)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        os.replace(tmp_path, dest_path)
+        return True
+    except Exception as e:
+        logger.warning("sportsdb download %s failed: %s", thumb_url, e)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return False
+
+
+class ThumbCache:
+    """Persistent JSON cache of marker -> (timestamp_iso, thumb_url_or_null).
+
+    Negative entries (URL is None) are cached too so we don't re-probe every
+    apply, but with a shorter TTL than positives because SportsDB indexes
+    fixtures gradually — a miss this morning can be a hit by evening.
+    """
+
+    def __init__(self, cache_path: str):
+        self.cache_path = cache_path
+        self._data: dict[str, list] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not os.path.exists(self.cache_path):
+            return
+        try:
+            with open(self.cache_path, "r", encoding="utf-8") as f:
+                obj = json.load(f)
+            if isinstance(obj, dict):
+                self._data = obj
+        except Exception as e:
+            logger.warning("sportsdb cache load failed (%s); starting fresh", e)
+            self._data = {}
+
+    def save(self) -> None:
+        tmp = f"{self.cache_path}.tmp.{os.getpid()}"
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(self._data, f)
+            os.replace(tmp, self.cache_path)
+        except Exception as e:
+            logger.warning("sportsdb cache save failed: %s", e)
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+    def get(self, marker: str) -> tuple[bool, Optional[str]]:
+        """Returns (fresh, url_or_None). fresh=False means caller should refetch."""
+        entry = self._data.get(marker)
+        if not entry or len(entry) < 2:
+            return False, None
+        try:
+            ts = datetime.fromisoformat(entry[0])
+        except (TypeError, ValueError):
+            return False, None
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        url = entry[1]
+        age = datetime.now(timezone.utc) - ts
+        ttl = _NEGATIVE_TTL if url is None else _POSITIVE_TTL
+        if age > ttl:
+            return False, url
+        return True, url
+
+    def put(self, marker: str, url: Optional[str]) -> None:
+        self._data[marker] = [datetime.now(timezone.utc).isoformat(), url]
+
+    def prune(self, live_markers: set[str]) -> int:
+        """Drop entries whose marker isn't in live_markers. Returns count dropped."""
+        stale = [k for k in self._data if k not in live_markers]
+        for k in stale:
+            del self._data[k]
+        return len(stale)
+
+
+def sweep_stale_logo_files(live_markers: set[str], logo_dir: str = LOGO_DIR) -> int:
+    """Delete /data/logos/ranked_matchups_*.jpg files whose marker isn't live.
+
+    Called at the end of each apply pass. Returns number of files removed.
+    Stale-detection is by filename hash: a file is live iff its name equals
+    marker_to_filename(m) for some m in live_markers.
+    """
+    if not os.path.isdir(logo_dir):
+        return 0
+    live_filenames = {marker_to_filename(m) for m in live_markers}
+    removed = 0
+    try:
+        entries = os.listdir(logo_dir)
+    except OSError:
+        return 0
+    for name in entries:
+        if not name.startswith(LOGO_FILENAME_PREFIX):
+            continue
+        if name in live_filenames:
+            continue
+        path = os.path.join(logo_dir, name)
+        try:
+            os.unlink(path)
+            removed += 1
+        except OSError as e:
+            logger.debug("sportsdb sweep: failed to unlink %s: %s", path, e)
+    return removed

--- a/plugin.json
+++ b/plugin.json
@@ -283,6 +283,14 @@
       "help_text": "Register: https://console.anthropic.com — used for two things, both optional: (1) EPG-to-channel matching when the regex pre-filter is ambiguous (cheap, Haiku, ~$0.0001 per ambiguous match), (2) LLM-rewritten EPG descriptions when 'Enable LLM-rewritten EPG descriptions' below is on. Only required if either is engaged."
     },
     {
+      "id": "sportsdb_api_key",
+      "type": "string",
+      "input_type": "password",
+      "label": "TheSportsDB API key (optional)",
+      "default": "",
+      "help_text": "Powers the per-matchup channel logo: TheSportsDB pre-renders a 960x540 graphic (both crests + league wordmark + region backdrop) for every event in its database. Blank means use the free public test tier ('3'), which is rate-limited but works for typical refresh cadence. Patreon keys unlock higher limits — see https://www.thesportsdb.com/api.php. When no matchup graphic is found (offseason, untracked league, field-event sport like F1/golf/UFC/tennis), the virtual channel falls back to the matched source channel's logo."
+    },
+    {
       "id": "model",
       "type": "select",
       "label": "Claude model",
@@ -430,6 +438,13 @@
       "label": "Dry run on Apply",
       "default": true,
       "help_text": "When true, 'Apply' logs intended changes but does not write to the DB."
+    },
+    {
+      "id": "enable_matchup_logos",
+      "type": "boolean",
+      "label": "Per-matchup channel logos (TheSportsDB)",
+      "default": true,
+      "help_text": "Replace each virtual channel's logo with TheSportsDB's pre-rendered 960x540 matchup graphic (both team crests + league wordmark + region backdrop). Resolved by team-name pair + date; cached per fixture for 14 days. Falls back to the matched source channel's logo when SportsDB has no thumbnail (offseason, untracked sport, field events like F1/golf/UFC/tennis). Configure key under 'API Keys'."
     },
     {
       "id": "_section_schedule",

--- a/plugin.py
+++ b/plugin.py
@@ -61,10 +61,18 @@ CACHE_PATH = os.path.join(PLUGIN_DIR, "cache.json")
 # unchanged) and the LLM cache can be safely deleted to force regen without
 # losing scoring state.
 LLM_DESCRIPTIONS_CACHE_PATH = os.path.join(PLUGIN_DIR, "llm_descriptions_cache.json")
+# Sidecar cache for SportsDB matchup-thumbnail URLs (marker -> url). Persists
+# across runs so apply only HTTP-probes each marker once per _POSITIVE_TTL /
+# _NEGATIVE_TTL window. Safe to delete to force re-resolution.
+SPORTSDB_THUMB_CACHE_PATH = os.path.join(PLUGIN_DIR, "sportsdb_thumb_cache.json")
 CFBD_KEY_PATH = os.path.join(PLUGIN_DIR, "cfbd_api_key")
 FD_KEY_PATH = os.path.join(PLUGIN_DIR, "football_data_api_key")
 ODDS_KEY_PATH = os.path.join(PLUGIN_DIR, "odds_api_key")
 ANTHROPIC_KEY_PATH = os.path.join(PLUGIN_DIR, "anthropic_api_key")
+SPORTSDB_KEY_PATH = os.path.join(PLUGIN_DIR, "sportsdb_api_key")
+# Free public test tier. Patreon keys unlock higher rate limits per
+# https://www.thesportsdb.com/api.php.
+SPORTSDB_DEFAULT_KEY = "3"
 
 # Window relative to game start in which the EPG should show the game.
 EPG_PRE_MIN = 30      # 30 min before game starts
@@ -1415,6 +1423,76 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         else:
             llm_cache = llm_descriptions.read_cache(LLM_DESCRIPTIONS_CACHE_PATH)
 
+    # Per-matchup logo: TheSportsDB pre-renders a 960x540 graphic for every
+    # event (both crests + league wordmark + region backdrop). Look up by
+    # team-name pair, download to /data/logos/ranked_matchups_<hash>.jpg, and
+    # point Channel.logo at it. On any miss (no event indexed, network failure,
+    # field-event source, dry_run) we fall through to the source channel's
+    # logo — preserving the v0 behavior for the long tail. Per-marker thumb
+    # URLs cached on disk to keep API hits to once per fixture per ~14 days.
+    from . import logos as matchup_logos
+    matchup_logos_enabled = bool(settings.get("enable_matchup_logos", True))
+    sportsdb_api_key = SPORTSDB_DEFAULT_KEY
+    thumb_cache: Optional[matchup_logos.ThumbCache] = None
+    matchup_logos_used = 0
+    matchup_logos_fallback = 0
+    if matchup_logos_enabled and not dry_run:
+        sportsdb_api_key = (
+            _resolve_key(settings, "sportsdb_api_key", SPORTSDB_KEY_PATH)
+            or SPORTSDB_DEFAULT_KEY
+        )
+        thumb_cache = matchup_logos.ThumbCache(SPORTSDB_THUMB_CACHE_PATH)
+
+    def _resolve_matchup_logo_id(
+        game: Dict[str, Any], marker: str, source,
+    ) -> Tuple[Optional[int], bool]:
+        """Returns (logo_id, hit_via_sportsdb).
+
+        Tries SportsDB lookup → local download → Logo.get_or_create. Falls back
+        to source.logo_id (current v0 behavior) on any miss; the bool tells the
+        caller which path was taken so it can update the per-apply counters
+        without recomputing the fallback id. Dry_run and feature-disabled
+        paths short-circuit to the fallback before any HTTP.
+        """
+        fallback_id = source.logo_id if source else None
+        if not matchup_logos_enabled or dry_run or thumb_cache is None:
+            return fallback_id, False
+        fresh, cached_url = thumb_cache.get(marker)
+        thumb_url = cached_url
+        if not fresh:
+            start_dt = parse_iso_utc(game.get("start_time_utc"))
+            if start_dt is None:
+                return fallback_id, False
+            thumb_url = matchup_logos.resolve_thumb_url(
+                home=game.get("home", ""),
+                away=game.get("away", ""),
+                expected_dt=start_dt,
+                sport_prefix=game.get("sport_prefix"),
+                api_key=sportsdb_api_key,
+            )
+            thumb_cache.put(marker, thumb_url)
+        if not thumb_url:
+            return fallback_id, False
+        # Ensure /data/logos/ exists (Dispatcharr creates it lazily on first
+        # upload via the UI; we might race a fresh install).
+        try:
+            os.makedirs(matchup_logos.LOGO_DIR, exist_ok=True)
+        except OSError as e:
+            logger.warning("[ranked_matchups] cannot mkdir %s: %s", matchup_logos.LOGO_DIR, e)
+            return fallback_id, False
+        local_path = os.path.join(
+            matchup_logos.LOGO_DIR, matchup_logos.marker_to_filename(marker),
+        )
+        if not os.path.exists(local_path):
+            if not matchup_logos.download_thumb(thumb_url, local_path):
+                return fallback_id, False
+        from apps.channels.models import Logo
+        logo_obj, _ = Logo.objects.get_or_create(
+            url=local_path,
+            defaults={"name": f"Top Matchup: {game.get('home','?')} vs {game.get('away','?')}"},
+        )
+        return logo_obj.id, True
+
     with transaction.atomic():
         # Phase 0: park existing virtual channels in a high temporary number
         # range so we can renumber based on cache order without colliding with
@@ -1540,14 +1618,20 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             source_streams = [sid for _, _, sid in stream_pool]
             existing = existing_virtuals.get(marker)
 
+            resolved_logo_id, used_sportsdb = _resolve_matchup_logo_id(g, marker, source)
+            if matchup_logos_enabled and not dry_run:
+                if used_sportsdb:
+                    matchup_logos_used += 1
+                else:
+                    matchup_logos_fallback += 1
+
             if existing:
                 changed = False
                 if existing.name != new_name:
                     existing.name = new_name
                     changed = True
-                source_logo_id = source.logo_id if source else None
-                if existing.logo_id != source_logo_id:
-                    existing.logo_id = source_logo_id
+                if existing.logo_id != resolved_logo_id:
+                    existing.logo_id = resolved_logo_id
                     changed = True
                 if existing.channel_number != target_chnum:
                     existing.channel_number = target_chnum
@@ -1584,7 +1668,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                         channel_number=target_chnum,
                         channel_group=target_group,
                         tvg_id=marker,
-                        logo=(source.logo if source else None),
+                        logo_id=resolved_logo_id,
                         auto_created=False,
                     )
                     for order, sid in enumerate(source_streams):
@@ -1712,6 +1796,17 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         pruned = llm_descriptions.prune_cache(llm_cache, seen_markers)
         llm_descriptions.write_cache(LLM_DESCRIPTIONS_CACHE_PATH, pruned)
 
+    # Persist the SportsDB thumb-URL cache and sweep stale matchup logo files
+    # from /data/logos/. Both prune to the live marker set so disk usage
+    # doesn't grow unbounded across many refresh cycles. Logo rows pointing
+    # at deleted files are left for Dispatcharr's own cleanup_unused_logos
+    # endpoint — deleting them here would race with concurrent UI reads.
+    stale_logo_files_swept = 0
+    if matchup_logos_enabled and not dry_run and thumb_cache is not None:
+        thumb_cache.prune(seen_markers)
+        thumb_cache.save()
+        stale_logo_files_swept = matchup_logos.sweep_stale_logo_files(seen_markers)
+
     prefix = "[dry] " if dry_run else ""
     rename_msg = ""
     if migrated_from_old_group or deleted_old_groups or deleted_old_sources:
@@ -1727,12 +1822,19 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     llm_msg = ""
     if llm_enabled:
         llm_msg = f" LLM descriptions: {llm_used} written, {llm_failed} fell back to deterministic."
+    logo_msg = ""
+    if matchup_logos_enabled and not dry_run:
+        logo_msg = (
+            f" Matchup logos: {matchup_logos_used} resolved via SportsDB, "
+            f"{matchup_logos_fallback} fell back to source-channel logo, "
+            f"{stale_logo_files_swept} stale file(s) swept."
+        )
     msg = (
         f"{prefix}Group {group_name!r}: created={created}, updated={updated} "
         f"(placeholders={placeholder_channels_created} included), "
         f"stale_deleted={deleted_stale}, "
         f"orphan_epg_deleted={orphan_epg_deleted if 'orphan_epg_deleted' in locals() else 0}, "
-        f"unmatched_skipped={skipped_unmatched}.{rename_msg}{llm_msg} "
+        f"unmatched_skipped={skipped_unmatched}.{rename_msg}{llm_msg}{logo_msg} "
         f"WHY descriptions written to EPG source."
     )
     return {"status": "ok", "message": msg}

--- a/tests/test_logos.py
+++ b/tests/test_logos.py
@@ -1,0 +1,411 @@
+"""Tests for the SportsDB matchup-thumbnail resolver (logos.py).
+
+Network-dependent paths are exercised via monkey-patched urlopen — no live
+HTTP. The cache-file and stale-sweep paths use tmp_path fixtures.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+def _load_logos():
+    """Load logos.py as a submodule of the test-registered package without
+    triggering the package __init__ (which imports Django via plugin.py)."""
+    mod_name = f"{PKG_NAME}.logos"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(
+        mod_name, os.path.join(REPO_ROOT, "logos.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+logos = _load_logos()
+
+
+# ---------- _strip_trailing_qualifier ----------
+
+class TestStripTrailingQualifier:
+    def test_no_qualifier_unchanged(self):
+        assert logos._strip_trailing_qualifier("Manchester City") == "Manchester City"
+
+    def test_fc_stripped(self):
+        assert logos._strip_trailing_qualifier("Manchester City FC") == "Manchester City"
+
+    def test_afc_stripped(self):
+        assert logos._strip_trailing_qualifier("Hull City AFC") == "Hull City"
+
+    def test_case_insensitive(self):
+        assert logos._strip_trailing_qualifier("Aston Villa fc") == "Aston Villa"
+
+    def test_only_trailing(self):
+        # "FC" in the middle of a name (rare but possible) is left alone.
+        assert logos._strip_trailing_qualifier("FC Barcelona") == "FC Barcelona"
+
+    def test_iterative(self):
+        # Some clubs have double qualifiers; both should strip.
+        assert logos._strip_trailing_qualifier("Some Team CF FC") == "Some Team"
+
+    def test_empty_and_none_safe(self):
+        assert logos._strip_trailing_qualifier("") == ""
+        assert logos._strip_trailing_qualifier(None) == ""
+
+
+# ---------- _build_search_query ----------
+
+class TestBuildSearchQuery:
+    def test_basic(self):
+        assert logos._build_search_query("Manchester City", "Aston Villa") == "Manchester City vs Aston Villa"
+
+    def test_strips_both(self):
+        assert (
+            logos._build_search_query("Manchester City FC", "Aston Villa FC")
+            == "Manchester City vs Aston Villa"
+        )
+
+
+# ---------- marker_to_filename ----------
+
+class TestMarkerToFilename:
+    def test_format(self):
+        f = logos.marker_to_filename("ranked_matchups:EPL:fd_535345")
+        assert f.startswith("ranked_matchups_")
+        assert f.endswith(".jpg")
+        # 16 hex chars + prefix + ext
+        assert len(f) == len("ranked_matchups_") + 16 + len(".jpg")
+
+    def test_stable(self):
+        m = "ranked_matchups:NBA:12345"
+        assert logos.marker_to_filename(m) == logos.marker_to_filename(m)
+
+    def test_distinct_markers_produce_distinct_filenames(self):
+        a = logos.marker_to_filename("ranked_matchups:EPL:fd_1")
+        b = logos.marker_to_filename("ranked_matchups:EPL:fd_2")
+        assert a != b
+
+
+# ---------- _date_in_tolerance ----------
+
+class TestDateInTolerance:
+    def test_same_day(self):
+        assert logos._date_in_tolerance("2026-05-24", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+    def test_one_day_off(self):
+        assert logos._date_in_tolerance("2026-05-25", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+    def test_two_days_off(self):
+        assert logos._date_in_tolerance("2026-05-26", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+    def test_three_days_off_rejected(self):
+        assert not logos._date_in_tolerance("2026-05-27", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+    def test_malformed_date_rejected(self):
+        assert not logos._date_in_tolerance("not-a-date", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+    def test_empty_date_rejected(self):
+        assert not logos._date_in_tolerance("", datetime(2026, 5, 24, tzinfo=timezone.utc))
+
+
+# ---------- _hint_matches ----------
+
+class TestHintMatches:
+    def test_no_hint_accepts_anything(self):
+        assert logos._hint_matches({"strLeague": "Anything"}, None)
+
+    def test_unmapped_prefix_accepts(self):
+        # Prefix not in _SPORT_HINT map => fail-open.
+        assert logos._hint_matches({"strLeague": "Anything"}, "UNKNOWNPREFIX")
+
+    def test_league_substring(self):
+        ev = {"strLeague": "English Premier League", "strSport": "Soccer"}
+        assert logos._hint_matches(ev, "EPL")
+
+    def test_sport_substring(self):
+        ev = {"strLeague": "Some Cup", "strSport": "NHL"}
+        assert logos._hint_matches(ev, "NHL")
+
+    def test_mismatch_rejected(self):
+        ev = {"strLeague": "NCAA Division I Basketball Mens", "strSport": "Basketball"}
+        # CFB hint requires "NCAA" in league — basketball league DOES contain
+        # "NCAA", so it would pass. The date filter is the real discriminator.
+        # Use a non-NCAA league to confirm rejection.
+        ev2 = {"strLeague": "MLB", "strSport": "Baseball"}
+        assert not logos._hint_matches(ev2, "CFB")
+
+    def test_case_insensitive(self):
+        ev = {"strLeague": "english premier league", "strSport": ""}
+        assert logos._hint_matches(ev, "EPL")
+
+
+# ---------- resolve_thumb_url ----------
+
+class _FakeHttpResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def read(self, n: int = -1):
+        if n == -1:
+            data, self._body = self._body, b""
+        else:
+            data, self._body = self._body[:n], self._body[n:]
+        return data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _fake_urlopen(payload: dict, status: int = 200):
+    def opener(req, timeout=None):
+        return _FakeHttpResponse(json.dumps(payload).encode("utf-8"), status=status)
+    return opener
+
+
+class TestResolveThumbUrl:
+    def test_field_event_short_circuits(self, monkeypatch):
+        # away="Field" means single-event sport (F1, golf, UFC, tennis).
+        called = []
+        monkeypatch.setattr(logos.urllib.request, "urlopen",
+                            lambda *a, **k: called.append(1))
+        url = logos.resolve_thumb_url(
+            "Heineken Chinese GP", "Field",
+            datetime(2026, 4, 15, tzinfo=timezone.utc), "F1", "3",
+        )
+        assert url is None
+        assert called == []  # no HTTP call
+
+    def test_empty_team_returns_none(self):
+        assert logos.resolve_thumb_url("", "Aston Villa",
+                                       datetime(2026, 5, 24, tzinfo=timezone.utc),
+                                       "EPL", "3") is None
+        assert logos.resolve_thumb_url("Manchester City", "",
+                                       datetime(2026, 5, 24, tzinfo=timezone.utc),
+                                       "EPL", "3") is None
+
+    def test_positive_match(self, monkeypatch):
+        payload = {"event": [{
+            "dateEvent": "2026-05-24",
+            "strEvent": "Manchester City vs Aston Villa",
+            "strLeague": "English Premier League",
+            "strSport": "Soccer",
+            "strThumb": "https://r2.thesportsdb.com/images/media/event/thumb/foo.jpg",
+        }]}
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen(payload))
+        url = logos.resolve_thumb_url(
+            "Manchester City", "Aston Villa",
+            datetime(2026, 5, 24, tzinfo=timezone.utc), "EPL", "3",
+        )
+        assert url == "https://r2.thesportsdb.com/images/media/event/thumb/foo.jpg"
+
+    def test_date_mismatch_rejected(self, monkeypatch):
+        # SportsDB returns a match for a different date — the date filter
+        # rejects it so we don't grab the wrong leg of a season series.
+        payload = {"event": [{
+            "dateEvent": "2024-12-15",  # 17 months off
+            "strLeague": "English Premier League",
+            "strThumb": "https://example.com/wrong.jpg",
+        }]}
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen(payload))
+        url = logos.resolve_thumb_url(
+            "Manchester City", "Aston Villa",
+            datetime(2026, 5, 24, tzinfo=timezone.utc), "EPL", "3",
+        )
+        assert url is None
+
+    def test_sport_hint_filters_cross_sport_collision(self, monkeypatch):
+        # SportsDB returns a basketball "Alabama vs Auburn" but we asked for football.
+        # The basketball league name does contain "NCAA" (the CFB hint), but we use
+        # MLB instead (no NCAA in league/sport) to confirm filter actually filters.
+        payload = {"event": [{
+            "dateEvent": "2025-11-29",
+            "strLeague": "MLB",  # missing CFB hint substring "NCAA"
+            "strSport": "Baseball",
+            "strThumb": "https://example.com/wrong.jpg",
+        }]}
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen(payload))
+        url = logos.resolve_thumb_url(
+            "Some Team", "Other Team",
+            datetime(2025, 11, 29, tzinfo=timezone.utc), "CFB", "3",
+        )
+        assert url is None
+
+    def test_empty_event_list(self, monkeypatch):
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen({"event": None}))
+        url = logos.resolve_thumb_url(
+            "Garbage", "Other",
+            datetime(2026, 5, 24, tzinfo=timezone.utc), "EPL", "3",
+        )
+        assert url is None
+
+    def test_event_without_thumb(self, monkeypatch):
+        payload = {"event": [{
+            "dateEvent": "2026-05-24",
+            "strLeague": "English Premier League",
+            "strThumb": "",  # event exists but no thumb yet
+        }]}
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen(payload))
+        url = logos.resolve_thumb_url(
+            "Manchester City", "Aston Villa",
+            datetime(2026, 5, 24, tzinfo=timezone.utc), "EPL", "3",
+        )
+        assert url is None
+
+    def test_http_failure_returns_none(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise OSError("network down")
+        monkeypatch.setattr(logos.urllib.request, "urlopen", boom)
+        url = logos.resolve_thumb_url(
+            "Manchester City", "Aston Villa",
+            datetime(2026, 5, 24, tzinfo=timezone.utc), "EPL", "3",
+        )
+        assert url is None
+
+
+# ---------- ThumbCache ----------
+
+class TestThumbCache:
+    def test_empty_when_missing(self, tmp_path):
+        cache = logos.ThumbCache(str(tmp_path / "missing.json"))
+        fresh, url = cache.get("any")
+        assert not fresh and url is None
+
+    def test_put_and_get_positive(self, tmp_path):
+        path = str(tmp_path / "cache.json")
+        cache = logos.ThumbCache(path)
+        cache.put("m1", "https://example.com/thumb.jpg")
+        fresh, url = cache.get("m1")
+        assert fresh and url == "https://example.com/thumb.jpg"
+
+    def test_put_and_get_negative(self, tmp_path):
+        cache = logos.ThumbCache(str(tmp_path / "c.json"))
+        cache.put("m1", None)
+        fresh, url = cache.get("m1")
+        assert fresh and url is None
+
+    def test_save_load_roundtrip(self, tmp_path):
+        path = str(tmp_path / "c.json")
+        c1 = logos.ThumbCache(path)
+        c1.put("m1", "https://example.com/x.jpg")
+        c1.put("m2", None)
+        c1.save()
+        c2 = logos.ThumbCache(path)
+        fresh, url = c2.get("m1")
+        assert fresh and url == "https://example.com/x.jpg"
+        fresh, url = c2.get("m2")
+        assert fresh and url is None
+
+    def test_positive_entry_expires(self, tmp_path):
+        cache = logos.ThumbCache(str(tmp_path / "c.json"))
+        cache.put("m1", "https://example.com/x.jpg")
+        # backdate beyond the positive TTL
+        stale_ts = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
+        cache._data["m1"][0] = stale_ts
+        fresh, url = cache.get("m1")
+        assert not fresh
+        assert url == "https://example.com/x.jpg"  # stale value still returned
+
+    def test_negative_entry_expires_faster(self, tmp_path):
+        cache = logos.ThumbCache(str(tmp_path / "c.json"))
+        cache.put("m1", None)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+        cache._data["m1"][0] = stale_ts
+        fresh, _ = cache.get("m1")
+        assert not fresh
+
+    def test_corrupt_file_recovers(self, tmp_path):
+        path = str(tmp_path / "c.json")
+        with open(path, "w") as f:
+            f.write("not-json{{{")
+        cache = logos.ThumbCache(path)
+        # No exception; starts empty.
+        fresh, url = cache.get("m1")
+        assert not fresh and url is None
+
+    def test_prune_drops_stale_markers(self, tmp_path):
+        cache = logos.ThumbCache(str(tmp_path / "c.json"))
+        cache.put("live", "https://example.com/x.jpg")
+        cache.put("stale", "https://example.com/y.jpg")
+        dropped = cache.prune({"live"})
+        assert dropped == 1
+        assert "live" in cache._data
+        assert "stale" not in cache._data
+
+
+# ---------- sweep_stale_logo_files ----------
+
+class TestSweepStaleLogoFiles:
+    def test_no_dir_zero_result(self, tmp_path):
+        # Directory doesn't exist.
+        assert logos.sweep_stale_logo_files(set(), str(tmp_path / "nope")) == 0
+
+    def test_keeps_live_removes_stale(self, tmp_path):
+        # Create three files: two ours (one live, one stale), one foreign.
+        live_marker = "ranked_matchups:EPL:fd_111"
+        stale_marker = "ranked_matchups:EPL:fd_222"
+        live_name = logos.marker_to_filename(live_marker)
+        stale_name = logos.marker_to_filename(stale_marker)
+        for name in (live_name, stale_name, "other_uploaded_logo.png"):
+            with open(tmp_path / name, "w") as f:
+                f.write("x")
+        removed = logos.sweep_stale_logo_files({live_marker}, str(tmp_path))
+        assert removed == 1
+        files = set(os.listdir(tmp_path))
+        assert live_name in files
+        assert stale_name not in files
+        assert "other_uploaded_logo.png" in files  # foreign file untouched
+
+    def test_no_files_matches_prefix(self, tmp_path):
+        # Empty dir or no matching prefix.
+        with open(tmp_path / "unrelated.png", "w") as f:
+            f.write("x")
+        assert logos.sweep_stale_logo_files({"anything"}, str(tmp_path)) == 0
+
+
+# ---------- download_thumb ----------
+
+class TestDownloadThumb:
+    def test_writes_atomically(self, tmp_path, monkeypatch):
+        body = b"FAKE JPEG BYTES"
+        monkeypatch.setattr(logos.urllib.request, "urlopen",
+                            lambda req, timeout=None: _FakeHttpResponse(body))
+        dest = str(tmp_path / "out.jpg")
+        ok = logos.download_thumb("https://example.com/x.jpg", dest)
+        assert ok is True
+        with open(dest, "rb") as f:
+            assert f.read() == body
+        # tmp file gone
+        assert not any(p.endswith(".tmp") or ".tmp." in p for p in os.listdir(tmp_path) if p != "out.jpg")
+
+    def test_http_error_returns_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(logos.urllib.request, "urlopen",
+                            lambda req, timeout=None: _FakeHttpResponse(b"", status=500))
+        dest = str(tmp_path / "out.jpg")
+        ok = logos.download_thumb("https://example.com/x.jpg", dest)
+        assert ok is False
+        assert not os.path.exists(dest)
+
+    def test_network_failure_cleans_up_tmp(self, tmp_path, monkeypatch):
+        def boom(req, timeout=None):
+            raise OSError("dropped")
+        monkeypatch.setattr(logos.urllib.request, "urlopen", boom)
+        dest = str(tmp_path / "out.jpg")
+        ok = logos.download_thumb("https://example.com/x.jpg", dest)
+        assert ok is False
+        # No partial file or .tmp left behind.
+        assert os.listdir(tmp_path) == []
+
+    def test_empty_url_returns_false(self, tmp_path):
+        assert logos.download_thumb("", str(tmp_path / "out.jpg")) is False


### PR DESCRIPTION
## Summary

Replaces each virtual channel's source-inherited logo with TheSportsDB's pre-rendered 960×540 matchup graphic (both team crests + league badge + region backdrop). Falls back to the matched source channel's logo on any miss — offseason, untracked sport, field-event source, network failure, dry_run.

**Sample rendered logo** (Manchester City vs Aston Villa, real fixture from the smoke test):

![manchester-city-aston-villa](https://r2.thesportsdb.com/images/media/event/thumb/3gdtcc1750321076.jpg)

## What changed

- New module `logos.py` (~290 lines) owns SportsDB resolution + atomic JPG download + cache management + stale-file sweep.
- `plugin.py` apply path: new closure resolves a logo per game, returning `(logo_id, hit_via_sportsdb)` so the per-apply summary reports both counts.
- Two new settings under existing sections: `enable_matchup_logos` (default on) and `sportsdb_api_key` (defaults to public test tier `3`; Patreon keys unlock higher rate limits).
- `CLAUDE.md` file-map gets a row for `logos.py`.
- 47 unit tests in `tests/test_logos.py` cover normalization, search, date tolerance, sport-hint disambiguation, cache TTL behavior, atomic download, and the sweep.

## Live verification

Tested against the running Dispatcharr container with the actual `cache.json`:

| Path | Outcome |
|---|---|
| Positive (Manchester City vs Aston Villa) | SportsDB resolved → JPG written to `/data/logos/ranked_matchups_<sha1>.jpg` → `Logo` row created → `Channel.logo_id` updated |
| Negative (PSG vs Arsenal — FC suffix strip yields "Paris Saint-Germain" but SportsDB indexes as "Paris SG") | Fell back to source-channel logo |
| Stale-sweep (removed game) | JPG deleted, cache entry pruned |
| Dry-run | No HTTP, no disk writes |
| Field-event sentinel (`away=="Field"`) | Skipped lookup, no HTTP |

The apply summary now includes:
> Matchup logos: 1 resolved via SportsDB, 0 fell back to source-channel logo, 0 stale file(s) swept.

## Known limitations / follow-ups

- European-soccer name abbreviations: SportsDB indexes "Paris SG" but Football-Data.org returns "Paris Saint-Germain FC". The trailing-qualifier stripper handles "FC"/"AFC"/etc. but doesn't have a name-alias table for canonical abbreviations. This is what #4 (Matcher v2) is scoped for; that work can extend the alias table to both the EPG matcher and the SportsDB lookup.
- Free-tier API key (`3`) is rate-limited and sampled — fine for typical refresh cadence but heavy users may want to set their Patreon key.

## Test plan

- [x] `logos.py` unit tests: 47/47 pass
- [x] Live positive: SportsDB lookup → JPG download → Logo row → channel logo updated
- [x] Live negative: SportsDB miss → fall back to source-channel logo
- [x] Live sweep: dropped game's logo file deleted
- [x] Dry-run side-effect-free (no HTTP, no disk writes)
- [x] Field-event sentinel skips lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)