### PR TITLE
Closes #27: synthesize WS placeholder during LCS week

### DIFF
--- a/sources/mlb.py
+++ b/sources/mlb.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import logging
 import random
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -83,6 +83,23 @@ _MLB_SERIES_LENGTHS: Dict[str, int] = {
     "LCS": 7,
     "WS": 7,
 }
+
+# MLB World Series 2-3-2 home pattern: top seed (AL/NL winner with the
+# better regular-season record) hosts games 1, 2, 6, 7; the other side
+# hosts games 3, 4, 5. NHL uses 2-2-1-1-1 — different sport, different
+# home rotation, same shape of pattern array (True = top-seed home).
+MLB_WS_HOME_PATTERN: Tuple[bool, ...] = (True, True, False, False, False, True, True)
+
+# Sentinel team names for the synthesized WS placeholder tie. Same
+# pattern as nhl.py's CUP_FINAL sentinels (#17). The mlb postseason
+# endpoint omits the WS series from its response until both LCS series
+# resolve — so during LCS week the WS cascade reads 0 leverage even on
+# an LCS Game-7. The placeholder lets the importance simulator
+# propagate counterfactual LCS winners into WS → WS_WINNER. DO NOT
+# change these strings without also updating _build_bracket's
+# placeholder-detection branch — the names are the join key. See #27.
+_WS_TOP_SENTINEL = "LCS_AL_WINNER"
+_WS_BOT_SENTINEL = "LCS_NL_WINNER"
 
 
 def _http_get(url: str, timeout: float = 20.0) -> Optional[Dict[str, Any]]:
@@ -458,5 +475,108 @@ class MlbPlayoffSource(BestOfNSeriesSource):
                     },
                 })
 
+        # Issue #27 fix: synthesize a WS placeholder tie when both LCS
+        # series have published games (= participants are known) but the
+        # endpoint hasn't yet populated the World Series. statsapi.mlb.com
+        # only emits the WS series after both LCS resolve, which leaves
+        # the ws_winner band reading 0 leverage during LCS week — exactly
+        # when LCS-Game-7 leverage should be maxing out. Mirrors the NHL
+        # CUP_FINAL fix in #17.
+        lcs_pair_set: set = set()
+        for g in out:
+            if g["stage"] == "LCS":
+                # frozenset because home/away can swap mid-series
+                lcs_pair_set.add(frozenset((g["home"], g["away"])))
+        ws_emitted = sum(1 for g in out if g["stage"] == "WS")
+        if len(lcs_pair_set) == 2 and ws_emitted == 0:
+            out.extend(self._synth_ws_placeholder_games())
+
         self._bracket_games_cache = out
         return out
+
+    # ---------- WS placeholder synthesis (#27) ----------
+
+    def _synth_ws_placeholder_games(self) -> List[Dict[str, Any]]:
+        """Emit 7 SCHEDULED WS games with sentinel team names following
+        MLB's 2-3-2 home pattern. Game IDs are negative ints to guarantee
+        non-collision with real statsapi gamePks (positive 6-digit ints
+        like 778411).
+
+        The sentinels are stable across refreshes within one importance
+        run — they're matched by _build_bracket below to wire feeds_from
+        to the two LCS series.
+        """
+        games: List[Dict[str, Any]] = []
+        for matchday in range(1, len(MLB_WS_HOME_PATTERN) + 1):
+            top_home = MLB_WS_HOME_PATTERN[matchday - 1]
+            home = _WS_TOP_SENTINEL if top_home else _WS_BOT_SENTINEL
+            away = _WS_BOT_SENTINEL if top_home else _WS_TOP_SENTINEL
+            games.append({
+                "game_id": -(200000 + matchday),  # synthetic, non-colliding
+                "stage": "WS",
+                "matchday": matchday,
+                "home": home,
+                "away": away,
+                "home_goals": None,
+                "away_goals": None,
+                "status": "SCHEDULED",
+                "start_time": None,
+                "extra": {
+                    "is_placeholder": True,
+                    "series_description": "synthetic-ws",
+                },
+            })
+        return games
+
+    def _build_bracket(self, games: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+        """Override the shared bracket build to wire feeds_from on the
+        WS placeholder tie (whose participants are sentinel names, which
+        the participant-set inference in the base class can't match
+        against the actual LCS participants). Same shape as
+        NhlPlayoffSource._build_bracket — see #17 and #27.
+        """
+        bracket = super()._build_bracket(games)
+        lcs_ties = bracket.get("LCS", [])
+        ws_ties = bracket.get("WS", [])
+        if len(lcs_ties) != 2 or len(ws_ties) != 1:
+            return bracket
+        ws_tie = ws_ties[0]
+        teams = ws_tie.get("teams") or frozenset()
+        if not (
+            _WS_TOP_SENTINEL in teams
+            and _WS_BOT_SENTINEL in teams
+        ):
+            return bracket  # not a placeholder, leave alone
+
+        # Wire feeds_from: each sentinel resolves to the winner of its
+        # corresponding LCS series. Bracket order from _build_bracket is
+        # deterministic per frozenset insertion order; we treat LCS[0] as
+        # the "top" feeder and LCS[1] as the "bottom" feeder. Without
+        # league-affiliation data this assignment is arbitrary — what
+        # matters for importance computation is that BOTH sentinels are
+        # cascaded into the WS_WINNER depth, not which league each one
+        # came from.
+        ws_tie["feeds_from"] = {
+            _WS_TOP_SENTINEL: ("LCS", 0),
+            _WS_BOT_SENTINEL: ("LCS", 1),
+        }
+        ws_tie["is_entry_tie"] = False
+        return bracket
+
+    def _source_team_for(self, sim_team: str, tie_meta: Dict[str, Any]) -> str:
+        """For the WS placeholder, sentinel team names need to map to
+        the resolved LCS winners by position. Return the FIRST game's
+        source-published home so the home/away swap logic in
+        BracketSportSource._emit_remaining_games_for_tie compares against
+        a consistent "team_a is sentinel-A" mapping rather than against
+        the resolved team name (which would never match a sentinel).
+
+        Non-placeholder cases get the same behavior for free: games[0].home
+        IS team_a's source name in those cases too. Same shape as
+        NhlPlayoffSource._source_team_for.
+        """
+        del sim_team  # mapping derived from tie_meta, not sim_team identity
+        games = tie_meta.get("games") or []
+        if not games:
+            return ""
+        return games[0].get("home") or ""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -6522,3 +6522,209 @@ class TestGroupStageContextCodes:
         wc_weight = next(w for _, lbl, w in LEAGUE_CONTEXTS["WC_GS"].thresholds if lbl == "advance")
         ec_weight = next(w for _, lbl, w in LEAGUE_CONTEXTS["EC_GS"].thresholds if lbl == "advance")
         assert wc_weight > ec_weight
+
+
+class TestMlbWsPlaceholder:
+    """Issue #27: synthesize a WS placeholder tie when both LCS series
+    have published games but the postseason endpoint hasn't yet
+    populated the World Series (which only happens after both LCS
+    resolve). Without the placeholder, ws_winner leverage reads 0
+    during LCS week — exactly when LCS-Game-7 leverage should max.
+    Mirrors NhlPlayoffSource's #17 fix.
+    """
+
+    @staticmethod
+    def _two_lcs_in_progress_games():
+        """7-game LCS pair × 2, all SCHEDULED + no WS games yet —
+        mimics live shape during LCS week."""
+        games = []
+        # AL LCS: Yankees vs Astros
+        # NL LCS: Dodgers vs Phillies
+        # 2-3-2 home pattern for both
+        pattern = (True, True, False, False, False, True, True)
+        for series_idx, (top, bot) in enumerate(
+            [("New York Yankees", "Houston Astros"), ("Los Angeles Dodgers", "Philadelphia Phillies")]
+        ):
+            for matchday in range(1, 8):
+                top_home = pattern[matchday - 1]
+                games.append({
+                    "game_id": 700000 + series_idx * 10 + matchday,
+                    "stage": "LCS",
+                    "matchday": matchday,
+                    "home": top if top_home else bot,
+                    "away": bot if top_home else top,
+                    "home_goals": None, "away_goals": None,
+                    "status": "SCHEDULED",
+                    "start_time": None,
+                    "extra": {"series_description": f"LCS-{series_idx}"},
+                })
+        return games
+
+    def test_synth_emits_7_games_with_mlb_home_pattern(self):
+        from dispatcharr_ranked_matchups.sources.mlb import (
+            MlbPlayoffSource, _WS_TOP_SENTINEL, _WS_BOT_SENTINEL, MLB_WS_HOME_PATTERN,
+        )
+        src = MlbPlayoffSource(season=2025)
+        games = src._synth_ws_placeholder_games()
+        assert len(games) == 7
+        assert all(g["stage"] == "WS" for g in games)
+        assert all(g["status"] == "SCHEDULED" for g in games)
+        assert all(g["game_id"] < 0 for g in games), \
+            "placeholder game IDs must be negative to avoid colliding with real gamePks"
+        # 2-3-2 verification: game 1 → top home, game 3 → bottom home, game 6 → top home.
+        for matchday in range(1, 8):
+            top_home = MLB_WS_HOME_PATTERN[matchday - 1]
+            expected_home = _WS_TOP_SENTINEL if top_home else _WS_BOT_SENTINEL
+            assert games[matchday - 1]["home"] == expected_home, \
+                f"game {matchday}: expected home {expected_home}, got {games[matchday - 1]['home']}"
+            assert games[matchday - 1]["matchday"] == matchday
+
+    def test_placeholder_fires_when_two_lcs_no_ws(self):
+        from dispatcharr_ranked_matchups.sources.mlb import (
+            MlbPlayoffSource, _WS_TOP_SENTINEL, _WS_BOT_SENTINEL,
+        )
+        src = MlbPlayoffSource(season=2025)
+        bracket_games = self._two_lcs_in_progress_games()
+        bracket_games.extend(src._synth_ws_placeholder_games())
+        src._bracket_games_cache = bracket_games
+        state = src.initial_state()
+        ws_ties = state["_bracket"].get("WS", [])
+        assert len(ws_ties) == 1
+        teams = set(ws_ties[0]["teams"])
+        assert teams == {_WS_TOP_SENTINEL, _WS_BOT_SENTINEL}
+
+    def test_placeholder_feeds_from_wired_to_lcs(self):
+        from dispatcharr_ranked_matchups.sources.mlb import (
+            MlbPlayoffSource, _WS_TOP_SENTINEL, _WS_BOT_SENTINEL,
+        )
+        src = MlbPlayoffSource(season=2025)
+        bracket_games = self._two_lcs_in_progress_games()
+        bracket_games.extend(src._synth_ws_placeholder_games())
+        src._bracket_games_cache = bracket_games
+        state = src.initial_state()
+        ws_tie = state["_bracket"]["WS"][0]
+        feeds = ws_tie["feeds_from"]
+        assert feeds[_WS_TOP_SENTINEL] == ("LCS", 0)
+        assert feeds[_WS_BOT_SENTINEL] == ("LCS", 1)
+        assert ws_tie["is_entry_tie"] is False
+
+    def test_placeholder_blocks_remaining_until_lcs_resolves(self):
+        from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
+        src = MlbPlayoffSource(season=2025)
+        bracket_games = self._two_lcs_in_progress_games()
+        bracket_games.extend(src._synth_ws_placeholder_games())
+        src._bracket_games_cache = bracket_games
+        state = src.initial_state()
+        remaining = src.remaining_matches(state)
+        ws_remaining = [g for g in remaining if g.extra.get("stage") == "WS"]
+        assert len(ws_remaining) == 0, "WS must be blocked while LCS unresolved"
+
+
+class TestMlbWsPlaceholderGating:
+    """Verifies the placeholder ONLY synthesizes in the LCS-in-progress
+    window. False positives during pre-LCS or post-LCS would either
+    short-circuit valid data or produce wrong game counts."""
+
+    def test_no_synthesis_when_only_one_lcs_series_started(self, monkeypatch):
+        # Only one LCS series has games (other still in LDS), so the
+        # placeholder should NOT fire — we don't know both participants yet.
+        from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
+        src = MlbPlayoffSource(season=2025)
+        # Stub _http_get to return a payload with 1 LCS series
+        from dispatcharr_ranked_matchups.sources import mlb as mlb_mod
+        fake = {"dates": [{"games": [
+            {
+                "gamePk": 700001, "seriesDescription": "AL Championship Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Yankees"}, "score": None},
+                    "away": {"team": {"name": "Astros"}, "score": None},
+                },
+                "status": {"abstractGameState": "Preview"},
+                "gameDate": "2025-10-12T20:00:00Z",
+            },
+        ]}]}
+        monkeypatch.setattr(mlb_mod, "_http_get", lambda url: fake)
+        out = src._fetch_bracket_games()
+        # 1 LCS series + 0 WS placeholders.
+        assert sum(1 for g in out if g["stage"] == "WS") == 0
+        assert sum(1 for g in out if g["stage"] == "LCS") == 1
+
+    def test_no_synthesis_when_ws_already_published(self, monkeypatch):
+        # Both LCS resolved AND WS published — real data, no placeholder.
+        from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
+        from dispatcharr_ranked_matchups.sources import mlb as mlb_mod
+        src = MlbPlayoffSource(season=2025)
+        fake = {"dates": [{"games": [
+            # 1 game in each LCS (enough to register as 2 distinct LCS series)
+            {
+                "gamePk": 700001, "seriesDescription": "AL Championship Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Yankees"}, "score": 5},
+                    "away": {"team": {"name": "Astros"}, "score": 2},
+                },
+                "status": {"abstractGameState": "Final"},
+                "gameDate": "2025-10-12T20:00:00Z",
+            },
+            {
+                "gamePk": 700002, "seriesDescription": "NL Championship Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Dodgers"}, "score": 4},
+                    "away": {"team": {"name": "Phillies"}, "score": 1},
+                },
+                "status": {"abstractGameState": "Final"},
+                "gameDate": "2025-10-12T20:00:00Z",
+            },
+            # WS game already published
+            {
+                "gamePk": 700100, "seriesDescription": "World Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Yankees"}, "score": None},
+                    "away": {"team": {"name": "Dodgers"}, "score": None},
+                },
+                "status": {"abstractGameState": "Preview"},
+                "gameDate": "2025-10-25T20:00:00Z",
+            },
+        ]}]}
+        monkeypatch.setattr(mlb_mod, "_http_get", lambda url: fake)
+        out = src._fetch_bracket_games()
+        # 1 real WS game; 0 placeholders.
+        ws_games = [g for g in out if g["stage"] == "WS"]
+        assert len(ws_games) == 1
+        assert ws_games[0]["game_id"] > 0, "Real WS game, should not be synthetic (negative ID)"
+
+    def test_synthesis_fires_when_lcs_in_progress(self, monkeypatch):
+        # Both LCS have published games, no WS yet — synthesizer should fire.
+        from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
+        from dispatcharr_ranked_matchups.sources import mlb as mlb_mod
+        src = MlbPlayoffSource(season=2025)
+        fake = {"dates": [{"games": [
+            {
+                "gamePk": 700001, "seriesDescription": "AL Championship Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Yankees"}, "score": None},
+                    "away": {"team": {"name": "Astros"}, "score": None},
+                },
+                "status": {"abstractGameState": "Preview"},
+                "gameDate": "2025-10-12T20:00:00Z",
+            },
+            {
+                "gamePk": 700002, "seriesDescription": "NL Championship Series",
+                "seriesGameNumber": 1,
+                "teams": {
+                    "home": {"team": {"name": "Dodgers"}, "score": None},
+                    "away": {"team": {"name": "Phillies"}, "score": None},
+                },
+                "status": {"abstractGameState": "Preview"},
+                "gameDate": "2025-10-12T20:00:00Z",
+            },
+        ]}]}
+        monkeypatch.setattr(mlb_mod, "_http_get", lambda url: fake)
+        out = src._fetch_bracket_games()
+        ws_games = [g for g in out if g["stage"] == "WS"]
+        assert len(ws_games) == 7, "should synth a 7-game WS placeholder"
+        assert all(g["game_id"] < 0 for g in ws_games), "all synthesized (negative IDs)"


### PR DESCRIPTION
## Summary

MLB analog of NHL CUP_FINAL placeholder (#17). statsapi.mlb.com only publishes the World Series ties after both LCS resolve, so during LCS week the \`ws_winner\` cascade band reads 0 leverage even on LCS Game-7 — exactly when leverage should peak.

Synthesizes a WS placeholder tie with sentinel team names (\`LCS_AL_WINNER\` / \`LCS_NL_WINNER\`) when both LCS series have published games but no WS games exist. The simulator cascades counterfactual LCS winners into the WS → WS_WINNER importance bands.

## Pattern reuse

Mirrors the NHL #17 fix structurally — same five hooks (sentinels, home pattern, fetch-loop synthesis, _build_bracket feeds_from wiring, _source_team_for resolution). The only sport-specific delta is MLB's 2-3-2 home rotation:

\`\`\`python
MLB_WS_HOME_PATTERN = (True, True, False, False, False, True, True)
# Top seed hosts games 1, 2, 6, 7. Bottom seed hosts 3, 4, 5.
\`\`\`

vs NHL's 2-2-1-1-1: \`(True, True, False, False, True, False, True)\`.

## Gating

Synthesis fires ONLY when:
- 2 distinct LCS team-pairs exist in the bracket data (= both LCS series have started)
- 0 WS games published

Verified through 3 dedicated gating tests:
- 1 LCS in progress (other in LDS) → no synth
- WS already published → no synth (real data trusted)
- 2 LCS in progress + 0 WS → 7-game synth

## Test plan

- [x] 7 unit tests covering synthesis structure (count, home pattern, negative game_ids), bracket wiring (feeds_from points to LCS[0] / LCS[1], is_entry_tie=False), blocking semantics (remaining_matches excludes WS while LCS unresolved), and all 3 gating windows
- [x] Bypasses network via stubbed _http_get + pre-baked bracket caches — same offline pattern as #17 tests
- [x] Severity matches: only matters ~14 days/year during LCS week; this PR closes the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)