### PR TITLE
Closes #30 part A: MLS per-conference standings importance

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -142,9 +142,9 @@
     {
       "id": "enable_mls",
       "type": "boolean",
-      "label": "MLS (regular season + Cup playoffs)",
+      "label": "MLS (regular season)",
       "default": false,
-      "help_text": "MLS games surface with favorite + closeness scoring only in V1 — no standings-based importance yet (conference structure and the mixed-format MLS Cup bracket are follow-ups). Uses ESPN's unofficial site.api.espn.com for the schedule. The Odds API key enables closeness via the soccer_usa_mls market; without it, MLS games appear but with no closeness signal."
+      "help_text": "MLS regular season with per-conference standings importance. Playoff seeding is per-conference (top 9 from Eastern + top 9 from Western), so threshold bands run separately on each conference: 30+ standings points (3 W / 1 D / 0 L) = playoff bubble, 45+ = playoff secured, 55+ = top-4 home-field advantage in R1 best-of-3, 70+ = Supporters' Shield contender. ESPN's unofficial site.api.espn.com for schedule + /standings for conference rosters; The Odds API key enables closeness via soccer_usa_mls. MLS Cup playoff bracket (mixed best-of-3 R1 + single-leg later rounds) is filed as a follow-up (#30 part B)."
     },
     {
       "id": "enable_nwsl",

--- a/plugin.py
+++ b/plugin.py
@@ -461,7 +461,7 @@ def _resolve_max_games(settings: Dict[str, Any]) -> int:
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
         GroupStageSoccerSource, KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
-        MlsSource, NwslSource, LigaMxSource,
+        MlsEastSource, MlsWestSource, NwslSource, LigaMxSource,
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
@@ -611,14 +611,18 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[nba] could not seed playoff strengths: %s", exc)
         sources.append(nba_po)
 
-    # MLS — ESPN schedule + Odds API closeness. V1 surfaces games with
-    # favorite + closeness signals only; no standings-based importance
-    # because conference standings bands and the MLS Cup mixed-format
-    # bracket (best-of-3 R1 + single-leg subsequent rounds) are both
-    # follow-ups. Closeness still requires the Odds API key — without
-    # it MLS games surface but with no closeness signal.
+    # MLS — issue #30 part A: register MlsEastSource + MlsWestSource
+    # for per-conference standings importance (playoff seeding is per-
+    # conference, not aggregate league). The closeness-only MlsSource
+    # stays as the base class for NwslSource / LigaMxSource but is NOT
+    # registered for MLS here; the East/West sources own the MLS
+    # emission and carry the same closeness signal forward via the
+    # shared Odds API helpers from mls.py. MLS Cup playoff bracket
+    # (mixed best-of-3 R1 + single-leg later rounds) is filed under
+    # #30 part B.
     if settings.get("enable_mls", False):
-        sources.append(MlsSource(odds_api_key=odds_key or ""))
+        sources.append(MlsEastSource(odds_api_key=odds_key or ""))
+        sources.append(MlsWestSource(odds_api_key=odds_key or ""))
 
     # NWSL — same V1 minimal pattern as MLS (schedule + closeness).
     # Subclasses MlsSource with NWSL-specific endpoint and Odds API

--- a/scoring.py
+++ b/scoring.py
@@ -746,6 +746,42 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="WC → Divisional → Conf Championship → Super Bowl → Champion",
     ),
+    # Issue #30 part A: MLS conference standings importance. Playoff
+    # seeding is per-conference (top 9 from Eastern, top 9 from Western
+    # in the 14-9 modern format), not aggregate league points — so the
+    # threshold bands MUST be per-conference. Two separate sources
+    # (MlsEastSource / MlsWestSource) route to MLS_EAST / MLS_WEST
+    # respectively; cutoffs are the same on both because the historical
+    # playoff lines have stayed within a couple of points of each other
+    # across conferences in the 34-game era.
+    #
+    # MLS uses 3 W / 1 D / 0 L standings points, so format="points_count"
+    # with the threshold field = standings_points. Bands keyed against
+    # the modern 34-game regular season:
+    #   - ~30 pts: playoff bubble (~9th seed line)
+    #   - ~45 pts: playoff secured (top-7 lock, no Wild Card stress)
+    #   - ~55 pts: top-4 home-field advantage for R1 best-of-3
+    #   - ~70 pts: Supporters' Shield pace (best record in MLS)
+    "MLS_EAST": LeagueContext(
+        code="MLS_EAST", matchdays_total=34, format="points_count",
+        thresholds=[
+            (30, "playoff_bubble",       1.5),
+            (45, "playoff_secured",      2.5),
+            (55, "top_4_home_field",     4.0),
+            (70, "shield_contender",     5.0),
+        ],
+        boundary_summary="30+ pts → bubble · 45+ → secured · 55+ → top-4 home field · 70+ → Shield contender (East)",
+    ),
+    "MLS_WEST": LeagueContext(
+        code="MLS_WEST", matchdays_total=34, format="points_count",
+        thresholds=[
+            (30, "playoff_bubble",       1.5),
+            (45, "playoff_secured",      2.5),
+            (55, "top_4_home_field",     4.0),
+            (70, "shield_contender",     5.0),
+        ],
+        boundary_summary="30+ pts → bubble · 45+ → secured · 55+ → top-4 home field · 70+ → Shield contender (West)",
+    ),
 }
 
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -2,6 +2,7 @@
 from .base import GameRow, SportSource
 from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
+from .mls_standings import MlsEastSource, MlsWestSource
 from .nwsl import NwslSource
 from .liga_mx import LigaMxSource
 from .field_event import (
@@ -38,7 +39,8 @@ from .soccer import (
 __all__ = [
     "GameRow", "SportSource",
     "MlbRegularSource", "MlbPlayoffSource",
-    "MlsSource", "NwslSource", "LigaMxSource",
+    "MlsSource", "MlsEastSource", "MlsWestSource",
+    "NwslSource", "LigaMxSource",
     "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
     "AtpSource", "WtaSource",
     "NbaRegularSource", "NbaPlayoffSource",

--- a/sources/mls_standings.py
+++ b/sources/mls_standings.py
@@ -1,0 +1,553 @@
+"""MLS conference-standings importance source — closes the gap left by
+the Phase J V1 MlsSource (which surfaced schedule + closeness only).
+
+Issue #30 (part A): MLS playoff seeding is per-conference (top 9 from
+Eastern, top 9 from Western), not aggregate league points. Modeling
+importance with a single league-wide threshold misclassifies bubble
+teams when one conference is point-rich and the other point-poor.
+
+Two source classes, one per conference, both extend the same
+MlsStandingsSourceBase mixin which carries the 3 W / 1 D / 0 L
+standings-points logic and the ESPN scoreboard fetch. Pattern mirrors
+NCAA Soccer (which uses the same 3/1/0 scheme) more than NHL (which
+uses a single league-wide source). Cross-conference games:
+  - `_fetch_full_season_games` filters to intra-conference games only
+    so the simulator's `_teams` dict never picks up out-of-conference
+    rows (which would get the wrong threshold bands applied). Strength
+    estimates lose ~9 cross-conf games per team out of ~34, an
+    acceptable accuracy cost vs the alternative of polluting the
+    outcome cascade.
+  - `fetch_upcoming` emits games where the HOME team is in this
+    conference. Cross-conf away games surface via the home team's
+    source — they still get importance computed (against the home
+    team's conference bands), they just don't double-emit.
+
+Note: this module does NOT touch the existing MlsSource (which remains
+the closeness-only base class for NwslSource / LigaMxSource). The
+plugin swaps `enable_mls` to register East + West here rather than
+the closeness-only MlsSource. NWSL / Liga MX keep the V1 shape until
+their own importance follow-ups land.
+
+Closeness via The Odds API is preserved (the V1 MlsSource computed
+it and we don't regress that signal): each conference source pulls
+the league-wide odds feed and attaches devigged h2h closeness to the
+games it emits. Helpers `_h2h_to_closeness` and `ODDS_BASE` are
+imported from mls.py to keep the calibration line consistent — the
+two sources MUST produce the same closeness for any given matchup as
+the legacy MlsSource would have.
+
+ESPN endpoints used:
+  - `/apis/v2/sports/soccer/usa.1/standings` — conference rosters +
+    current standings points (3 W / 1 D / 0 L). Fetched once per
+    refresh; the team→conference map is cached on the source instance.
+  - `/apis/site/v2/sports/soccer/usa.1/scoreboard?dates=YYYYMMDD` —
+    per-day schedule sweep across the Feb-Nov regular season.
+
+Known limitation — ESPN MLS future-fixtures coverage. The day-by-day
+scoreboard sweep finds the season's FINISHED games but very few
+SCHEDULED ones: ESPN's MLS scoreboard endpoint publishes only ~1-2
+weeks of future fixtures, while pro leagues like MLB / NCAA Baseball
+publish months ahead. Effect on the importance signal: with a thin
+remaining_matches list, the simulator can't propagate the season
+forward enough to differentiate end-of-season outcomes, so mid-season
+importance reads close to 0 for marginal games. Signal sharpens as
+the season approaches its end (fewer remaining games means the
+published-fixture window covers more of the rest). The structural
+code is correct; the gap is external. A future improvement could
+hit `/teams/{id}/schedule` per-team or synthesize a round-robin
+pairing matrix to backfill the remaining-fixtures list. DO NOT
+remove this comment without resolving the underlying data gap.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import requests
+
+from .base import GameRow
+from .points_based import PointsBasedSportSource
+from .mls import (
+    ODDS_BASE as _ODDS_BASE,
+    _h2h_to_closeness,
+    _team_canonical_name,
+)
+from .._util import parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.mls_standings")
+
+ESPN_SCOREBOARD_BASE = "https://site.api.espn.com/apis/site/v2/sports/soccer/usa.1"
+ESPN_STANDINGS_URL = "https://site.api.espn.com/apis/v2/sports/soccer/usa.1/standings"
+
+# MLS regular season runs late February through late October in the
+# modern era. The day-sweep loop walks Feb 1 through Nov 30 to be safe
+# either side of the bookend weekends. Each day call returns 0-7 events;
+# 300 days × ~120ms = ~36s, acceptable on a 6-hour refresh budget.
+SEASON_START_MONTH = 2
+SEASON_END_MONTH = 11
+
+# Per-team goal averages cluster around 1.4 goals/game in modern MLS
+# (slightly higher than NCAA soccer's 1.5/game prior because pro-level
+# finishing is sharper). Used as the league-average prior for any team
+# the simulator hasn't seen finished results for.
+_DEFAULT_GOALS_FOR = 1.4
+_DEFAULT_GOALS_AGAINST = 1.4
+
+
+def _http_get(url: str, timeout: float = 15.0, **params: Any) -> Optional[Any]:
+    """HTTP GET wrapper. Return type is Optional[Any] because the
+    callers hit two shapes: ESPN endpoints return dicts (standings,
+    scoreboard) while The Odds API returns a JSON list. Caller checks
+    via isinstance before iterating.
+    """
+    try:
+        r = requests.get(url, timeout=timeout, params=params or None)
+        if r.status_code >= 400:
+            logger.warning("[mls_standings] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[mls_standings] %s failed: %s", url, exc)
+        return None
+
+
+# `_team_canonical_name` is imported from mls.py — both modules need
+# the same ESPN displayName join key across /standings and /scoreboard
+# endpoints. DO NOT define a parallel canonicalizer here; divergence
+# between the two would break the cross-endpoint team lookup.
+
+
+# ESPN's season.slug value for MLS regular season. Playoff games have
+# slugs like "eastern-conference-playoffs---round-one" or "mls-cup";
+# the regular-season filter excludes them so postseason matchups don't
+# pollute the bands the threshold cascade is calibrated against.
+REGULAR_SEASON_SLUG = "regular-season"
+
+# ESPN exposes MLS conference rosters under /standings → children[].abbreviation
+# as either "East" or "West". DO NOT use `children[].name` ("Eastern
+# Conference" / "Western Conference") — match the short token to keep
+# `MlsEastSource._conference` / `MlsWestSource._conference` concise.
+CONFERENCE_ABBREVIATIONS = ("East", "West")
+
+
+def _fetch_conference_map() -> Dict[str, str]:
+    """Pull the current MLS conference assignments from ESPN's /standings
+    endpoint. Returns {team_displayName: "East" | "West"}. Empty dict
+    on any failure — the source falls back to emitting zero games for
+    that conference (no spurious importance signal).
+
+    The conference roster changes year over year (expansion teams). The
+    map is rebuilt on every refresh rather than cached, so an expansion
+    team's first game in the new season gets the right conference
+    routing without redeploy.
+    """
+    data = _http_get(ESPN_STANDINGS_URL)
+    if not isinstance(data, dict):
+        return {}
+    out: Dict[str, str] = {}
+    for child in data.get("children") or []:
+        conf_abbrev = (child.get("abbreviation") or "").strip()
+        if conf_abbrev not in CONFERENCE_ABBREVIATIONS:
+            continue
+        entries = (child.get("standings") or {}).get("entries") or []
+        for entry in entries:
+            team = entry.get("team") or {}
+            name = _team_canonical_name(team)
+            if name:
+                out[name] = conf_abbrev
+    return out
+
+
+def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert one ESPN MLS scoreboard event into the canonical
+    PointsBasedSportSource game record. Soccer-specific: a tied score
+    in a finished regulation game IS a draw (1 point each) — DO NOT
+    coin-flip it into a win the way NCAAF / NCAAM do. Same shape as
+    `ncaa_soccer._extract_game_record`.
+
+    Returns None when the event is malformed (missing competitors,
+    missing teams) or when status reads as in-progress with no
+    final score.
+    """
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = _team_canonical_name(home.get("team") or {})
+    away_team = _team_canonical_name(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    season_slug = ((event.get("season") or {}).get("slug") or "").lower()
+    return {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "season_slug": season_slug,
+        "extra": {"season_slug": season_slug},
+    }
+
+
+class MlsStandingsSourceBase(PointsBasedSportSource):
+    """Shared logic for MlsEastSource / MlsWestSource. Subclasses set
+    `_conference` ("East" | "West") and the matching
+    `league_context_code` ("MLS_EAST" | "MLS_WEST"). Everything else —
+    the standings fetch, the per-day scoreboard sweep, the 3 / 1 / 0
+    `_record_result_into_state` override — is shared here.
+    """
+
+    _count_field = "standings_points"
+    _DEFAULT_POINTS_FOR = _DEFAULT_GOALS_FOR
+    _DEFAULT_POINTS_AGAINST = _DEFAULT_GOALS_AGAINST
+
+    # Subclasses MUST set these.
+    _conference: str = ""
+
+    def __init__(
+        self,
+        odds_api_key: str = "",
+        season_year: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        self.odds_api_key = odds_api_key
+        now = datetime.now(timezone.utc)
+        # MLS season is named by calendar year (the 2025 season runs Feb-Nov
+        # 2025). Default to current calendar year; pre-February in early
+        # winter reads as the prior season (MLS Cup wraps in early Dec, so
+        # January is firmly between seasons — default to prior year so
+        # offseason refreshes still pick up the last-finished season's data).
+        self.season_year = (
+            season_year if season_year is not None
+            else (now.year if now.month >= SEASON_START_MONTH else now.year - 1)
+        )
+        self._conference_map_cache: Optional[Dict[str, str]] = None
+        self._closeness_cache: Optional[Dict[Tuple[str, str], float]] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "MLS"
+
+    @property
+    def sport_label(self) -> str:
+        # The same channel label for both conferences keeps the user's
+        # Top Matchups group cohesive. The conference identity lives in
+        # the league_context_code, not the display label.
+        return "MLS"
+
+    # ---------- conference map (shared across instances per-refresh) ----------
+
+    def _conference_map(self) -> Dict[str, str]:
+        if self._conference_map_cache is not None:
+            return self._conference_map_cache
+        self._conference_map_cache = _fetch_conference_map()
+        return self._conference_map_cache
+
+    def _own_conf_teams(self) -> Set[str]:
+        cmap = self._conference_map()
+        return {name for name, conf in cmap.items() if conf == self._conference}
+
+    # ---------- closeness (carried over from V1 MlsSource) ----------
+
+    def _fetch_closeness(self) -> Dict[Tuple[str, str], float]:
+        """Pull h2h odds for upcoming MLS matches from The Odds API and
+        compute devigged closeness in [0, 1]. Returns {(home_lc, away_lc):
+        closeness}. Empty dict on missing key or any API failure.
+
+        Reuses the MlsSource pattern verbatim (helper functions imported
+        from mls.py) so the calibration line between MlsEastSource and
+        MlsWestSource matches the legacy MlsSource closeness output.
+        """
+        if not self.odds_api_key:
+            return {}
+        if self._closeness_cache is not None:
+            return self._closeness_cache
+        data = _http_get(
+            f"{_ODDS_BASE}/sports/soccer_usa_mls/odds/",
+            regions="us,uk,eu",
+            markets="h2h",
+            apiKey=self.odds_api_key,
+            oddsFormat="decimal",
+        )
+        out: Dict[Tuple[str, str], float] = {}
+        if isinstance(data, list):
+            for ev in data:
+                home = (ev.get("home_team") or "").strip().lower()
+                away = (ev.get("away_team") or "").strip().lower()
+                if not home or not away:
+                    continue
+                books = ev.get("bookmakers") or []
+                closeness_val: Optional[float] = None
+                for bk in books:
+                    for mk in bk.get("markets", []):
+                        if mk.get("key") != "h2h":
+                            continue
+                        closeness_val = _h2h_to_closeness(
+                            mk.get("outcomes") or [], home, away,
+                        )
+                        if closeness_val is not None:
+                            break
+                    if closeness_val is not None:
+                        break
+                if closeness_val is not None:
+                    out[(home, away)] = closeness_val
+        self._closeness_cache = out
+        return out
+
+    @staticmethod
+    def _lookup_closeness(
+        closeness_map: Dict[Tuple[str, str], float],
+        home: str, away: str,
+    ) -> Optional[float]:
+        """Match canonical team names to Odds API team names. Exact
+        lower-case match first, then a substring fallback for cases
+        where ESPN includes a suffix the Odds API drops ("Atlanta
+        United FC" vs "Atlanta United"). Same shape as MlsSource's
+        legacy helper.
+        """
+        h_lc = home.lower()
+        a_lc = away.lower()
+        if (h_lc, a_lc) in closeness_map:
+            return closeness_map[(h_lc, a_lc)]
+        for (hk, ak), v in closeness_map.items():
+            if (h_lc == hk or h_lc in hk or hk in h_lc) and (
+                a_lc == ak or a_lc in ak or ak in a_lc
+            ):
+                return v
+        return None
+
+    # ---------- fetch_upcoming ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Emit upcoming games where the HOME team is in this conference.
+        Cross-conf away games surface via the home team's source so the
+        UI emit doesn't double-count. Per-day sweep mirrors ncaa_soccer
+        / ncaa_baseball patterns (ESPN's date-range syntax silently
+        caps at 25 events).
+        """
+        own_conf = self._own_conf_teams()
+        if not own_conf:
+            return []
+        closeness_map = self._fetch_closeness()
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: Set[Any] = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(
+                f"{ESPN_SCOREBOARD_BASE}/scoreboard",
+                dates=day.strftime("%Y%m%d"),
+            )
+            if not isinstance(data, dict):
+                continue
+            for event in data.get("events") or []:
+                rec = _extract_game_record(event)
+                if rec is None:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                home = rec["home"]
+                if home not in own_conf:
+                    continue
+                # Skip non-regular-season games for V1. MLS Cup playoff
+                # bracket is filed under issue #30 part B; until it lands,
+                # postseason MLS games should not be emitted here — they
+                # would get importance computed against regular-season
+                # bands, inflating their score.
+                if rec.get("season_slug") != REGULAR_SEASON_SLUG:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=home,
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    closeness=self._lookup_closeness(
+                        closeness_map, home, rec["away"],
+                    ),
+                    extra={
+                        "espn_event_id": eid,
+                        "fd_competition_code": self.league_context_code,
+                        "season_slug": rec.get("season_slug"),
+                    },
+                ))
+        return out
+
+    # ---------- _fetch_full_season_games (importance side) ----------
+
+    def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
+        """Day-by-day sweep across Feb 1 - Nov 30 of `season_year`.
+        Filters to INTRA-CONFERENCE regular-season games only — the
+        simulator's `_teams` dict then never picks up out-of-conference
+        teams (which would get the wrong threshold bands applied in
+        terminal_outcomes).
+
+        Cross-conf games are lost from strength estimation here (~9 per
+        team per season vs ~34 total games per team). The accuracy hit
+        on Poisson lambda estimates is small; the alternative of
+        pollution of terminal_outcomes is structurally wrong.
+        """
+        own_conf = self._own_conf_teams()
+        if not own_conf:
+            return []
+        seen: Dict[Any, Dict[str, Any]] = {}
+        season_start = datetime(
+            self.season_year, SEASON_START_MONTH, 1, tzinfo=timezone.utc
+        ).date()
+        # End-of-November: build December 1, subtract one day.
+        season_end = (datetime(
+            self.season_year, SEASON_END_MONTH + 1, 1, tzinfo=timezone.utc
+        ).date()) - timedelta(days=1)
+        now = datetime.now(timezone.utc).date()
+        end = min(now + timedelta(days=7), season_end)
+        if end < season_start:
+            return []
+        day = season_start
+        while day <= end:
+            data = _http_get(
+                f"{ESPN_SCOREBOARD_BASE}/scoreboard",
+                dates=day.strftime("%Y%m%d"),
+            )
+            if isinstance(data, dict):
+                for event in data.get("events") or []:
+                    rec = _extract_game_record(event)
+                    if rec is None or rec["id"] is None:
+                        continue
+                    if rec["id"] in seen:
+                        continue
+                    # Intra-conference regular season only.
+                    if rec.get("season_slug") != REGULAR_SEASON_SLUG:
+                        continue
+                    if rec["home"] not in own_conf:
+                        continue
+                    if rec["away"] not in own_conf:
+                        continue
+                    seen[rec["id"]] = rec
+            day += timedelta(days=1)
+        return list(seen.values())
+
+    # ---------- sample_result (allows draws — soccer rules) ----------
+
+    def sample_result(self, state, match, strengths, rng):
+        """Sample Poisson goals per side. Soccer regulation results
+        include draws — DO NOT coin-flip a tied score into a win the
+        way the base PointsBasedSportSource does for NCAAF / NCAAM /
+        NHL. MLS regular-season games CAN end in regulation draws
+        (MLS dropped the shootout tiebreaker in 2000). A draw banks 1
+        standings point for each side.
+        """
+        del state  # interface-required, not used at this level
+        from .._util import poisson_sample
+        from .base import MatchResult
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.05, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.05, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        return MatchResult(
+            home_goals=poisson_sample(lam_home, rng),
+            away_goals=poisson_sample(lam_away, rng),
+        )
+
+    # ---------- 3 / 1 / 0 standings-points record ----------
+
+    def _record_result_into_state(
+        self,
+        teams: Dict[str, Dict[str, int]],
+        home: str, away: str,
+        home_pts: int, away_pts: int,
+        result_extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """MLS standings scheme mirrors college soccer's 3 / 1 / 0:
+        win = 3 standings points, draw = 1 each, loss = 0. Subclass
+        of `ncaa_soccer._record_result_into_state` structurally —
+        same pattern, no shared inheritance because the rest of the
+        ESPN endpoint shape differs.
+        """
+        del result_extra  # not used — MLS regular-season ties bank 1 pt each
+        h = teams[home]
+        a = teams[away]
+        h.setdefault("draws", 0)
+        a.setdefault("draws", 0)
+        h.setdefault("standings_points", 0)
+        a.setdefault("standings_points", 0)
+        h["pf"] += home_pts
+        h["pa"] += away_pts
+        a["pf"] += away_pts
+        a["pa"] += home_pts
+        h["games_played"] += 1
+        a["games_played"] += 1
+        if home_pts > away_pts:
+            h["wins"] += 1
+            a["losses"] += 1
+            h["standings_points"] += 3
+        elif away_pts > home_pts:
+            a["wins"] += 1
+            h["losses"] += 1
+            a["standings_points"] += 3
+        else:
+            # Draw: 1 standings point each, no W/L update.
+            h["draws"] += 1
+            a["draws"] += 1
+            h["standings_points"] += 1
+            a["standings_points"] += 1
+
+
+class MlsEastSource(MlsStandingsSourceBase):
+    """Eastern Conference standings importance. Threshold bands from
+    LEAGUE_CONTEXTS['MLS_EAST']: 30 / 45 / 55 / 70 standings points
+    correspond to playoff bubble / playoff secured / top-4 home field /
+    Supporters' Shield contender. Conference identity lives in
+    `_conference = "East"`; the league_context_code routes the threshold
+    cascade.
+    """
+    _conference = "East"
+    league_context_code = "MLS_EAST"
+
+
+class MlsWestSource(MlsStandingsSourceBase):
+    """Western Conference standings importance. Same threshold bands as
+    East (the conference cutoff lines have been within a couple of
+    points of each other for the modern 14-9 playoff format)."""
+    _conference = "West"
+    league_context_code = "MLS_WEST"

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4061,10 +4061,13 @@ class TestMlsSourceIdentity:
         assert src.sport_prefix == "MLS"
         assert src.sport_label == "MLS"
 
-    def test_does_not_support_importance_in_v1(self):
-        """V1 explicitly omits the importance simulator path. The
-        flag stays False; future MLS importance work (filed as a
-        follow-up) will flip this on."""
+    def test_does_not_support_importance(self):
+        """MlsSource is the closeness-only base class for NwslSource
+        and LigaMxSource. MLS itself is now handled by MlsEastSource +
+        MlsWestSource (issue #30 part A), which DO support importance.
+        MlsSource the class stays importance-free so NWSL / Liga MX
+        keep the V1 minimal shape until their own follow-ups land.
+        """
         assert self._make().supports_importance is False
 
 
@@ -5147,6 +5150,487 @@ class TestNflPlayoffSource:
         depths = [KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds]
         for i in range(len(depths) - 1):
             assert depths[i] < depths[i + 1]
+
+
+# =====================================================================
+# Issue #30 part A: MLS conference-standings importance
+# =====================================================================
+
+class TestMlsStandingsIdentity:
+    """MlsEastSource / MlsWestSource: per-conference standings importance.
+    Pin identity (sport prefix, supports_importance, count field) before
+    exercising conference-routing logic."""
+
+    @staticmethod
+    def _east():
+        from dispatcharr_ranked_matchups.sources.mls_standings import MlsEastSource
+        return MlsEastSource()
+
+    @staticmethod
+    def _west():
+        from dispatcharr_ranked_matchups.sources.mls_standings import MlsWestSource
+        return MlsWestSource()
+
+    def test_east_routes_to_mls_east_context(self):
+        e = self._east()
+        assert e.league_context_code == "MLS_EAST"
+        assert e._conference == "East"
+
+    def test_west_routes_to_mls_west_context(self):
+        w = self._west()
+        assert w.league_context_code == "MLS_WEST"
+        assert w._conference == "West"
+
+    def test_sport_prefix_is_shared(self):
+        # Top Matchups group surfaces all MLS games under a single MLS
+        # prefix; conference identity is internal routing only.
+        assert self._east().sport_prefix == "MLS"
+        assert self._west().sport_prefix == "MLS"
+        assert self._east().sport_label == self._west().sport_label
+
+    def test_count_field_is_standings_points(self):
+        # 3 W / 1 D / 0 L means raw wins understate draw-heavy teams.
+        # Threshold cascade must read standings_points, not wins.
+        assert self._east()._count_field == "standings_points"
+        assert self._west()._count_field == "standings_points"
+
+    def test_supports_importance(self):
+        assert self._east().supports_importance is True
+        assert self._west().supports_importance is True
+
+
+class TestMlsStandingsContexts:
+    """Pin LEAGUE_CONTEXTS entries for MLS_EAST / MLS_WEST so a threshold
+    tweak doesn't silently drift away from the issue's spec
+    (~30 bubble / 45 secured / 55 top-4 / 70 Shield)."""
+
+    def test_mls_east_and_west_exist(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert "MLS_EAST" in LEAGUE_CONTEXTS
+        assert "MLS_WEST" in LEAGUE_CONTEXTS
+
+    def test_both_use_points_count_format(self):
+        # 3/1/0 scheme means win-count alone is misleading; format must
+        # be points_count to threshold against standings_points.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["MLS_EAST"].format == "points_count"
+        assert LEAGUE_CONTEXTS["MLS_WEST"].format == "points_count"
+
+    def test_threshold_cutoffs_match_spec(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        cutoffs_east = [c for c, _, _ in LEAGUE_CONTEXTS["MLS_EAST"].thresholds]
+        cutoffs_west = [c for c, _, _ in LEAGUE_CONTEXTS["MLS_WEST"].thresholds]
+        assert cutoffs_east == [30, 45, 55, 70]
+        assert cutoffs_west == [30, 45, 55, 70]
+
+    def test_threshold_weights_are_monotonic_increasing(self):
+        # Out-of-order weights would let a marginal team outscore an
+        # elite one. Cross-sport consequence calibration requires the
+        # deeper-outcome weight to dominate.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        for code in ("MLS_EAST", "MLS_WEST"):
+            weights = [w for _, _, w in LEAGUE_CONTEXTS[code].thresholds]
+            for i in range(len(weights) - 1):
+                assert weights[i] < weights[i + 1], (
+                    f"{code} weights {weights} not monotonic at {i}"
+                )
+
+    def test_matchdays_total_matches_modern_season(self):
+        # MLS modern regular season is 34 games per team.
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["MLS_EAST"].matchdays_total == 34
+        assert LEAGUE_CONTEXTS["MLS_WEST"].matchdays_total == 34
+
+
+class TestMlsStandingsRecordResult:
+    """The 3 / 1 / 0 standings-points credit. Mirrors ncaa_soccer's
+    record path because both apply the same soccer scheme — pin
+    independently so regression in one doesn't drag the other."""
+
+    @staticmethod
+    def _make():
+        from dispatcharr_ranked_matchups.sources.mls_standings import MlsEastSource
+        return MlsEastSource()
+
+    @staticmethod
+    def _row():
+        return {"wins": 0, "losses": 0, "pf": 0, "pa": 0, "games_played": 0}
+
+    def test_win_credits_three_to_winner(self):
+        src = self._make()
+        teams = {"Atlanta United FC": self._row(),
+                 "Inter Miami CF": self._row()}
+        src._record_result_into_state(
+            teams, "Atlanta United FC", "Inter Miami CF", 2, 1,
+        )
+        assert teams["Atlanta United FC"]["standings_points"] == 3
+        assert teams["Inter Miami CF"]["standings_points"] == 0
+        assert teams["Atlanta United FC"]["wins"] == 1
+        assert teams["Inter Miami CF"]["losses"] == 1
+
+    def test_draw_credits_one_each(self):
+        src = self._make()
+        teams = {"Charlotte FC": self._row(),
+                 "Orlando City SC": self._row()}
+        src._record_result_into_state(
+            teams, "Charlotte FC", "Orlando City SC", 1, 1,
+        )
+        # Pin both invariants: 1 pt each AND no W/L update. Regression
+        # cost would be a tied game showing as a loss in the cascade.
+        assert teams["Charlotte FC"]["standings_points"] == 1
+        assert teams["Orlando City SC"]["standings_points"] == 1
+        assert teams["Charlotte FC"]["wins"] == 0
+        assert teams["Charlotte FC"]["losses"] == 0
+        assert teams["Charlotte FC"]["draws"] == 1
+        assert teams["Orlando City SC"]["draws"] == 1
+
+    def test_loss_credits_zero(self):
+        src = self._make()
+        teams = {"Toronto FC": self._row(), "FC Cincinnati": self._row()}
+        src._record_result_into_state(
+            teams, "Toronto FC", "FC Cincinnati", 0, 2,
+        )
+        assert teams["Toronto FC"]["standings_points"] == 0
+        assert teams["FC Cincinnati"]["standings_points"] == 3
+
+
+class TestMlsStandingsSampleResultAllowsDraws:
+    """MLS regular-season games CAN end in regulation draws (the league
+    dropped the shootout tiebreaker in 2000). Confirm sample_result
+    does NOT coin-flip ties into wins the way base PointsBasedSportSource
+    does for NCAAF / NCAAM."""
+
+    def test_sample_result_can_produce_ties(self):
+        import random
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        from dispatcharr_ranked_matchups.sources.mls_standings import MlsEastSource
+        src = MlsEastSource()
+        strengths = {
+            "Atlanta United FC": {"pf_per_game": 1.0, "pa_per_game": 1.0},
+            "Inter Miami CF":    {"pf_per_game": 1.0, "pa_per_game": 1.0},
+        }
+        gr = GameRow(
+            sport_prefix="MLS", sport_label="MLS",
+            home="Atlanta United FC", away="Inter Miami CF",
+            rank_home=None, rank_away=None,
+            start_time=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        )
+        rng = random.Random(42)
+        # With λ≈1 and 200 samples, Poisson generates ties at ~30% rate.
+        # At least one tie distinguishes soccer sample_result from the
+        # NCAAF/NCAAM force-a-winner shape.
+        ties = 0
+        for _ in range(200):
+            res = src.sample_result({}, gr, strengths, rng)
+            if res.home_goals == res.away_goals:
+                ties += 1
+        assert ties > 0, (
+            "MLS sample_result must allow regulation draws; "
+            "force-a-winner shape would be a regression to NCAAF behavior"
+        )
+
+
+class TestMlsStandingsConferenceFilter:
+    """Conference-aware filter on _fetch_full_season_games: only intra-
+    conference games are returned so the simulator's `_teams` dict stays
+    single-conference (terminal_outcomes assumes uniform thresholds
+    across all tracked teams)."""
+
+    def test_filters_to_own_conference_intra_games(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources.mls_standings import (
+            MlsEastSource,
+        )
+        from dispatcharr_ranked_matchups.sources import mls_standings as mod
+        monkeypatch.setattr(
+            mod, "_fetch_conference_map",
+            lambda: {"A": "East", "B": "East", "C": "West", "D": "West"},
+        )
+        calls = {"n": 0}
+        def fake_get(url, *_, **__):
+            calls["n"] += 1
+            if calls["n"] != 1:
+                return {"events": []}
+            return {"events": [
+                # (1) A vs B — intra-East, should appear
+                {"id": 1, "date": "2025-04-01T19:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": True, "state": "post"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "A"}, "score": "2"},
+                         {"homeAway": "away", "team": {"displayName": "B"}, "score": "1"},
+                     ],
+                 }]},
+                # (2) A vs C — cross-conf, should be filtered out
+                {"id": 2, "date": "2025-04-01T19:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": True, "state": "post"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "A"}, "score": "1"},
+                         {"homeAway": "away", "team": {"displayName": "C"}, "score": "1"},
+                     ],
+                 }]},
+                # (3) C vs D — intra-West, should be filtered out for East
+                {"id": 3, "date": "2025-04-01T19:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": True, "state": "post"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "C"}, "score": "0"},
+                         {"homeAway": "away", "team": {"displayName": "D"}, "score": "2"},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        monkeypatch.setattr(mod, "SEASON_START_MONTH", 4)
+        monkeypatch.setattr(mod, "SEASON_END_MONTH", 4)
+        src = MlsEastSource(season_year=2025)
+        games = src._fetch_full_season_games()
+        ids = {g["id"] for g in games}
+        # Only the A-vs-B intra-East game survives.
+        assert ids == {1}, f"expected only intra-East game, got {ids}"
+
+    def test_fetch_upcoming_emits_home_team_in_conference(self, monkeypatch):
+        """fetch_upcoming emits a game only when HOME team is in own
+        conference; cross-conf games surface via the home team's source.
+        Pin this so registered East+West don't double-emit cross-conf
+        games."""
+        from dispatcharr_ranked_matchups.sources.mls_standings import (
+            MlsWestSource,
+        )
+        from dispatcharr_ranked_matchups.sources import mls_standings as mod
+        monkeypatch.setattr(
+            mod, "_fetch_conference_map",
+            lambda: {"East1": "East", "West1": "West"},
+        )
+        def fake_get(url, *_, **__):
+            return {"events": [
+                {"id": "g1", "date": "2030-04-01T19:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "East1"}},
+                         {"homeAway": "away", "team": {"displayName": "West1"}},
+                     ],
+                 }]},
+                {"id": "g2", "date": "2030-04-01T19:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "West1"}},
+                         {"homeAway": "away", "team": {"displayName": "East1"}},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        src = MlsWestSource()
+        games = src.fetch_upcoming(days_ahead=0)
+        ids = {(g.extra or {}).get("espn_event_id") for g in games}
+        assert ids == {"g2"}, (
+            f"West source must emit only home-in-West games, got {ids}"
+        )
+
+    def test_late_season_bubble_match_produces_nonzero_importance(self):
+        """Issue #30 acceptance: a bubble-line matchup with enough
+        remaining matches in the season produces nonzero playoff_bubble
+        leverage. Uses a stub state to bypass ESPN's thin future-
+        fixtures publishing (see module docstring's "Known limitation"
+        — live mid-season importance reads near 0 because ESPN MLS
+        publishes only ~1-2 weeks of future games, so the simulator
+        can't propagate; this test pins the simulator pipeline
+        independent of the data-availability quirk).
+        """
+        import random
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_standings import (
+            MlsEastSource,
+        )
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        from dispatcharr_ranked_matchups.scoring import (
+            LEAGUE_CONTEXTS, compute_match_importance,
+        )
+
+        class _StubEast(MlsEastSource):
+            def initial_state(self):
+                # Nashville at 29 pts, one game from the 30 pt bubble.
+                # Inter Miami at 26, also within reach. A single match
+                # result genuinely moves Nashville above or below the
+                # threshold — leverage should be nonzero.
+                return {
+                    "_applied": frozenset(),
+                    "_teams": {
+                        "Nashville SC": {
+                            "wins": 9, "losses": 4, "pf": 18, "pa": 12,
+                            "games_played": 15, "standings_points": 29,
+                            "draws": 2,
+                        },
+                        "Inter Miami CF": {
+                            "wins": 8, "losses": 5, "pf": 16, "pa": 14,
+                            "games_played": 15, "standings_points": 26,
+                            "draws": 2,
+                        },
+                        "Atlanta United FC": {
+                            "wins": 4, "losses": 8, "pf": 10, "pa": 16,
+                            "games_played": 15, "standings_points": 15,
+                            "draws": 3,
+                        },
+                        "CF Montréal": {
+                            "wins": 5, "losses": 7, "pf": 11, "pa": 14,
+                            "games_played": 15, "standings_points": 18,
+                            "draws": 3,
+                        },
+                        "Charlotte FC": {
+                            "wins": 6, "losses": 6, "pf": 13, "pa": 13,
+                            "games_played": 15, "standings_points": 21,
+                            "draws": 3,
+                        },
+                    },
+                }
+
+            def remaining_matches(self, state):
+                applied = state.get("_applied", frozenset())
+                base = [
+                    GameRow("MLS", "MLS", "Inter Miami CF", "CF Montréal",
+                            None, None, datetime(2026, 10, 1, tzinfo=timezone.utc),
+                            extra={"game_id": "r2"}),
+                    GameRow("MLS", "MLS", "Atlanta United FC", "Nashville SC",
+                            None, None, datetime(2026, 10, 8, tzinfo=timezone.utc),
+                            extra={"game_id": "r3"}),
+                    GameRow("MLS", "MLS", "Charlotte FC", "Inter Miami CF",
+                            None, None, datetime(2026, 10, 15, tzinfo=timezone.utc),
+                            extra={"game_id": "r4"}),
+                    GameRow("MLS", "MLS", "Nashville SC", "CF Montréal",
+                            None, None, datetime(2026, 10, 22, tzinfo=timezone.utc),
+                            extra={"game_id": "r5"}),
+                ]
+                return [m for m in base if m.extra["game_id"] not in applied]
+
+            def estimate_strengths(self):
+                return {
+                    "Nashville SC":      {"pf_per_game": 1.2, "pa_per_game": 0.8},
+                    "Inter Miami CF":    {"pf_per_game": 1.1, "pa_per_game": 0.9},
+                    "Atlanta United FC": {"pf_per_game": 0.7, "pa_per_game": 1.1},
+                    "CF Montréal":       {"pf_per_game": 0.7, "pa_per_game": 0.9},
+                    "Charlotte FC":      {"pf_per_game": 0.9, "pa_per_game": 0.9},
+                }
+
+        ctx = LEAGUE_CONTEXTS["MLS_EAST"]
+        src = _StubEast()
+        target = GameRow(
+            "MLS", "MLS", "Nashville SC", "Inter Miami CF",
+            None, None, datetime(2026, 9, 30, tzinfo=timezone.utc),
+            extra={"game_id": "target"},
+        )
+        points, _, hits = compute_match_importance(
+            src, target, ctx, n_sims=300, rng=random.Random(42),
+        )
+        # Bubble-line match must register nonzero leverage. Seed 42 with
+        # n_sims=300 gives a reproducible ~0.5-1.0 point reading on
+        # this scenario; pinning >= 0.05 keeps the assertion resilient
+        # to Poisson sampling noise across Python implementations.
+        assert points >= 0.05, f"expected nonzero bubble leverage, got {points}"
+        assert "playoff_bubble" in hits, (
+            f"expected playoff_bubble in thresholds hit, got {hits}"
+        )
+
+    def test_conference_map_parses_espn_standings_shape(self, monkeypatch):
+        """Pin the parser against ESPN's actual /standings response
+        shape so a schema drift (e.g., abbreviation renamed,
+        children[] nesting changed) fails loudly here instead of
+        silently returning an empty conference map (which would
+        cascade into 0 emitted games + 0 importance with no error).
+        """
+        from dispatcharr_ranked_matchups.sources import mls_standings as mod
+        # Realistic ESPN shape: top-level "children" list with two
+        # entries, each carrying a standings.entries[].team.displayName.
+        fixture = {
+            "children": [
+                {
+                    "abbreviation": "East",
+                    "name": "Eastern Conference",
+                    "standings": {"entries": [
+                        {"team": {"displayName": "Atlanta United FC"}},
+                        {"team": {"displayName": "Inter Miami CF"}},
+                    ]},
+                },
+                {
+                    "abbreviation": "West",
+                    "name": "Western Conference",
+                    "standings": {"entries": [
+                        {"team": {"displayName": "LA Galaxy"}},
+                        {"team": {"displayName": "LAFC"}},
+                    ]},
+                },
+                # A third child with a non-East/West abbreviation should
+                # be silently ignored (defensive against ESPN adding new
+                # buckets like an exhibition group).
+                {
+                    "abbreviation": "Other",
+                    "name": "Exhibition",
+                    "standings": {"entries": [
+                        {"team": {"displayName": "Bogus Team"}},
+                    ]},
+                },
+            ],
+        }
+        monkeypatch.setattr(mod, "_http_get", lambda *_a, **_k: fixture)
+        cmap = mod._fetch_conference_map()
+        assert cmap == {
+            "Atlanta United FC": "East",
+            "Inter Miami CF":    "East",
+            "LA Galaxy":         "West",
+            "LAFC":              "West",
+        }, f"unexpected conference map: {cmap}"
+
+    def test_conference_map_returns_empty_on_endpoint_failure(self, monkeypatch):
+        """When _http_get returns None (ESPN down / network error /
+        4xx), the conference map MUST be empty rather than partial.
+        An empty map cascades to 0 emitted games — graceful degradation
+        rather than misclassified teams getting the wrong conference's
+        threshold bands.
+        """
+        from dispatcharr_ranked_matchups.sources import mls_standings as mod
+        monkeypatch.setattr(mod, "_http_get", lambda *_a, **_k: None)
+        assert mod._fetch_conference_map() == {}
+
+    def test_filters_out_non_regular_season(self, monkeypatch):
+        """Playoff games (season.slug != 'regular-season') must be filtered
+        out so the Cup bracket (sibling #30 part B) doesn't pollute
+        regular-season threshold computation."""
+        from dispatcharr_ranked_matchups.sources.mls_standings import (
+            MlsEastSource,
+        )
+        from dispatcharr_ranked_matchups.sources import mls_standings as mod
+        monkeypatch.setattr(
+            mod, "_fetch_conference_map",
+            lambda: {"A": "East", "B": "East"},
+        )
+        calls = {"n": 0}
+        def fake_get(url, *_, **__):
+            calls["n"] += 1
+            if calls["n"] != 1:
+                return {"events": []}
+            return {"events": [
+                {"id": 100, "date": "2025-04-01T19:00:00Z",
+                 "season": {"slug": "eastern-conference-playoffs---round-one"},
+                 "competitions": [{
+                     "status": {"type": {"completed": True, "state": "post"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "A"}, "score": "2"},
+                         {"homeAway": "away", "team": {"displayName": "B"}, "score": "1"},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        monkeypatch.setattr(mod, "SEASON_START_MONTH", 4)
+        monkeypatch.setattr(mod, "SEASON_END_MONTH", 4)
+        src = MlsEastSource(season_year=2025)
+        games = src._fetch_full_season_games()
+        assert games == [], "playoff-slug games must be filtered from season fetch"
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

- Adds `MlsEastSource` / `MlsWestSource` as `PointsBasedSportSource` subclasses with 3 W / 1 D / 0 L standings-points scheme and per-conference threshold bands (30 / 45 / 55 / 70 points).
- Adds `LEAGUE_CONTEXTS["MLS_EAST"]` and `["MLS_WEST"]` with `format="points_count"` matching the cross-sport calibration shape.
- Plugin's `enable_mls` toggle now registers East + West instead of the closeness-only `MlsSource`. NWSL / Liga MX (which subclass `MlsSource`) are unaffected.
- Closeness via The Odds API is preserved: `MlsStandingsSourceBase` reuses `_h2h_to_closeness` / `ODDS_BASE` / `_team_canonical_name` from `mls.py`.

## Scope nuances

Per-conference threshold bands required separate `LEAGUE_CONTEXTS` entries because MLS playoff seeding is per-conference (top 9 from each), not aggregate league points. A 60-pt team in the Eastern conference can be playoff-bubble while a 55-pt team in the Western conference is comfortably in — a single league-wide cutoff misclassifies both.

`_fetch_full_season_games` filters to intra-conference games only so the simulator's `_teams` dict never picks up out-of-conference rows (which would get the wrong threshold bands applied in `terminal_outcomes`). Strength estimates lose ~9 cross-conf games per team out of ~34, an acceptable accuracy cost vs polluting the outcome cascade.

`fetch_upcoming` emits a game only when the HOME team is in own conference, so the simultaneously-registered East and West sources don't double-emit cross-conf games.

## Known live-data limitation (filed as #65)

ESPN's MLS scoreboard endpoint publishes only ~1-2 weeks of future fixtures, so live mid-season `remaining_matches` is thin and importance reads near 0 for marginal games. Probed against the real endpoint: MLB / NCAA Baseball expose months of future fixtures, MLS does not. The structural code is correct; the gap is external. Backfill via `/teams/{id}/nextEvent` or round-robin pairing matrix is filed as #65.

Synthetic late-season acceptance test pins the simulator pipeline: with enough remaining matches, a bubble-line matchup (Nashville SC at 29 pts vs Inter Miami CF at 26 pts, 4 games left) produces 0.866 importance points with leverage on `playoff_bubble` for both teams.

## Filed during /sr-dev-review

- #65: backfill remaining-fixtures gap (the live-data ESPN quirk above)
- #66: DRY-up shared ESPN scoreboard event parser (mls_standings / ncaa_soccer / ncaa_baseball all duplicate `_extract_game_record`)

## Test plan

- [x] `pytest tests/` — 900 pass (was 880 on `main`; +20 new tests covering identity, contexts, record-result, sample-result-allows-draws, conference filter, fetch_upcoming filter, non-regular-season filter, late-season nonzero-leverage acceptance, conference-map parser, conference-map endpoint failure)
- [x] Plugin reloads cleanly in the running Dispatcharr container (`force_reload=True`, no import errors)
- [x] Live `_fetch_conference_map()` returns 15 East + 15 West teams as expected
- [x] Live `_fetch_full_season_games` for East produces intra-conf 2026 games, correct standings_points totals (Nashville SC 26 pts = 8W*3 + 2D*1, matching ESPN /standings)
- [x] Synthetic late-season importance test confirms simulator pipeline produces nonzero `playoff_bubble` leverage when given sufficient `remaining_matches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)