### PR TITLE
Fix: preserve Channel.id across group renames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,10 +158,18 @@ buckets against the threshold cutoff.
   `tvg_id` prefix `ranked_matchups:` — otherwise it matches games against
   our own virtual channels (whose EPG titles literally contain the team
   names). Fixed in `_build_epg_lookup()`.
-- **Group rename migration**: when user changes the target group name,
-  apply detects old virtual channels (any group, by tvg_id prefix) and
-  cleans them up + the orphaned dummy EPGSource. Don't break this — the user
-  has a habit of renaming `Top Matchups` → `!Top Matchups` etc.
+- **Group rename migration MUST preserve `Channel.id`**: when user changes
+  the target group name, apply detects old virtual channels (any group, by
+  tvg_id prefix) and **moves** them into the new target group via
+  `.update(channel_group=target_group)`, NOT delete + recreate. Channel.id
+  is the stable handle that `ChannelProfileMembership` (Dispatcharr only
+  auto-adds new channels to profiles at PROFILE-creation time, never on
+  channel-creation, so a recreate orphans every membership) and IPTV-client
+  playlist caches both key off. A delete-then-create cycle silently makes
+  the channel disappear from the user's IPTV guide until they manually
+  refresh — exactly the regression that bit #1 live-verify. The user has a
+  habit of renaming `Top Matchups` → `!Top Matchups` etc; every rename
+  cycle must be a no-op for downstream consumers.
 - **Soccer team-name suffixes**: Football-Data.org returns "Hull City AFC",
   "Manchester City FC". The favorites matcher uses a `TEAM_QUALIFIER_TOKENS`
   whitelist (FC, AFC, City, United, etc.) so the bare name "Hull" matches

--- a/plugin.py
+++ b/plugin.py
@@ -1293,18 +1293,29 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         logger.info("[ranked_matchups] created ChannelGroup id=%s name=%r",
                     target_group.id, group_name)
 
-    # Migrate / clean up any virtual channels in old groups
+    # Migrate any virtual channels in old groups INTO the target group, in
+    # place. DO NOT delete + recreate — Channel.id is the stable handle that
+    # ChannelProfileMembership, IPTV-client playlist caches, and the user's
+    # pinned-channel state all key off. A delete-then-create cycle silently
+    # orphans every one of those: profile memberships are gone (Dispatcharr
+    # auto-adds new channels to existing profiles ONLY at profile-creation
+    # time, never on channel-creation), and IPTV clients that cached the old
+    # tvg-id render an empty slot for the renamed channel until the user
+    # manually refreshes — exactly what bit us during the #1 live-verify.
+    #
+    # The .update() bypasses Django's post_save signal (mirroring the same
+    # signal-bypass pattern at apps/channels/signals.py:60 / our epg_data
+    # write at the bottom of the loop). The downstream main loop will hit
+    # the "existing" branch keyed by tvg_id and update name / channel_number
+    # / logo / streams in place. ChannelStream rows are FK'd to Channel, so
+    # they survive the channel_group change untouched.
     migrated_from_old_group = 0
     deleted_old_groups = 0
     if not dry_run and foreign_owned_groups:
         for old_g in foreign_owned_groups:
             old_chans = Channel.objects.filter(_owned_tvg_id_q(), channel_group=old_g)
             n = old_chans.count()
-            # We re-create everything fresh anyway (cache index drives target chnum),
-            # so just delete the old virtual channels here. Their stream + EPG
-            # links cascade.
-            ChannelStream.objects.filter(channel__in=old_chans).delete()
-            old_chans.delete()
+            old_chans.update(channel_group=target_group)
             migrated_from_old_group += n
             # If the old group is now empty AND was named like a Top Matchups
             # (heuristic: contains 'matchup' or 'top' in name), delete it too.
@@ -1812,8 +1823,8 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     if migrated_from_old_group or deleted_old_groups or deleted_old_sources:
         rename_msg = (
             f" Migrated from old target: {migrated_from_old_group} channel(s) "
-            f"removed from {deleted_old_groups} old group(s), {deleted_old_sources} "
-            f"old EPGSource(s) deleted."
+            f"moved (same Channel.id) from {deleted_old_groups} old group(s), "
+            f"{deleted_old_sources} old EPGSource(s) deleted."
         )
     # `placeholders` is a *subset* of (created + updated) — placeholder games
     # go through the same upsert path as matched ones, so they're already


### PR DESCRIPTION
## Summary

Apply's foreign-group cleanup used to **delete + recreate** Channel rows on group rename — silently orphaning every Channel.id-keyed downstream state (ChannelProfile memberships, IPTV-client playlist caches, anything pinned by PK). Fixed to **move** channels in place via \`.update(channel_group=target_group)\`.

## Root cause

\`_action_apply\` ran \`old_chans.delete()\` for any channels found in a "foreign" group (i.e., a group with our tvg_id prefix but a different name from the current target). The main loop then created brand-new Channel rows in the target group. The new rows had different Django PKs.

Dispatcharr's auto-membership signal only fires at **profile creation** time, not at channel creation. So:
- Profile membership: lost
- IPTV client cache (TiviMate / Plex / Jellyfin): broken until manual playlist resync
- Anything else keyed on \`Channel.id\`: orphaned

## Surface that bit me

During #1's live-verify I accidentally ran apply with the wrong group name, then corrected it. The user reported the channel "doesn't show up anymore" — root-cause analysis showed the Channel.id had churned from 160633 → 160634 across the two renames, and his IPTV client / any pinned state were keyed against the old PK.

## Fix

\`\`\`python
# Before
ChannelStream.objects.filter(channel__in=old_chans).delete()
old_chans.delete()

# After
old_chans.update(channel_group=target_group)
\`\`\`

\`ChannelStream\` rows FK to \`Channel\` — they survive the channel_group change untouched. EPG data still gets reassigned through the main loop's existing-channel branch using the same \`.update()\`-not-\`.save()\` signal-bypass pattern documented elsewhere in the file.

## Live verification

Double rename: \`!Top Matchups\` → \`Top Matchups\` → \`!Top Matchups\`.

\`\`\`
BEFORE:        Channel.id=160634 group='!Top Matchups'
AFTER rename1: Channel.id=160634 group='Top Matchups'   PRESERVED=True
AFTER rename2: Channel.id=160634 group='!Top Matchups'  PRESERVED=True
streams attached: 1   |  EPG programs: 3   |  channel.epg_data_id non-null
\`\`\`

## CLAUDE.md

Updated the "Group rename migration" gotcha entry to mark \`Channel.id\` preservation as a load-bearing invariant — future contributors get a clear "don't regress this" with the why.

## Test plan

- [x] Double rename preserves Channel.id
- [x] Streams remain attached
- [x] EPG ProgramData rows recreated and linked
- [x] Report message updated ("moved (same Channel.id)" instead of "removed")

🤖 Generated with [Claude Code](https://claude.com/claude-code)