### PR TITLE
Closes #9: curation presets bundle weights + max_games

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -316,11 +316,24 @@
       "help_text": "Substring-matched against home/away team names (with team-qualifier whitelist for soccer suffixes like 'FC', 'AFC', 'City', 'United'). Always shown regardless of rank, with a flat score boost. Teams in playoff races still get the 'impact-on-favorite' signal automatically when they sit near a favorite's position."
     },
     {
+      "id": "curation_preset",
+      "type": "select",
+      "label": "Curation preset",
+      "default": "manual",
+      "options": [
+        {"value": "manual", "label": "Manual (use individual weights + max_games below)"},
+        {"value": "high_curation", "label": "High curation (~10 games, only the best)"},
+        {"value": "balanced", "label": "Balanced (~25 games, default v0 behavior)"},
+        {"value": "high_coverage", "label": "High coverage (~50 games, include smaller stakes)"}
+      ],
+      "help_text": "Bundles weight + max_games tuning into one knob so you don't have to tune 9 sliders. Picking anything other than 'manual' overrides the individual weight_* settings and max_games below with the preset's values. Stick with 'manual' if you've hand-tuned weights."
+    },
+    {
       "id": "max_games",
       "type": "number",
       "label": "Max curated games per refresh",
       "default": 25,
-      "help_text": "Top-N games by score across all enabled sports (20-50 is a sensible range; lower = tighter curation, higher = more coverage). Favorites guaranteed inclusion above this cap."
+      "help_text": "Top-N games by score across all enabled sports (20-50 is a sensible range; lower = tighter curation, higher = more coverage). Favorites guaranteed inclusion above this cap. IGNORED when curation_preset is anything other than 'manual'."
     },
     {
       "id": "lookahead_days",

--- a/plugin.py
+++ b/plugin.py
@@ -337,6 +337,43 @@ def _parse_favorites(raw: str) -> List[str]:
     return [t.strip() for t in raw.split(",") if t.strip()]
 
 
+# Curation presets (#9). Each preset bundles a Weights tuning + a max_games
+# cap so users don't have to tune 9 individual knobs to get a "vibe":
+#
+# - "manual": read individual weight + max_games settings (V0 behavior).
+# - "high_curation": narrow to ~10 high-leverage games; weights emphasize
+#   structural importance + rank, downweight favorites/spread so they don't
+#   dominate the list when the user wants tight curation.
+# - "balanced": ~25 games with default weights — mirrors the v0 default.
+# - "high_coverage": ~50 games with permissive weights so smaller-stakes
+#   matchups still show up even on quiet days.
+#
+# Manual mode and a non-manual preset are mutually exclusive in spirit but
+# not enforced. Picking a preset overrides individual weight + max_games
+# settings during refresh; users who tune individual knobs should leave the
+# preset on "manual".
+_CURATION_PRESETS: Dict[str, Dict[str, float]] = {
+    "high_curation": {
+        "rank": 1.5, "spread": 2.0, "favorite": 4.0, "rivalry": 1.5,
+        "tournament": 2.0, "narrative": 0.0, "importance": 4.0,
+        "max_games": 10,
+    },
+    "balanced": {
+        # Mirrors Weights() dataclass defaults — kept here for the SAME
+        # reason _build_weights pulls from Weights(): if defaults change,
+        # the "balanced" preset SHOULD track them. DRY check pinned by tests.
+        "rank": 1.0, "spread": 3.0, "favorite": 6.0, "rivalry": 2.0,
+        "tournament": 1.5, "narrative": 0.0, "importance": 3.0,
+        "max_games": 25,
+    },
+    "high_coverage": {
+        "rank": 0.7, "spread": 4.0, "favorite": 8.0, "rivalry": 2.5,
+        "tournament": 1.0, "narrative": 0.0, "importance": 2.5,
+        "max_games": 50,
+    },
+}
+
+
 def _build_weights(settings: Dict[str, Any]):
     # Source of truth for default values is scoring.Weights's dataclass
     # declaration. Do NOT duplicate the numbers here — when a default
@@ -344,6 +381,24 @@ def _build_weights(settings: Dict[str, Any]):
     # uses the old value until somebody runs the tests.
     from .scoring import Weights
     d = Weights()
+
+    # Preset path: if a non-manual preset is selected, individual weight_*
+    # settings are IGNORED and the preset bundle wins. Manual (or any
+    # unrecognized preset name) falls through to the individual-setting
+    # path so power-users keep their tuning.
+    preset_key = str(settings.get("curation_preset", "manual") or "manual").lower()
+    if preset_key != "manual" and preset_key in _CURATION_PRESETS:
+        p = _CURATION_PRESETS[preset_key]
+        return Weights(
+            rank=float(p["rank"]),
+            spread=float(p["spread"]),
+            favorite=float(p["favorite"]),
+            rivalry=float(p["rivalry"]),
+            tournament=float(p["tournament"]),
+            narrative=float(p["narrative"]),
+            importance=float(p["importance"]),
+        )
+
     return Weights(
         rank=float(settings.get("weight_rank", d.rank)),
         spread=float(settings.get("weight_spread", d.spread)),
@@ -353,6 +408,19 @@ def _build_weights(settings: Dict[str, Any]):
         narrative=float(settings.get("weight_narrative", d.narrative)),
         importance=float(settings.get("weight_importance", d.importance)),
     )
+
+
+def _resolve_max_games(settings: Dict[str, Any]) -> int:
+    """Returns max_games for the curated list, honoring an active preset.
+
+    Non-manual preset → preset's max_games cap wins over individual setting.
+    Manual / unrecognized → read the user's max_games setting (default 25,
+    matching the balanced preset).
+    """
+    preset_key = str(settings.get("curation_preset", "manual") or "manual").lower()
+    if preset_key != "manual" and preset_key in _CURATION_PRESETS:
+        return int(_CURATION_PRESETS[preset_key]["max_games"])
+    return int(settings.get("max_games", 25))
 
 
 def _build_sources(settings: Dict[str, Any]):
@@ -648,7 +716,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     favorites = _parse_favorites(settings.get("favorites", ""))
     weights = _build_weights(settings)
     lookahead = int(settings.get("lookahead_days", 7))
-    max_games = int(settings.get("max_games", 25))
+    max_games = _resolve_max_games(settings)
 
     sources = _build_sources(settings)
     if not sources:

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1129,6 +1129,81 @@ class TestComputePastSlotEnd:
         assert past_end.utcoffset().total_seconds() == 0
 
 
+class TestCurationPresets:
+    def test_manual_preset_uses_individual_weights(self, plugin):
+        settings = {
+            "curation_preset": "manual",
+            "weight_rank": 99.0, "weight_favorite": 99.0,
+        }
+        w = plugin._build_weights(settings)
+        assert w.rank == 99.0
+        assert w.favorite == 99.0
+
+    def test_manual_preset_default_when_setting_blank(self, plugin):
+        # No curation_preset key at all → manual path.
+        w = plugin._build_weights({"weight_rank": 99.0})
+        assert w.rank == 99.0
+
+    def test_high_curation_preset_overrides_individuals(self, plugin):
+        # Even with manual weights set, preset values win.
+        w = plugin._build_weights({
+            "curation_preset": "high_curation",
+            "weight_rank": 99.0, "weight_favorite": 99.0,
+        })
+        assert w.rank == 1.5
+        assert w.favorite == 4.0
+
+    def test_balanced_preset_matches_default_weights(self, plugin):
+        # Balanced preset == scoring.Weights() defaults — DRY check that
+        # prevents the preset drifting silently as defaults change.
+        from dispatcharr_ranked_matchups.scoring import Weights
+        d = Weights()
+        w = plugin._build_weights({"curation_preset": "balanced"})
+        assert w.rank == d.rank
+        assert w.spread == d.spread
+        assert w.favorite == d.favorite
+        assert w.rivalry == d.rivalry
+        assert w.tournament == d.tournament
+        assert w.narrative == d.narrative
+        assert w.importance == d.importance
+
+    def test_high_coverage_preset_lower_rank_higher_favorite(self, plugin):
+        w = plugin._build_weights({"curation_preset": "high_coverage"})
+        assert w.rank == 0.7
+        assert w.favorite == 8.0
+
+    def test_unknown_preset_falls_back_to_manual(self, plugin):
+        # Defensive: unrecognized preset name shouldn't crash, just use individuals.
+        w = plugin._build_weights({
+            "curation_preset": "best_in_show_only",
+            "weight_rank": 42.0,
+        })
+        assert w.rank == 42.0
+
+    def test_case_insensitive_preset_name(self, plugin):
+        w = plugin._build_weights({"curation_preset": "HIGH_CURATION"})
+        assert w.rank == 1.5
+
+    # ---------- max_games resolution ----------
+
+    def test_resolve_max_games_manual_reads_setting(self, plugin):
+        assert plugin._resolve_max_games({
+            "curation_preset": "manual", "max_games": 7,
+        }) == 7
+
+    def test_resolve_max_games_preset_wins(self, plugin):
+        # User set max_games=999 but picked high_curation — preset wins.
+        assert plugin._resolve_max_games({
+            "curation_preset": "high_curation", "max_games": 999,
+        }) == 10
+        assert plugin._resolve_max_games({"curation_preset": "balanced"}) == 25
+        assert plugin._resolve_max_games({"curation_preset": "high_coverage"}) == 50
+
+    def test_resolve_max_games_default(self, plugin):
+        # No setting at all → default 25.
+        assert plugin._resolve_max_games({}) == 25
+
+
 class TestIsCatchupMatchday:
     def _table(self, max_played):
         # Synthetic table where most teams played `max_played` and a couple


### PR DESCRIPTION
## Summary

New \`curation_preset\` select setting bundles the 8 individual weight knobs + \`max_games\` into a single \"vibe\" choice. Power-users keep \`manual\` mode.

\`\`\`
manual          ← read individual weight_* + max_games settings (V0 behavior)
high_curation   ← ~10 games; emphasize importance + rank, downweight favorites
balanced        ← ~25 games with default weights (mirrors V0 defaults)
high_coverage   ← ~50 games; broaden net for quiet days
\`\`\`

## Design choices

- **4 options** (3 presets + manual). 5+ was overkill; 2 felt too binary.
- **Apply at refresh time** — preset is read by \`_build_weights\` and \`_resolve_max_games\` during refresh's curation pass. Affects which games make the cut.
- **No warning** when a user picks a preset on top of hand-tuned weights — documented in the help_text and via the manual fallback path. \"Stick with manual\" is enough guidance.
- **'balanced' preset mirrors \`scoring.Weights()\` defaults** — pinned by \`test_balanced_preset_matches_default_weights\` so the two can't drift silently when defaults change. This is the DRY check called out in /sr-dev-review Q2.

## Test plan

- [x] 10 unit tests covering manual path (reads individuals), preset path (overrides individuals), each preset's specific values, max_games resolution, the balanced ↔ Weights() DRY pin, unknown-preset fallback to manual, case-insensitive match
- [x] Settings field added to plugin.json with help_text that clearly states the override semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)