### PR TITLE
Closes #8: populate is_rivalry from curated rivalries.json

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -759,6 +759,14 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
                     g.home, g.away, e,
                 )
 
+        # Rivalry detection: source-set is_rivalry takes precedence (no adapter
+        # currently does this, but the door is open); otherwise we consult the
+        # static rivalries.json list. See #8.
+        from .rivalries import is_rivalry as _is_known_rivalry
+        rivalry_flag = bool(g.is_rivalry) or _is_known_rivalry(
+            g.home, g.away, g.sport_prefix,
+        )
+
         signals = GameSignals(
             rank_a=g.rank_home,
             rank_b=g.rank_away,
@@ -767,6 +775,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
             favorite_match=match_favorites(g.home, g.away, favorites),
             spread=g.spread,
             closeness=g.closeness,
+            is_rivalry=rivalry_flag,
             tournament_stage=extra.get("stage"),
             importance_points=importance_pts,
             importance_notes=importance_notes,
@@ -838,6 +847,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
             "score_breakdown": score.breakdown,
             "score_notes": score.notes,
             "favorites_matched": signals.favorite_match,
+            "is_rivalry": signals.is_rivalry,
             "tournament_stage": signals.tournament_stage,
             "importance_points": signals.importance_points,
             "importance_notes": signals.importance_notes,
@@ -1052,6 +1062,13 @@ def _build_signals_score_from_payload(g: Dict[str, Any]):
         or g.get("stakes_thresholds_hit")
         or []
     )
+    # is_rivalry: cache shape may or may not carry it explicitly (older caches
+    # won't), but the score_breakdown will have a "rivalry" key when the
+    # signal fired during the original refresh. Reading the breakdown is the
+    # cheapest single-source-of-truth; no need to re-walk rivalries.json here.
+    breakdown_peek = g.get("score_breakdown") or {}
+    rivalry_from_cache = bool(g.get("is_rivalry")) or ("rivalry" in breakdown_peek)
+
     signals = GameSignals(
         rank_a=g.get("rank_home"),
         rank_b=g.get("rank_away"),
@@ -1060,6 +1077,7 @@ def _build_signals_score_from_payload(g: Dict[str, Any]):
         favorite_match=g.get("favorites_matched", []),
         spread=g.get("spread"),
         closeness=g.get("closeness"),
+        is_rivalry=rivalry_from_cache,
         tournament_stage=g.get("tournament_stage"),
         # Cache files predating this signal default to 0.0 / [] — graceful
         # degradation: the importance block in score_game just contributes

--- a/rivalries.json
+++ b/rivalries.json
@@ -1,0 +1,148 @@
+{
+  "_comment": "Per-sport-prefix list of known rivalry pairs. Names match case-insensitive substring against home/away team names from each source, so 'Manchester City' here matches 'Manchester City FC' from Football-Data.org. Order within a pair doesn't matter. See #8.",
+  "CFB": [
+    ["Alabama", "Auburn"],
+    ["Ohio State", "Michigan"],
+    ["USC", "Notre Dame"],
+    ["Texas", "Oklahoma"],
+    ["Florida", "Georgia"],
+    ["Army", "Navy"],
+    ["Florida", "Florida State"],
+    ["Clemson", "South Carolina"],
+    ["Oregon", "Oregon State"],
+    ["Iowa", "Iowa State"],
+    ["BYU", "Utah"],
+    ["Virginia", "Virginia Tech"],
+    ["NC State", "North Carolina"],
+    ["Penn State", "Pitt"],
+    ["Wisconsin", "Minnesota"],
+    ["Tennessee", "Kentucky"],
+    ["Mississippi", "Mississippi State"],
+    ["Indiana", "Purdue"],
+    ["Cal", "Stanford"],
+    ["Texas", "Texas A&M"]
+  ],
+  "CBB": [
+    ["Duke", "North Carolina"],
+    ["Kentucky", "Louisville"],
+    ["Kansas", "Kansas State"],
+    ["Indiana", "Purdue"],
+    ["Michigan", "Michigan State"],
+    ["UCLA", "USC"],
+    ["Georgetown", "Syracuse"],
+    ["Cincinnati", "Xavier"],
+    ["Arizona", "Arizona State"],
+    ["Villanova", "Georgetown"]
+  ],
+  "EPL": [
+    ["Liverpool", "Manchester United"],
+    ["Arsenal", "Tottenham"],
+    ["Manchester City", "Manchester United"],
+    ["Chelsea", "Tottenham"],
+    ["Liverpool", "Everton"],
+    ["Arsenal", "Chelsea"],
+    ["Newcastle", "Sunderland"],
+    ["Aston Villa", "Birmingham"],
+    ["West Ham", "Tottenham"],
+    ["Crystal Palace", "Brighton"],
+    ["Leeds", "Manchester United"]
+  ],
+  "EFL": [
+    ["Sheffield United", "Sheffield Wednesday"],
+    ["Nottingham Forest", "Derby County"],
+    ["Bristol City", "Bristol Rovers"],
+    ["Cardiff", "Swansea"],
+    ["Norwich", "Ipswich"]
+  ],
+  "BL1": [
+    ["Bayern Munich", "Borussia Dortmund"],
+    ["Borussia Dortmund", "Schalke"],
+    ["Hamburger", "Werder Bremen"],
+    ["Bayern Munich", "1860 Munich"]
+  ],
+  "LaLiga": [
+    ["Real Madrid", "Barcelona"],
+    ["Real Madrid", "Atletico"],
+    ["Sevilla", "Real Betis"],
+    ["Espanyol", "Barcelona"],
+    ["Athletic Club", "Real Sociedad"]
+  ],
+  "SerieA": [
+    ["Inter", "AC Milan"],
+    ["Roma", "Lazio"],
+    ["Juventus", "Inter"],
+    ["Juventus", "Torino"],
+    ["Napoli", "Roma"],
+    ["Genoa", "Sampdoria"]
+  ],
+  "Ligue1": [
+    ["Paris Saint-Germain", "Marseille"],
+    ["Paris SG", "Marseille"],
+    ["Lyon", "Saint-Etienne"],
+    ["Lyon", "Marseille"],
+    ["Lens", "Lille"]
+  ],
+  "NFL": [
+    ["Green Bay Packers", "Chicago Bears"],
+    ["Pittsburgh Steelers", "Baltimore Ravens"],
+    ["Pittsburgh Steelers", "Cleveland Browns"],
+    ["Dallas Cowboys", "Washington"],
+    ["Dallas Cowboys", "Philadelphia Eagles"],
+    ["New England Patriots", "New York Jets"],
+    ["Kansas City Chiefs", "Las Vegas Raiders"],
+    ["Denver Broncos", "Las Vegas Raiders"],
+    ["Minnesota Vikings", "Green Bay Packers"],
+    ["San Francisco 49ers", "Seattle Seahawks"],
+    ["New York Giants", "Philadelphia Eagles"],
+    ["Cincinnati Bengals", "Cleveland Browns"]
+  ],
+  "NBA": [
+    ["Boston Celtics", "Los Angeles Lakers"],
+    ["Golden State Warriors", "Cleveland Cavaliers"],
+    ["Boston Celtics", "Philadelphia 76ers"],
+    ["New York Knicks", "Boston Celtics"],
+    ["Chicago Bulls", "Detroit Pistons"],
+    ["Los Angeles Lakers", "Los Angeles Clippers"],
+    ["Miami Heat", "New York Knicks"],
+    ["San Antonio Spurs", "Houston Rockets"]
+  ],
+  "NHL": [
+    ["Montreal Canadiens", "Boston Bruins"],
+    ["Montreal Canadiens", "Toronto Maple Leafs"],
+    ["New York Rangers", "New York Islanders"],
+    ["New York Rangers", "Philadelphia Flyers"],
+    ["Pittsburgh Penguins", "Philadelphia Flyers"],
+    ["Pittsburgh Penguins", "Washington Capitals"],
+    ["Detroit Red Wings", "Chicago Blackhawks"],
+    ["Detroit Red Wings", "Toronto Maple Leafs"],
+    ["Edmonton Oilers", "Calgary Flames"],
+    ["Vancouver Canucks", "Calgary Flames"]
+  ],
+  "MLB": [
+    ["New York Yankees", "Boston Red Sox"],
+    ["Los Angeles Dodgers", "San Francisco Giants"],
+    ["Chicago Cubs", "Chicago White Sox"],
+    ["Chicago Cubs", "St. Louis Cardinals"],
+    ["New York Yankees", "New York Mets"],
+    ["Los Angeles Dodgers", "San Diego Padres"],
+    ["Cleveland Guardians", "Detroit Tigers"],
+    ["Houston Astros", "Texas Rangers"],
+    ["Baltimore Orioles", "Washington Nationals"]
+  ],
+  "MLS": [
+    ["LA Galaxy", "Los Angeles FC"],
+    ["Seattle Sounders", "Portland Timbers"],
+    ["New York Red Bulls", "New York City FC"],
+    ["DC United", "New York Red Bulls"],
+    ["Atlanta United", "Orlando City"],
+    ["Toronto FC", "Montreal Impact"],
+    ["Sporting Kansas City", "FC Dallas"]
+  ],
+  "LigaMX": [
+    ["Club America", "Chivas"],
+    ["Club America", "Cruz Azul"],
+    ["Pumas", "Cruz Azul"],
+    ["Monterrey", "Tigres"],
+    ["Toluca", "Club America"]
+  ]
+}

--- a/rivalries.py
+++ b/rivalries.py
@@ -1,0 +1,104 @@
+"""Rivalry detection: case-insensitive substring match against a curated JSON list.
+
+`rivalries.json` lives next to this module and maps sport_prefix to a list of
+team-name pairs. At plugin import, the JSON is read once and indexed by sport;
+`is_rivalry(home, away, sport_prefix)` returns True when the (home, away) pair
+appears in either order in the list for that sport.
+
+Substring matching (in both directions per token) handles source-side name
+variations — Football-Data.org returns "Manchester City FC" but our list
+stores the bare "Manchester City"; ESPN returns "Boston Celtics" while we
+store the same. See #8.
+
+To extend: edit `rivalries.json`. The match runs once per refresh per game, so
+even a 10,000-entry list would barely register on the profile. No LLM-judged
+path here — that's a deferred follow-up if the static list proves too narrow.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+_RIVALRIES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rivalries.json")
+
+
+def _normalize(name: str) -> str:
+    """Lowercase + collapse whitespace. Substring match runs against this form."""
+    return " ".join((name or "").lower().split())
+
+
+def _load_rivalries() -> Dict[str, List[Tuple[str, str]]]:
+    """Load and normalize the rivalries map. Returns {sport_prefix: [(a, b), ...]}.
+
+    Failure modes (file missing, JSON corrupt) log a warning and return an
+    empty map so the plugin still works — rivalries are an enhancement, not
+    a hard dependency.
+    """
+    try:
+        with open(_RIVALRIES_PATH, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except FileNotFoundError:
+        logger.warning("rivalries.json missing at %s; rivalry signal disabled", _RIVALRIES_PATH)
+        return {}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("rivalries.json load failed (%s); rivalry signal disabled", e)
+        return {}
+    out: Dict[str, List[Tuple[str, str]]] = {}
+    for key, pairs in raw.items():
+        if key.startswith("_"):
+            continue  # skip _comment etc
+        if not isinstance(pairs, list):
+            continue
+        clean: List[Tuple[str, str]] = []
+        for entry in pairs:
+            if (
+                isinstance(entry, list)
+                and len(entry) == 2
+                and all(isinstance(s, str) and s.strip() for s in entry)
+            ):
+                clean.append((_normalize(entry[0]), _normalize(entry[1])))
+        if clean:
+            out[key] = clean
+    return out
+
+
+# Loaded once per process. Plugin reload re-imports the module so edits to
+# rivalries.json land on the next .reload_token bump.
+_RIVALRIES_BY_SPORT = _load_rivalries()
+
+
+def is_rivalry(home: str, away: str, sport_prefix: str) -> bool:
+    """True when (home, away) matches a known rivalry pair for this sport.
+
+    Match is case-insensitive substring in both directions: the rivalry entry
+    'Manchester City' matches 'Manchester City FC' (rivalry-string is a
+    substring of team-string). The reverse — entry 'Manchester City FC FC FC'
+    matching team 'Manchester City' — also matches, which is a feature for
+    occasional source-side abbreviations.
+    """
+    pairs = _RIVALRIES_BY_SPORT.get(sport_prefix)
+    if not pairs or not home or not away:
+        return False
+    h, a = _normalize(home), _normalize(away)
+    for rival_a, rival_b in pairs:
+        # Order in the JSON pair is incidental — match against both orderings.
+        if _name_matches(h, rival_a) and _name_matches(a, rival_b):
+            return True
+        if _name_matches(h, rival_b) and _name_matches(a, rival_a):
+            return True
+    return False
+
+
+def _name_matches(team_name: str, rivalry_name: str) -> bool:
+    """Substring match in either direction.
+
+    Both arguments must already be normalized via _normalize. We allow either
+    direction so e.g. 'manchester city' (rivalry) matches 'manchester city fc'
+    (team) AND 'paris sg' (team) matches 'paris saint-germain' (rivalry — if
+    the file stored the longer form).
+    """
+    return rivalry_name in team_name or team_name in rivalry_name

--- a/tests/test_rivalries.py
+++ b/tests/test_rivalries.py
@@ -1,0 +1,138 @@
+"""Tests for the rivalries.json + rivalries.py rivalry-detection helper."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+def _load_rivalries_mod():
+    mod_name = f"{PKG_NAME}.rivalries"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(
+        mod_name, os.path.join(REPO_ROOT, "rivalries.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rivalries = _load_rivalries_mod()
+
+
+class TestNormalize:
+    def test_lowercases(self):
+        assert rivalries._normalize("Manchester City") == "manchester city"
+
+    def test_strips_whitespace(self):
+        assert rivalries._normalize("  Arsenal   FC  ") == "arsenal fc"
+
+    def test_empty_safe(self):
+        assert rivalries._normalize("") == ""
+        assert rivalries._normalize(None) == ""
+
+
+class TestIsRivalry:
+    def test_known_epl_pair(self):
+        assert rivalries.is_rivalry("Liverpool FC", "Manchester United FC", "EPL")
+
+    def test_order_independent(self):
+        # Same pair, swapped — should still match.
+        assert rivalries.is_rivalry("Manchester United FC", "Liverpool FC", "EPL")
+
+    def test_case_insensitive(self):
+        assert rivalries.is_rivalry("liverpool fc", "MANCHESTER UNITED FC", "EPL")
+
+    def test_substring_handles_fd_org_suffixes(self):
+        # FD.org names have trailing FC / AFC; the JSON stores bare names.
+        assert rivalries.is_rivalry("Arsenal FC", "Tottenham Hotspur FC", "EPL")
+        assert rivalries.is_rivalry("Manchester City FC", "Manchester United FC", "EPL")
+
+    def test_unknown_pair_returns_false(self):
+        assert not rivalries.is_rivalry("Brighton", "Burnley", "EPL")
+
+    def test_unknown_sport_returns_false(self):
+        assert not rivalries.is_rivalry("Anyone", "Anyone", "NOT_A_REAL_SPORT")
+
+    def test_missing_team_names_safe(self):
+        assert not rivalries.is_rivalry("", "Manchester United FC", "EPL")
+        assert not rivalries.is_rivalry("Liverpool FC", "", "EPL")
+        assert not rivalries.is_rivalry("", "", "EPL")
+
+    def test_ncaa_football_pair(self):
+        assert rivalries.is_rivalry("Alabama", "Auburn", "CFB")
+        assert rivalries.is_rivalry("Ohio State", "Michigan", "CFB")
+
+    def test_nba_classic(self):
+        assert rivalries.is_rivalry("Boston Celtics", "Los Angeles Lakers", "NBA")
+
+    def test_nhl_original_six(self):
+        assert rivalries.is_rivalry("Montreal Canadiens", "Boston Bruins", "NHL")
+
+    def test_mlb_yankees_red_sox(self):
+        assert rivalries.is_rivalry("New York Yankees", "Boston Red Sox", "MLB")
+
+    def test_la_classico_either_name(self):
+        # Real Madrid vs Barcelona — full names + abbreviations.
+        assert rivalries.is_rivalry("Real Madrid", "Barcelona", "LaLiga")
+        assert rivalries.is_rivalry("Real Madrid CF", "FC Barcelona", "LaLiga")
+
+    def test_paris_sg_abbreviation(self):
+        # SportsDB returns "Paris SG"; FD.org returns "Paris Saint-Germain FC".
+        # JSON has both forms — both should match Marseille.
+        assert rivalries.is_rivalry("Paris SG", "Olympique de Marseille", "Ligue1")
+        assert rivalries.is_rivalry("Paris Saint-Germain FC", "Marseille", "Ligue1")
+
+    def test_cross_sport_no_false_positive(self):
+        # Liverpool isn't a rivalry in MLS even if a "Liverpool" entry existed.
+        assert not rivalries.is_rivalry("Liverpool FC", "Manchester United FC", "MLS")
+
+    def test_handles_one_word_team_name_substring(self):
+        # NCAA Football "Texas vs Oklahoma" — bare 1-word names. Both
+        # appear in many other team names ("UT-Austin Texas Longhorns"),
+        # but the JSON entries are exact-bare so they only match teams
+        # whose name actually contains "Texas".
+        assert rivalries.is_rivalry("Texas", "Oklahoma", "CFB")
+        assert rivalries.is_rivalry("Texas Longhorns", "Oklahoma Sooners", "CFB")
+
+
+class TestLoadRivalries:
+    def test_json_is_valid(self):
+        path = os.path.join(REPO_ROOT, "rivalries.json")
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+        # At least the sports listed in the issue are present.
+        for sport in ("CFB", "EPL", "NBA", "NHL", "MLB", "NFL"):
+            assert sport in raw, f"Missing sport {sport} in rivalries.json"
+            assert isinstance(raw[sport], list)
+            assert len(raw[sport]) > 0
+
+    def test_every_pair_has_two_strings(self):
+        path = os.path.join(REPO_ROOT, "rivalries.json")
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+        for key, pairs in raw.items():
+            if key.startswith("_"):
+                continue
+            for pair in pairs:
+                assert isinstance(pair, list) and len(pair) == 2
+                assert all(isinstance(s, str) and s.strip() for s in pair), \
+                    f"Bad pair in {key}: {pair}"
+
+    def test_no_self_rivalries(self):
+        # A team can't be its own rival.
+        path = os.path.join(REPO_ROOT, "rivalries.json")
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+        for key, pairs in raw.items():
+            if key.startswith("_"):
+                continue
+            for a, b in pairs:
+                assert rivalries._normalize(a) != rivalries._normalize(b), \
+                    f"Self-rivalry in {key}: {a} / {b}"


### PR DESCRIPTION
## Summary

\`weight_rivalry=2.0\` has been wired through scoring forever but no source populated \`is_rivalry\`, so the rivalry signal was effectively dead. Now activated via a curated static list.

New \`rivalries.py\` + \`rivalries.json\` covers the known rivalries across NCAA football/basketball, EPL/EFL/Bundesliga/La Liga/Serie A/Ligue 1, NFL/NBA/NHL/MLB/MLS/Liga MX. Case-insensitive substring match in both directions so both SportsDB-style abbreviations (\"Paris SG\") and FD.org-style long forms (\"Paris Saint-Germain FC\") match the same JSON entry.

## Live verification

\`\`\`
EPL: 'Liverpool FC' vs 'Manchester United FC' -> True
EPL: 'Arsenal FC' vs 'Tottenham Hotspur FC'   -> True
EPL: 'Brighton' vs 'Burnley'                  -> False  ← not a derby
CFB: 'Alabama' vs 'Auburn'                    -> True
NBA: 'Boston Celtics' vs 'Los Angeles Lakers' -> True
Ligue1: 'Paris SG' vs 'Marseille'             -> True
\`\`\`

## Design choices

- **Static JSON over LLM-judged.** The issue suggested shipping both. Static covers the high-signal known rivalries with zero external API dependency. LLM path filed as a deferred follow-up.
- **Substring match (both directions)** absorbs source-side name variations without needing a name-alias table. False-positive risk is bounded by the curated list itself — only \"Manchester City\" and \"Manchester United\" appear in the EPL list, so \"Manchester Brighton FC\" wouldn't false-match.
- **Set on GameSignals at refresh, persisted to cache.** Cache replay reads is_rivalry from either explicit cache key OR \`\"rivalry\" in score_breakdown\` for old caches predating this commit.

## Test plan

- [x] 21 unit tests covering normalize, order-independence, case sensitivity, substring matching, cross-sport isolation, defensive empty-input paths, JSON validity
- [x] Live verification across 6 sport prefixes — known rivalries True, non-rivalries False, both SportsDB and FD.org name forms matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)