### PR TITLE
Closes #7: season-relative adaptive score normalization

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -405,6 +405,13 @@
       "help_text": "Optional LLM-judged narrative score. Disabled by default — the Monte Carlo importance signal covers structural standings stakes. Set > 0 to enable Claude-based narrative scoring for storyline / form / managerial-drama factors that the structural simulator can't capture."
     },
     {
+      "id": "adaptive_scoring",
+      "type": "boolean",
+      "label": "Adaptive (season-relative) scoring",
+      "default": false,
+      "help_text": "Off (default) = absolute scoring: raw signal sum compressed via fixed tanh curve. ★10 saturates late-season; early-season weeks feel flat. On = each refresh batch's median raw score sets the scale, so the top games of any week always feel like top games. Recommended once the season is in full swing; leave off for the simpler absolute mode."
+    },
+    {
       "id": "weight_importance",
       "type": "number",
       "label": "Monte Carlo importance weight",

--- a/plugin.py
+++ b/plugin.py
@@ -887,6 +887,18 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
         score = score_game(signals, weights)
         scored.append((g, signals, score))
 
+    # Adaptive normalization (#7): re-derive each game's final score from
+    # the batch's median raw, so top games feel "top" regardless of
+    # where in the season we are. Opt-in via `adaptive_scoring`; the
+    # default keeps the absolute-tanh compression in score_game.
+    if bool(settings.get("adaptive_scoring", False)) and scored:
+        from .scoring import adaptive_compress
+        raws = [score.raw for _, _, score in scored]
+        finals = adaptive_compress(raws)
+        for (game, sigs, score), new_final in zip(scored, finals):
+            del game, sigs  # unpacking only; the GameScore is what we update
+            score.final = round(new_final, 2)
+
     # Sort: today's games first (0 before 1), then 0-10 score desc, then raw as
     # tiebreak, then start_time ascending. So a game today with ★7 outranks a
     # game next week with ★9.5.

--- a/scoring.py
+++ b/scoring.py
@@ -791,6 +791,55 @@ def _compress_to_10(raw: float) -> float:
     return 10.0 * math.tanh(raw / _FINAL_KNEE)
 
 
+# Minimum batch size for adaptive normalization to engage. With fewer
+# samples than this the in-batch median is too noisy to scale against —
+# fall through to absolute compression in that case.
+_ADAPTIVE_MIN_SAMPLES = 5
+
+# Target: median raw in the batch maps to ~5 stars. tanh(1/1.6) ≈ 0.55,
+# so 10 × tanh(median / (scale × 1.6)) where scale = median / 5 yields:
+#   tanh(5/1.6) ≈ 0.998 × 10 = 9.98 — too steep, the median outlier saturates.
+# Instead use scale = median itself and target factor 1.6 to land median at:
+#   10 × tanh(median / median / 1.6) = 10 × tanh(0.625) ≈ 10 × 0.555 = 5.55.
+# Below the median compresses to under 5; well above saturates near 10.
+_ADAPTIVE_TARGET_FACTOR = 1.6
+
+
+def adaptive_compress(raw_scores: List[float]) -> List[float]:
+    """Season-relative normalization (see #7).
+
+    Each raw score gets compressed to 0-10 using a scale derived from the
+    batch's median raw score. Effect: top games in any given refresh feel
+    like top games regardless of where in the season they fall — early-
+    season low-stakes weeks no longer compress to all-low; late-season
+    saturation no longer flattens every game to ★10.
+
+    Falls back to absolute compression when the batch has fewer than
+    _ADAPTIVE_MIN_SAMPLES games (median is too noisy on small batches).
+
+    Median scale anchors at minimum 1.0 so a uniformly-low batch doesn't
+    collapse to all 10s via division-by-near-zero.
+    """
+    if len(raw_scores) < _ADAPTIVE_MIN_SAMPLES:
+        return [_compress_to_10(r) for r in raw_scores]
+    sorted_raws = sorted(raw_scores)
+    n = len(sorted_raws)
+    # Median that handles even-length batches without statistics import.
+    median_raw = (
+        sorted_raws[n // 2]
+        if n % 2
+        else (sorted_raws[n // 2 - 1] + sorted_raws[n // 2]) / 2.0
+    )
+    scale = max(float(median_raw), 1.0)
+    out: List[float] = []
+    for r in raw_scores:
+        if r <= 0:
+            out.append(0.0)
+        else:
+            out.append(10.0 * math.tanh(r / (scale * _ADAPTIVE_TARGET_FACTOR)))
+    return out
+
+
 # Spread (point-spread sports) fallback: scale where 0 = full
 # closeness, _SPREAD_BLOWOUT = zero closeness. Anchored to 14 because
 # the pre-B.3 formula maxed at spread=14 too — keeps NCAAF / NCAAM

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -738,3 +738,69 @@ class TestScoreGameImportanceBranch:
         # weight=0 → zero contribution AND no breakdown entry — same as
         # importance_points=0. Other signals (rank_pair) still fire.
         assert "importance" not in score.breakdown
+
+
+class TestAdaptiveCompress:
+    """#7: season-relative score normalization via batch-median scaling."""
+
+    def test_falls_back_to_absolute_on_small_batch(self):
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress, _compress_to_10
+        # 4 samples < _ADAPTIVE_MIN_SAMPLES=5 → absolute compression.
+        raws = [2.0, 4.0, 8.0, 12.0]
+        out = adaptive_compress(raws)
+        expected = [_compress_to_10(r) for r in raws]
+        assert out == expected
+
+    def test_scales_against_median_when_above_threshold(self):
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        # All-low batch: median 4 → scale=4. The top entry (8) is 2×
+        # median → should compress to a high but non-saturated value.
+        out = adaptive_compress([2.0, 3.0, 4.0, 5.0, 8.0])
+        # Median = 4. Each entry's tanh(r / (4 × 1.6)) = tanh(r/6.4).
+        # 4.0 (median) → 10 × tanh(4/6.4) = 10 × tanh(0.625) ≈ 5.54.
+        # 8.0 (2× median) → 10 × tanh(8/6.4) = 10 × tanh(1.25) ≈ 8.48.
+        assert 5.4 <= out[2] <= 5.6, f"median should map near 5.55, got {out[2]:.2f}"
+        assert 8.0 <= out[4] <= 8.7, f"2× median should map near 8.48, got {out[4]:.2f}"
+
+    def test_zero_compresses_to_zero(self):
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        out = adaptive_compress([0.0, 4.0, 8.0, 12.0, 16.0, 20.0])
+        assert out[0] == 0.0
+
+    def test_negative_raw_treated_as_zero(self):
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        out = adaptive_compress([-1.0, 4.0, 8.0, 12.0, 16.0, 20.0])
+        assert out[0] == 0.0
+
+    def test_uniformly_low_batch_doesnt_saturate(self):
+        # If every game is low (median 0.5), scale floors at 1.0 so a
+        # raw=0.5 doesn't compress to ★10 via division-by-near-zero.
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        out = adaptive_compress([0.5] * 5)
+        # All identical inputs map to the same output. With scale=1.0
+        # (floor): tanh(0.5/(1×1.6)) = tanh(0.3125) ≈ 0.303 → 3.03.
+        for v in out:
+            assert v < 4.0, f"low-uniform batch should NOT saturate, got {v:.2f}"
+
+    def test_late_season_inflated_batch_compresses(self):
+        # Late-season simulation: half the batch is high-stakes (raw 20+),
+        # median pushes high → high-raw scores no longer saturate at ★10.
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        out = adaptive_compress([4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0])
+        # Median = 16; routine games (raw=4-8, half the median) compress
+        # to mid-range; top (28 = ~1.75× median) still leaves headroom for the
+        # rare ★10. Top output well below 10 → curve doesn't saturate.
+        assert out[-1] < 10.0
+        # Spread: top of batch is meaningfully higher than median.
+        assert out[-1] - out[3] > 1.0
+
+    def test_preserves_ordering(self):
+        from dispatcharr_ranked_matchups.scoring import adaptive_compress
+        raws = [1.0, 5.0, 3.0, 9.0, 7.0, 12.0]
+        out = adaptive_compress(raws)
+        # Same order after normalization as raw order.
+        pairs_in = sorted(zip(raws, range(len(raws))))
+        pairs_out = sorted(zip(out, range(len(out))))
+        in_order = [i for _, i in pairs_in]
+        out_order = [i for _, i in pairs_out]
+        assert in_order == out_order


### PR DESCRIPTION
## Summary

Absolute tanh compression saturates late-season at ★10 (everything's near a threshold) and under-fires early-season (nobody is). Adds an opt-in batch-median scaling layer so the top games of any refresh feel like top games regardless of where in the season they fall.

## Math

\`\`\`
scale = max(median(raw_scores), 1.0)
final = 10 × tanh(raw / (scale × 1.6))
\`\`\`

Calibration:
- raw = median → final ≈ 5.55 (median games hover around the middle of the scale)
- raw = 2 × median → final ≈ 8.48 (above-median games clearly stand out)
- raw = 0 → final = 0
- raw < 0 → final = 0

Falls back to absolute \`_compress_to_10\` when batch has fewer than 5 samples (median too noisy on small refreshes).

## Behavior

| Scenario | Before | After |
|---|---|---|
| Late-season EPL with 20 games all at high stakes | All ★9.5-10 (saturation) | Median ★5-6, top still ★9 (differentiation preserved) |
| Early-season week 3, low stakes | All ★3-4 (flat) | Median ★5-6 (re-normalized to feel like top games) |
| Small batch (3 games) | Same as before | Same as before (fallback) |
| Uniformly low (all raw=0.5) | All near zero | All near 3 (no division-by-near-zero saturation) |

## Opt-in default

New \`adaptive_scoring\` boolean (default \`false\`). The default keeps simple absolute scoring; users who want season-relative behavior turn it on. v0.1 keeps the V0 mathematical surface unchanged unless explicitly opted in.

## Test plan

- [x] 7 unit tests: small-batch fallback, median-anchor mapping, zero/negative handling, uniformly-low batch non-saturation, late-season inflated batch headroom, ordering preservation
- [x] Ordering preserved by construction — tanh is monotonic, so the top-N pick is identical with or without normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)