### PR TITLE
Closes #24: NCAA Men's + Women's College Cup brackets

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -233,16 +233,16 @@
     {
       "id": "enable_ncaa_mens_soccer",
       "type": "boolean",
-      "label": "NCAA Men's Soccer (D1)",
+      "label": "NCAA Men's Soccer (D1 + College Cup)",
       "default": false,
-      "help_text": "D1 men's soccer regular season. ESPN unofficial API + United Soccer Coaches Top 25 poll. Standings points (3 W / 1 D / 0 L): 25+ tournament bubble, 35+ at-large lock, 45+ top regional, 50+ national seed. College Cup bracket not yet modeled. No API key required."
+      "help_text": "D1 men's soccer regular season + College Cup tournament bracket. ESPN unofficial API + United Soccer Coaches Top 25 poll. Regular-season standings points (3 W / 1 D / 0 L): 25+ tournament bubble, 35+ at-large lock, 45+ top regional, 50+ national seed. Postseason: single-game elim (R1 -> R2 -> Sweet 16 -> Elite 8 -> College Cup Semis -> Final -> Champion). 48-team field with 16 byes for top seeds. No API key required."
     },
     {
       "id": "enable_ncaa_womens_soccer",
       "type": "boolean",
-      "label": "NCAA Women's Soccer (D1)",
+      "label": "NCAA Women's Soccer (D1 + College Cup)",
       "default": false,
-      "help_text": "D1 women's soccer regular season. ESPN unofficial API + United Soccer Coaches Top 25 poll. Standings points (3 W / 1 D / 0 L): 25+ tournament bubble, 35+ at-large lock, 45+ top regional, 50+ national seed. College Cup bracket not yet modeled. No API key required."
+      "help_text": "D1 women's soccer regular season + College Cup tournament bracket. ESPN unofficial API + United Soccer Coaches Top 25 poll. Regular-season standings points (3 W / 1 D / 0 L): 25+ tournament bubble, 35+ at-large lock, 45+ top regional, 50+ national seed. Postseason: single-game elim across 6 rounds (full 64-team field). No API key required."
     },
     {
       "id": "_section_keys",

--- a/plugin.py
+++ b/plugin.py
@@ -467,7 +467,7 @@ def _build_sources(settings: Dict[str, Any]):
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
         NcaaBaseballRegularSource, NcaaBaseballPlayoffSource, NcaaBaseballPlayoffBracketSource,
         NcaaSoftballRegularSource, NcaaSoftballPlayoffSource, NcaaSoftballPlayoffBracketSource,
-        NcaaSoccerSource,
+        NcaaSoccerSource, NcaaSoccerCupSource,
         NcaafSource, NcaamSource,
         NflPlayoffSource, NflRegularSource,
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
@@ -756,10 +756,35 @@ def _build_sources(settings: Dict[str, Any]):
     # semantics for both, only the ESPN URL slug differs. Standings
     # points (3 W / 1 D / 0 L) drive the importance signal because
     # draws are common in college soccer.
+    #
+    # Issue #24: NcaaSoccerCupSource (College Cup bracket) pairs with
+    # the regular-season source like NHL/MLB/NBA/WNBA — playoff
+    # source borrows regular-season strength estimates via
+    # `set_regular_season_strengths`. Without the seed, College Cup
+    # samples fall back to the 1.5/1.5 league-average prior; with it,
+    # the 20-game regular season informs scoring rates for each team.
     if settings.get("enable_ncaa_mens_soccer", False):
-        sources.append(NcaaSoccerSource(gender="m"))
+        ncaa_msoc_reg = NcaaSoccerSource(gender="m")
+        sources.append(ncaa_msoc_reg)
+        ncaa_msoc_cup = NcaaSoccerCupSource(gender="m")
+        try:
+            ncaa_msoc_cup.set_regular_season_strengths(
+                ncaa_msoc_reg.estimate_strengths(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ncaa_mens_soccer] could not seed cup strengths: %s", exc)
+        sources.append(ncaa_msoc_cup)
     if settings.get("enable_ncaa_womens_soccer", False):
-        sources.append(NcaaSoccerSource(gender="w"))
+        ncaa_wsoc_reg = NcaaSoccerSource(gender="w")
+        sources.append(ncaa_wsoc_reg)
+        ncaa_wsoc_cup = NcaaSoccerCupSource(gender="w")
+        try:
+            ncaa_wsoc_cup.set_regular_season_strengths(
+                ncaa_wsoc_reg.estimate_strengths(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ncaa_womens_soccer] could not seed cup strengths: %s", exc)
+        sources.append(ncaa_wsoc_cup)
     return sources
 
 

--- a/scoring.py
+++ b/scoring.py
@@ -490,9 +490,8 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # and is well above the tournament bubble. Bands tuned against the
     # United Soccer Coaches Top 25 historical NCAA Tournament cutoffs:
     # ~25 points is the bubble; 45+ puts a team in top-regional / seed
-    # contention. Postseason College Cup bracket is not modeled in V1
-    # (single-elimination — filed as follow-up; reuses the existing
-    # KnockoutSoccerSource machinery once API bracket data is parsed).
+    # contention. Postseason College Cup bracket lives at
+    # `NCAA_MSOC_CUP` / `NCAA_WSOC_CUP` further down (issue #24).
     "NCAA_MSOC": LeagueContext(
         code="NCAA_MSOC", matchdays_total=20, format="points_count",
         thresholds=[
@@ -512,6 +511,46 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (50, "national_seed",     4.0),
         ],
         boundary_summary="25+ pts → bubble · 35+ → at-large lock · 45+ → top regional · 50+ → national seed (Women's)",
+    ),
+    # Issue #24: NCAA Men's + Women's College Cup brackets. Six rounds
+    # of single-game elimination (R64 → R32 → S16 → E8 → F4 → NCG)
+    # reusing the same stage labels as NCAA Women's March Madness —
+    # the depth ordering in KNOCKOUT_ROUND_DEPTH already supports them
+    # and the bracket-cascade behaves identically for any single-game
+    # elim shape. Field-size asymmetry handled at the source level
+    # (M's 48-team with 16 byes, W's full 64-team).
+    #
+    # Weights ramp aggressively toward the National Championship Game
+    # because postseason is when these channels get real broadcast
+    # pickup. The NCG is the single highest-viewership D1 soccer game
+    # by an order of magnitude; the cup_winner band concentrates that
+    # consequence. Entry round (R64) is NOT in the threshold list —
+    # making the tournament is the bar, advancing past R64 is what
+    # counts. Same pattern as NCAA Women's Basketball March Madness
+    # context which also omits R64 from its thresholds.
+    "NCAA_MSOC_CUP": LeagueContext(
+        code="NCAA_MSOC_CUP", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("R32",        "round_of_32",          1.0),
+            ("S16",        "sweet_16",             2.0),
+            ("E8",         "elite_8",              3.5),
+            ("F4",         "college_cup_semis",    5.0),
+            ("NCG",        "college_cup_final",    7.0),
+            ("NCG_WINNER", "cup_winner",          10.0),
+        ],
+        boundary_summary="R1 → R2 → Sweet 16 → Elite 8 → College Cup Semis → Final → Champion (Men's)",
+    ),
+    "NCAA_WSOC_CUP": LeagueContext(
+        code="NCAA_WSOC_CUP", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("R32",        "round_of_32",          1.0),
+            ("S16",        "sweet_16",             2.0),
+            ("E8",         "elite_8",              3.5),
+            ("F4",         "college_cup_semis",    5.0),
+            ("NCG",        "college_cup_final",    7.0),
+            ("NCG_WINNER", "cup_winner",          10.0),
+        ],
+        boundary_summary="R1 → R2 → Sweet 16 → Elite 8 → College Cup Semis → Final → Champion (Women's)",
     ),
     # NCAA football and men's basketball. Format is
     # "win_count" — threshold cutoffs are MINIMUM win counts rather than

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -27,6 +27,7 @@ from .ncaa_softball import (
     NcaaSoftballRegularSource,
 )
 from .ncaa_soccer import NcaaSoccerSource
+from .ncaa_soccer_cup import NcaaSoccerCupSource
 from .ncaaf import NcaafSource
 from .ncaam import NcaamSource
 from .nhl import NhlPlayoffSource, NhlRegularSource
@@ -49,7 +50,7 @@ __all__ = [
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",
     "NcaaBaseballRegularSource", "NcaaBaseballPlayoffSource", "NcaaBaseballPlayoffBracketSource",
     "NcaaSoftballRegularSource", "NcaaSoftballPlayoffSource", "NcaaSoftballPlayoffBracketSource",
-    "NcaaSoccerSource",
+    "NcaaSoccerSource", "NcaaSoccerCupSource",
     "NcaafSource", "NcaamSource",
     "NhlRegularSource", "NhlPlayoffSource",
     "NflRegularSource", "NflPlayoffSource",

--- a/sources/ncaa_soccer_cup.py
+++ b/sources/ncaa_soccer_cup.py
@@ -1,0 +1,494 @@
+"""NCAA College Cup source — single-game-elim bracket via ESPN.
+
+Issue #24: NCAA Men's + Women's D1 Soccer Tournament. Both genders use
+the same structural shape (single-leg elimination across multiple
+rounds); only ESPN's URL slug, the LEAGUE_CONTEXTS code, and the
+gender-specific round labels differ. One source class parametrized on
+gender, mirroring NcaaSoccerSource (regular season) — same pattern.
+
+Bracket shape (6 rounds, both genders):
+
+| ESPN season.slug                | Stage label | KNOCKOUT_ROUND_DEPTH |
+|---------------------------------|-------------|----------------------|
+| first-round                     | R64         | 0 (entry)            |
+| second-round                    | R32         | 1                    |
+| third-round                     | S16         | 2 (Sweet 16)         |
+| quarterfinals                   | E8          | 3 (Elite 8)          |
+| college-cup---semifinal (M's)   | F4          | 4 (College Cup SF)   |
+| semifinals (W's)                | F4          | 4                    |
+| college-cup---championship (M's)| NCG         | 5 (Final)            |
+| college-cup (W's)               | NCG         | 5                    |
+
+Gender-specific slug aliases for the final two rounds (M's uses "college-
+cup---semifinal" / "college-cup---championship"; W's uses "semifinals" /
+"college-cup"). Both map to the same canonical R64/R32/S16/E8/F4/NCG
+stage labels, which match `KNOCKOUT_ROUND_DEPTH` entries already in use
+by NCAA Women's Basketball March Madness (also a 6-round single-game
+elim bracket — the depth dict is shared and the cascade is identical).
+
+Field size note: Men's NCAA Soccer Tournament uses a 48-team field with
+16 byes (top 16 seeds play their first match in the second round), so
+"first-round" has only 16 games (32 of 48 teams), then "second-round"
+has 16 games (32 teams: 16 byes + 16 R1 winners). Treating the entry
+round as R64 is correct conceptually — the cascade only cares about
+depth ordering, and a team that played and lost R1 has reached the
+"R64" entry tier even though the tier isn't full. Women's bracket is
+a full 64-team field with no byes.
+
+Strength sharing: `set_regular_season_strengths` lets the plugin seed
+playoff sampling with per-team Poisson rates from the regular-season
+NcaaSoccerSource — the College Cup samples then reflect actual scoring
+skill from the 20-game regular season instead of the 1.5/1.5 league-
+average prior. Without the seed the source falls back to the prior.
+
+Postseason is filed under `LEAGUE_CONTEXTS["NCAA_MSOC_CUP"]` /
+`["NCAA_WSOC_CUP"]` (sibling to the regular-season `NCAA_MSOC` /
+`NCAA_WSOC` contexts already shipped in Phase O). Weights ramp into
+the College Cup Final because postseason is when these channels get
+real TV pickup, and the National Championship Game has the highest
+viewership of any D1 soccer game by an order of magnitude.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from .base import GameRow, MatchResult
+from .bracket import BestOfNSeriesSource
+from .._util import parse_iso_utc, poisson_sample as _poisson
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_soccer_cup")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/soccer"
+
+# Tournament window: M's runs late Nov through mid-Dec, W's runs mid-Nov
+# through early-Dec. Walking Nov 1 through Dec 31 of season_year covers
+# both with margin on either side.
+TOURNAMENT_START_MONTH = 11
+TOURNAMENT_END_MONTH = 12
+
+# Per-team scoring rate priors. NCAA D1 soccer averages ~1.5 goals/team/
+# game across both M's and W's. Same prior as NcaaSoccerSource so the
+# regular-season → playoff strength seed lines up consistently when
+# `set_regular_season_strengths` is wired.
+_DEFAULT_GOALS_FOR = 1.5
+_DEFAULT_GOALS_AGAINST = 1.5
+
+# Map ESPN's per-event `season.slug` to canonical bracket stage labels.
+# Stage labels are reused from NCAAW Basketball (R64/R32/S16/E8/F4/NCG)
+# because the depth ordering in KNOCKOUT_ROUND_DEPTH already supports
+# them and the cascade behaves identically for single-game elim brackets.
+# Gender-specific keys for the last two rounds — both M's and W's map
+# to the same canonical labels via slug aliases.
+SLUG_TO_STAGE: Dict[str, str] = {
+    "first-round":                  "R64",
+    "second-round":                 "R32",
+    "third-round":                  "S16",
+    "quarterfinals":                "E8",
+    # College Cup Semifinals — gender split:
+    "college-cup---semifinal":      "F4",  # M's slug
+    "semifinals":                   "F4",  # W's slug
+    # National Championship Game — gender split:
+    "college-cup---championship":   "NCG", # M's slug
+    "college-cup":                  "NCG", # W's slug (the final, not the full event)
+}
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Any]:
+    """ESPN endpoints return dicts; the wrapper type is Optional[Any]
+    rather than Optional[Dict] to keep the contract honest about the
+    None failure path. Caller checks isinstance(data, dict)."""
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[ncaa_soccer_cup] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[ncaa_soccer_cup] %s failed: %s", url, exc)
+        return None
+
+
+def _dedupe_pk_shootout_pairs(
+    records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Collapse multiple events at the same (stage, participants) tuple
+    into the single decisive event. ESPN occasionally publishes two
+    records for a soccer bracket game that goes to OT / PKs: one with
+    the regulation tie (e.g., 0-0) marked finished, and a second with
+    the PK shootout final score (e.g., 3-2). Both are tagged complete
+    in ESPN's scoreboard.
+
+    Preference order when multiple records collide on (stage,
+    frozenset(home, away)):
+      1. SCHEDULED records lose to any FINISHED record (real outcomes
+         beat placeholders).
+      2. Among FINISHED records, non-tie outcomes beat tie outcomes
+         (PK shootout score beats the regulation tie).
+      3. Among non-tie FINISHED records, the LATEST `start_time` wins
+         (handles a real same-day duplicate; in practice the shootout
+         event is published with a later timestamp than the regulation
+         tie).
+
+    This is conservative: single-game elimination brackets cannot have
+    a real second leg between the same two teams at the same stage, so
+    any (stage, participants) collision IS data noise.
+    """
+    # Bucket records by their dedup key. order matters: insertion order
+    # in the candidates list is by-date, so the first record we see for
+    # a (stage, participants) pair is the earliest event.
+    buckets: Dict[Tuple[str, frozenset], List[Dict[str, Any]]] = {}
+    for rec in records:
+        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
+        buckets.setdefault(key, []).append(rec)
+
+    out: List[Dict[str, Any]] = []
+    for key, bucket in buckets.items():
+        if len(bucket) == 1:
+            out.append(bucket[0])
+            continue
+        out.append(_pick_decisive_event(bucket))
+    return out
+
+
+def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Apply the (FINISHED > SCHEDULED, non-tie > tie, latest > earliest)
+    preference order. Bucket has 2+ records guaranteed.
+    """
+    finished = [r for r in bucket if r.get("status") == "FINISHED"]
+    if not finished:
+        # All scheduled — keep the latest by start_time (most recent
+        # info is the canonical one).
+        return max(bucket, key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc))
+    non_tie = [
+        r for r in finished
+        if r.get("home_goals") is not None
+        and r.get("away_goals") is not None
+        and r["home_goals"] != r["away_goals"]
+    ]
+    pool = non_tie if non_tie else finished
+    return max(pool, key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc))
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """Prefer `team.location` (school) over `team.name` (mascot) — the
+    EPG side of the matcher uses school names like "Washington at
+    Stanford" rather than mascots like "Huskies at Cardinal". Same
+    canonicalizer as NcaaSoccerSource so the cross-source team-name
+    join (regular-season strength seed → College Cup teams) holds.
+    """
+    loc = (team_obj.get("location") or "").strip()
+    if loc:
+        return loc
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+class NcaaSoccerCupSource(BestOfNSeriesSource):
+    """NCAA D1 soccer College Cup bracket, parametrized on gender.
+
+    Six single-game elim rounds (R64 → R32 → S16 → E8 → F4 → NCG).
+    SERIES_LENGTH = 1 so each "series" clinches at ceil(1/2) = 1 win —
+    the BestOfNSeriesSource state machine handles round_reached and
+    terminal_outcomes for free at this length.
+
+    Field-size asymmetry: M's has 48 teams (16 byes at entry), W's has
+    64 teams (no byes). The bracket source doesn't care — both genders
+    surface the same 6 stage labels via slug aliases in `SLUG_TO_STAGE`.
+    """
+
+    KO_STAGES = ("R64", "R32", "S16", "E8", "F4", "NCG")
+    SERIES_LENGTH = 1
+    supports_importance = True
+
+    def __init__(
+        self,
+        gender: str = "m",
+        season_year: Optional[int] = None,
+    ) -> None:
+        g = (gender or "").lower().strip()
+        if g not in ("m", "w"):
+            raise ValueError(f"gender must be 'm' or 'w', got {gender!r}")
+        self.gender = g
+        now = datetime.now(timezone.utc)
+        # NCAA soccer seasons are named by their calendar year (2025
+        # season runs Aug-Dec 2025, with the tournament wrapping mid-
+        # December 2025). Default to current calendar year; pre-August
+        # treats as the prior season (postseason wraps by mid-Dec, so
+        # January reads as offseason → use prior year for any lingering
+        # postseason data fetch).
+        self.season_year = (
+            season_year if season_year is not None
+            else (now.year if now.month >= 8 else now.year - 1)
+        )
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[
+            Dict[str, Dict[str, float]]
+        ] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "NCAAMSOC" if self.gender == "m" else "NCAAWSOC"
+
+    @property
+    def sport_label(self) -> str:
+        return (
+            "NCAA Men's College Cup"
+            if self.gender == "m"
+            else "NCAA Women's College Cup"
+        )
+
+    @property
+    def _espn_slug(self) -> str:
+        return f"usa.ncaa.{self.gender}.1"
+
+    def _league_context_code(self) -> str:
+        return "NCAA_MSOC_CUP" if self.gender == "m" else "NCAA_WSOC_CUP"
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        # Champion is the synthetic depth above NCG (final game). Mirror
+        # the NCAAW Basketball NCG → NCG_WINNER mapping — same depth
+        # entry in KNOCKOUT_ROUND_DEPTH (already at depth 6).
+        if stage == "NCG":
+            return "NCG_WINNER"
+        return None
+
+    # ---------- strength sharing (regular season → playoff) ----------
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        """Per-team scoring/conceding rate. Seeded from the regular-
+        season NcaaSoccerSource via `set_regular_season_strengths`;
+        without the seed, falls back to the league-average prior."""
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]],
+    ) -> None:
+        """Hook for the plugin to share regular-season strength
+        estimates with the College Cup source. Without this, every
+        bracket team gets the league-average 1.5/1.5 prior — accurate
+        enough for early-round importance but loses the team-skill
+        signal that a 20-game regular season provides."""
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_GOALS_FOR,
+            "pa_per_game": _DEFAULT_GOALS_AGAINST,
+        }
+
+    # ---------- sample_result (force a winner — bracket games) ----------
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        """Bracket games CANNOT end in a draw — NCAA postseason soccer
+        goes to OT then PKs if needed. Sample Poisson goals; on a tied
+        regulation result, coin-flip the +1 boost so the bracket
+        cascade gets a clean winner. Distinct from NcaaSoccerSource
+        regular-season sample_result which allows draws (1 standings
+        point each) — bracket scenarios have no draw outcome at all.
+        """
+        del state  # interface-required, per-game classification only
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.05, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.05, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_goals = _poisson(lam_home, rng)
+        away_goals = _poisson(lam_away, rng)
+        if home_goals == away_goals:
+            # OT / PKs in real life; coin-flip the +1 here. Strength
+            # asymmetry already biased the Poisson means — no further
+            # bias added (PK shootouts are roughly coin-flips empirically
+            # at the NCAA level).
+            if rng.random() < 0.5:
+                home_goals += 1
+            else:
+                away_goals += 1
+        return MatchResult(home_goals=home_goals, away_goals=away_goals)
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Emit upcoming tournament games (any stage). Per-day sweep —
+        ESPN's date-range syntax silently caps at 25 events, same trap
+        as ncaa_baseball.py / ncaa_soccer.py. Postseason games carry
+        a `season.slug` of one of the SLUG_TO_STAGE keys; non-tournament
+        games are filtered out so only bracket games surface here.
+        """
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(
+                f"{ESPN_BASE}/{self._espn_slug}/scoreboard?"
+                f"dates={day.strftime('%Y%m%d')}"
+            )
+            if not isinstance(data, dict):
+                continue
+            for event in data.get("events") or []:
+                rec = self._extract_bracket_record(event)
+                if rec is None:
+                    continue
+                eid = rec.get("game_id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "espn_event_id": eid,
+                        "fd_competition_code": self._league_context_code(),
+                        "stage": rec.get("stage"),
+                    },
+                ))
+        return out
+
+    # ---------- _fetch_bracket_games (importance side) ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Pull the November-December tournament window and emit one
+        canonical record per bracket game. Filters out non-tournament
+        events via SLUG_TO_STAGE membership — regular-season games
+        won't carry a slug like 'quarterfinals', so they fall out
+        naturally.
+
+        ESPN sometimes records two events for a single bracket game
+        that goes to OT / PKs: one with the regulation 0-0 / X-X tie
+        and a second with the PK shootout final score (observed live
+        on the 2024 M's Marshall @ SMU QF: events 723937 with 0-0
+        and 724472 with 3-2). Both are tagged status="post" and
+        share the same slug, so we dedupe by (stage, frozenset
+        participants) keeping the event with a non-tie outcome (or
+        the latest by start_time when both are non-tie). Single-game
+        elimination brackets have at most one game per (stage,
+        participants); a second event at the same stage between the
+        same two teams is ESPN data noise, not a real second leg.
+        """
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        candidates: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        # Tournament window: Nov 1 - Dec 31 of season_year.
+        start = datetime(
+            self.season_year, TOURNAMENT_START_MONTH, 1, tzinfo=timezone.utc,
+        ).date()
+        # End of December: build Jan 1 of next year, subtract one day.
+        end = (
+            datetime(self.season_year + 1, 1, 1, tzinfo=timezone.utc).date()
+            - timedelta(days=1)
+        )
+        day = start
+        while day <= end:
+            data = _http_get(
+                f"{ESPN_BASE}/{self._espn_slug}/scoreboard?"
+                f"dates={day.strftime('%Y%m%d')}"
+            )
+            if isinstance(data, dict):
+                for event in data.get("events") or []:
+                    rec = self._extract_bracket_record(event)
+                    if rec is None or rec["game_id"] is None:
+                        continue
+                    if rec["game_id"] in seen_ids:
+                        continue
+                    seen_ids.add(rec["game_id"])
+                    candidates.append(rec)
+            day += timedelta(days=1)
+
+        self._bracket_games_cache = _dedupe_pk_shootout_pairs(candidates)
+        return self._bracket_games_cache
+
+    @staticmethod
+    def _extract_bracket_record(
+        event: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Convert one ESPN scoreboard event into the canonical
+        BracketSportSource per-game record shape, OR None if the event
+        isn't a tournament bracket game.
+
+        Stage routing: `event.season.slug` carries the round identifier
+        (e.g. 'first-round', 'college-cup---semifinal'). Non-tournament
+        games (regular-season) carry a different slug and are filtered
+        out via SLUG_TO_STAGE membership.
+        """
+        season = event.get("season") or {}
+        slug = (season.get("slug") or "").strip().lower()
+        stage = SLUG_TO_STAGE.get(slug)
+        if stage is None:
+            return None
+
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        is_final = completed or state == "post"
+        status = "FINISHED" if is_final else "SCHEDULED"
+
+        try:
+            hg = int(home.get("score")) if is_final else None
+        except (TypeError, ValueError):
+            hg = None
+        try:
+            ag = int(away.get("score")) if is_final else None
+        except (TypeError, ValueError):
+            ag = None
+
+        if is_final and (hg is None or ag is None):
+            status = "SCHEDULED"
+            hg = None
+            ag = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            # SERIES_LENGTH=1 means each game is its own one-game series.
+            # matchday is always 1; BracketSportSource clinches at first win.
+            "matchday": 1,
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hg,
+            "away_goals": ag,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"season_slug": slug},
+        }

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4670,6 +4670,486 @@ class TestNcaawBasketballPlayoffSource:
 
 
 # =====================================================================
+# Issue #24: NCAA College Cup brackets (M's + W's)
+# =====================================================================
+
+class TestNcaaSoccerCupSource:
+    """One source class parametrized on gender — same shape / endpoints
+    / stage labels for both, only ESPN URL slug + league_context_code
+    differ. Mirrors NcaaSoccerSource (regular season) parametrization."""
+
+    @staticmethod
+    def _make(gender="m", bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        src = NcaaSoccerCupSource(gender=gender, season_year=2024)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    # ---------- identity + parametrization ----------
+
+    def test_gender_routes_to_correct_context(self):
+        m = self._make("m")
+        w = self._make("w")
+        assert m._league_context_code() == "NCAA_MSOC_CUP"
+        assert w._league_context_code() == "NCAA_WSOC_CUP"
+        assert m.sport_prefix == "NCAAMSOC"
+        assert w.sport_prefix == "NCAAWSOC"
+        assert "Men's" in m.sport_label
+        assert "Women's" in w.sport_label
+
+    def test_gender_routes_to_correct_espn_slug(self):
+        assert self._make("m")._espn_slug == "usa.ncaa.m.1"
+        assert self._make("w")._espn_slug == "usa.ncaa.w.1"
+
+    def test_invalid_gender_rejected(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        try:
+            NcaaSoccerCupSource(gender="x")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError on invalid gender")
+
+    def test_supports_importance(self):
+        assert self._make("m").supports_importance is True
+        assert self._make("w").supports_importance is True
+
+    def test_ko_stages(self):
+        # Six rounds, same canonical labels as NCAAW Basketball's tournament
+        # so KNOCKOUT_ROUND_DEPTH entries are reused.
+        assert self._make().KO_STAGES == ("R64", "R32", "S16", "E8", "F4", "NCG")
+
+    def test_series_length_uniform_one(self):
+        """Single-game elim — every stage uses SERIES_LENGTH=1; clinches
+        at ceil(1/2)=1 win."""
+        src = self._make()
+        for stage in src.KO_STAGES:
+            assert src._series_length_for_stage(stage) == 1
+            assert src._clinching_wins_for_stage(stage) == 1
+
+    def test_winner_advance_label(self):
+        # NCG winner → NCG_WINNER synthetic depth (shared with NCAAW
+        # Basketball's bracket). All non-final stages return None and
+        # the base machinery handles the next-stage advance.
+        src = self._make()
+        assert src._winner_advance_label("NCG") == "NCG_WINNER"
+        assert src._winner_advance_label("F4") is None
+        assert src._winner_advance_label("R64") is None
+
+    # ---------- slug parser ----------
+
+    def test_slug_to_stage_table_covers_both_genders(self):
+        """Both M's and W's College Cup slugs map to the same canonical
+        stage labels — M's uses 'college-cup---semifinal' / 'college-
+        cup---championship', W's uses 'semifinals' / 'college-cup'. Pin
+        both gender aliases so an ESPN slug rename surfaces here, not
+        as silently-missing-stage in production."""
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            SLUG_TO_STAGE,
+        )
+        # Shared across genders (R1 - QF)
+        assert SLUG_TO_STAGE["first-round"] == "R64"
+        assert SLUG_TO_STAGE["second-round"] == "R32"
+        assert SLUG_TO_STAGE["third-round"] == "S16"
+        assert SLUG_TO_STAGE["quarterfinals"] == "E8"
+        # M's gender-specific aliases
+        assert SLUG_TO_STAGE["college-cup---semifinal"] == "F4"
+        assert SLUG_TO_STAGE["college-cup---championship"] == "NCG"
+        # W's gender-specific aliases
+        assert SLUG_TO_STAGE["semifinals"] == "F4"
+        assert SLUG_TO_STAGE["college-cup"] == "NCG"
+
+    def test_extract_bracket_record_filters_non_tournament_slugs(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        # Regular-season game with the regular-season slug should be
+        # filtered out entirely (return None), not silently coerced
+        # into a bracket stage.
+        event = {
+            "id": "regular-1",
+            "date": "2024-09-01T19:00:00Z",
+            "season": {"slug": "regular-season"},
+            "competitions": [{
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"location": "Stanford"}, "score": "2"},
+                    {"homeAway": "away", "team": {"location": "Washington"}, "score": "1"},
+                ],
+            }],
+        }
+        assert NcaaSoccerCupSource._extract_bracket_record(event) is None
+
+    def test_extract_bracket_record_routes_third_round_to_s16(self):
+        """ESPN's 'third-round' slug is what humans call Sweet 16 —
+        confirm the routing so a label mismatch surfaces here, not via
+        an importance-band silently misfiring on production data.
+        """
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        event = {
+            "id": "s16-1",
+            "date": "2024-11-30T19:00:00Z",
+            "season": {"slug": "third-round"},
+            "competitions": [{
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"location": "Stanford"}, "score": "2"},
+                    {"homeAway": "away", "team": {"location": "Washington"}, "score": "1"},
+                ],
+            }],
+        }
+        rec = NcaaSoccerCupSource._extract_bracket_record(event)
+        assert rec is not None
+        assert rec["stage"] == "S16"
+        assert rec["home"] == "Stanford"
+        assert rec["away"] == "Washington"
+        assert rec["home_goals"] == 2
+        assert rec["away_goals"] == 1
+        assert rec["status"] == "FINISHED"
+        assert rec["matchday"] == 1  # SERIES_LENGTH=1 means single game per "tie"
+
+    def test_extract_bracket_record_scheduled_has_no_score(self):
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        event = {
+            "id": "qf-1",
+            "date": "2030-12-07T19:00:00Z",
+            "season": {"slug": "quarterfinals"},
+            "competitions": [{
+                "status": {"type": {"completed": False, "state": "pre"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"location": "Stanford"}},
+                    {"homeAway": "away", "team": {"location": "Washington"}},
+                ],
+            }],
+        }
+        rec = NcaaSoccerCupSource._extract_bracket_record(event)
+        assert rec is not None
+        assert rec["stage"] == "E8"
+        assert rec["status"] == "SCHEDULED"
+        assert rec["home_goals"] is None
+        assert rec["away_goals"] is None
+
+    # ---------- LEAGUE_CONTEXTS for both genders ----------
+
+    def test_contexts_use_knockout_format(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["NCAA_MSOC_CUP"].format == "knockout"
+        assert LEAGUE_CONTEXTS["NCAA_WSOC_CUP"].format == "knockout"
+
+    def test_outcome_labels(self):
+        labels = self._make("m").outcome_labels
+        assert "round_of_32" in labels
+        assert "sweet_16" in labels
+        assert "elite_8" in labels
+        assert "college_cup_semis" in labels
+        assert "college_cup_final" in labels
+        assert "cup_winner" in labels
+
+    def test_thresholds_are_depth_ordered(self):
+        # Cross-sport calibration requires later stages to be ranked
+        # deeper than earlier ones. Out-of-order depths would break the
+        # cascade — a team reaching SF wouldn't be credited with the
+        # E8 / S16 / R32 labels below it.
+        from dispatcharr_ranked_matchups.scoring import (
+            LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH,
+        )
+        for code in ("NCAA_MSOC_CUP", "NCAA_WSOC_CUP"):
+            ctx = LEAGUE_CONTEXTS[code]
+            depths = [
+                KNOCKOUT_ROUND_DEPTH[stage] for stage, _, _ in ctx.thresholds
+            ]
+            for i in range(len(depths) - 1):
+                assert depths[i] < depths[i + 1], (
+                    f"{code} depths {depths} not monotonic at {i}"
+                )
+
+    def test_weights_are_monotonic_increasing(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        for code in ("NCAA_MSOC_CUP", "NCAA_WSOC_CUP"):
+            weights = [w for _, _, w in LEAGUE_CONTEXTS[code].thresholds]
+            for i in range(len(weights) - 1):
+                assert weights[i] < weights[i + 1], (
+                    f"{code} weights {weights} not monotonic at {i}"
+                )
+
+    # ---------- bracket cascade end-to-end ----------
+
+    def test_champion_cascade(self):
+        """A team that wins each of the 6 rounds reaches NCG_WINNER
+        depth and `terminal_outcomes` returns every band — pin the
+        cascade end-to-end so a future refactor of bracket.py can't
+        silently break the round_reached → terminal_outcomes path
+        for soccer-style brackets.
+        """
+        games = []
+        for i, (stage, opp) in enumerate([
+            ("R64", "Sixteen"),
+            ("R32", "Eight"),
+            ("S16", "Four"),
+            ("E8",  "Two"),
+            ("F4",  "One"),
+            ("NCG", "Final"),
+        ]):
+            games.append({
+                "game_id": f"ncsoc-{i+1}",
+                "stage": stage,
+                "matchday": 1,
+                "home": "Champion",
+                "away": opp,
+                "home_goals": 2,
+                "away_goals": 1,
+                "status": "FINISHED",
+                "start_time": None,
+                "extra": {},
+            })
+        src = self._make(bracket_games=games)
+        state = src.initial_state()
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        assert state["_round_reached"]["Champion"] == KNOCKOUT_ROUND_DEPTH["NCG_WINNER"]
+        assert state["_round_reached"]["Final"] == KNOCKOUT_ROUND_DEPTH["NCG"]
+        assert state["_round_reached"]["One"] == KNOCKOUT_ROUND_DEPTH["F4"]
+        outcomes = src.terminal_outcomes(state)
+        assert "cup_winner" in outcomes["Champion"]
+        assert "college_cup_final" in outcomes["Final"]
+        assert "college_cup_final" not in outcomes["One"]
+        assert "college_cup_semis" in outcomes["One"]
+
+    # ---------- sample_result forces a winner (no draws in bracket) ----------
+
+    def test_sample_result_never_produces_ties(self):
+        """Bracket games go to OT then PKs in real life — sample_result
+        must coin-flip a +1 to break a regulation tie. Distinct from the
+        regular-season NcaaSoccerSource which allows draws (1 standings
+        point each). Run a tight-Poisson sample 200x and confirm zero
+        draws.
+        """
+        import random
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        src = self._make()
+        strengths = {
+            "A": {"pf_per_game": 1.0, "pa_per_game": 1.0},
+            "B": {"pf_per_game": 1.0, "pa_per_game": 1.0},
+        }
+        gr = GameRow(
+            sport_prefix="NCAAMSOC", sport_label="NCAA Men's College Cup",
+            home="A", away="B", rank_home=None, rank_away=None,
+            start_time=datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        rng = random.Random(42)
+        ties = 0
+        for _ in range(200):
+            res = src.sample_result({}, gr, strengths, rng)
+            if res.home_goals == res.away_goals:
+                ties += 1
+        assert ties == 0, (
+            f"bracket sample_result must force a winner; got {ties} ties"
+        )
+
+    # ---------- strength sharing ----------
+
+    def test_set_regular_season_strengths_persists_to_estimate(self):
+        src = self._make()
+        custom = {
+            "Stanford":   {"pf_per_game": 2.5, "pa_per_game": 0.5},
+            "Washington": {"pf_per_game": 1.0, "pa_per_game": 1.5},
+        }
+        src.set_regular_season_strengths(custom)
+        assert src.estimate_strengths() == custom
+
+    def test_estimate_strengths_empty_when_not_seeded(self):
+        # Without a regular-season seed, the source returns {} and
+        # sample_result falls through to the league-average prior.
+        # Pin this so a future change to the default doesn't silently
+        # inject league-wide priors that should have been per-team.
+        assert self._make().estimate_strengths() == {}
+
+    # ---------- loser stops at the stage they lost ----------
+
+    def test_loser_round_reached_stops_at_lost_stage(self):
+        """A team that wins R64 + R32 but loses S16 should have
+        round_reached at depth(S16) — they made it to Sweet 16, didn't
+        advance to Elite 8. terminal_outcomes returns sweet_16 and
+        round_of_32 but NOT elite_8.
+        """
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        games = [
+            # Loser wins R64
+            {"game_id": "g1", "stage": "R64", "matchday": 1,
+             "home": "Loser", "away": "Sixteen",
+             "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # Loser wins R32
+            {"game_id": "g2", "stage": "R32", "matchday": 1,
+             "home": "Loser", "away": "Eight",
+             "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # Loser loses S16
+            {"game_id": "g3", "stage": "S16", "matchday": 1,
+             "home": "Loser", "away": "Four",
+             "home_goals": 0, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make(bracket_games=games)
+        state = src.initial_state()
+        rr = state["_round_reached"]
+        assert rr["Loser"] == KNOCKOUT_ROUND_DEPTH["S16"], (
+            f"Loser should reach S16 depth, got {rr['Loser']}"
+        )
+        # Four (the opponent that beat Loser at S16) advances to E8.
+        assert rr["Four"] == KNOCKOUT_ROUND_DEPTH["E8"]
+        outcomes = src.terminal_outcomes(state)
+        assert "sweet_16" in outcomes["Loser"]
+        assert "round_of_32" in outcomes["Loser"]
+        assert "elite_8" not in outcomes["Loser"]
+        assert "college_cup_semis" not in outcomes["Loser"]
+
+    # ---------- PK shootout dedup ----------
+
+    def test_dedupe_pk_shootout_keeps_non_tie_event(self):
+        """ESPN sometimes publishes two events for a soccer bracket
+        game that goes to PKs: one with regulation 0-0 and a second
+        with the PK shootout final score. The dedup must keep the
+        non-tie event so the bracket cascade gets the actual winner.
+        Pin the live 2024 M's Marshall @ SMU QF shape observed during
+        live verification.
+        """
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            _dedupe_pk_shootout_pairs,
+        )
+        regulation_tie = {
+            "game_id": "723937", "stage": "E8", "matchday": 1,
+            "home": "SMU", "away": "Marshall",
+            "home_goals": 0, "away_goals": 0,
+            "status": "FINISHED",
+            "start_time": datetime(2024, 12, 8, 0, 0, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        pk_shootout = {
+            "game_id": "724472", "stage": "E8", "matchday": 1,
+            "home": "SMU", "away": "Marshall",
+            "home_goals": 2, "away_goals": 3,
+            "status": "FINISHED",
+            "start_time": datetime(2024, 12, 8, 20, 0, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        deduped = _dedupe_pk_shootout_pairs([regulation_tie, pk_shootout])
+        assert len(deduped) == 1
+        assert deduped[0]["game_id"] == "724472"
+        assert deduped[0]["away_goals"] == 3
+        assert deduped[0]["home_goals"] == 2
+
+    def test_dedupe_with_scheduled_vs_finished_keeps_finished(self):
+        """A scheduled placeholder and a finished result for the same
+        bracket game must collapse to the finished record."""
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            _dedupe_pk_shootout_pairs,
+        )
+        scheduled = {
+            "game_id": "s1", "stage": "S16", "matchday": 1,
+            "home": "A", "away": "B",
+            "home_goals": None, "away_goals": None,
+            "status": "SCHEDULED",
+            "start_time": datetime(2024, 11, 30, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        finished = {
+            "game_id": "f1", "stage": "S16", "matchday": 1,
+            "home": "A", "away": "B",
+            "home_goals": 2, "away_goals": 1,
+            "status": "FINISHED",
+            "start_time": datetime(2024, 11, 30, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        deduped = _dedupe_pk_shootout_pairs([scheduled, finished])
+        assert len(deduped) == 1
+        assert deduped[0]["game_id"] == "f1"
+
+    def test_dedupe_passes_through_unique_games(self):
+        """A bracket with all distinct (stage, participants) tuples
+        passes through unchanged — no false collapsing of legitimate
+        bracket games."""
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            _dedupe_pk_shootout_pairs,
+        )
+        games = [
+            {"game_id": "1", "stage": "S16", "matchday": 1,
+             "home": "A", "away": "B", "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "2", "stage": "S16", "matchday": 1,
+             "home": "C", "away": "D", "home_goals": 1, "away_goals": 2,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "3", "stage": "E8", "matchday": 1,
+             "home": "A", "away": "B",  # same teams BUT different stage
+             "home_goals": 3, "away_goals": 2,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        deduped = _dedupe_pk_shootout_pairs(games)
+        assert len(deduped) == 3
+        ids = {g["game_id"] for g in deduped}
+        assert ids == {"1", "2", "3"}
+
+    # ---------- fetch_upcoming (EPG emit side) ----------
+
+    def test_fetch_upcoming_emits_only_bracket_games(self, monkeypatch):
+        """fetch_upcoming must filter to events with a tournament slug
+        — a regular-season game that happens to fall in the same date
+        window must not appear. Pin via stub so a slug-table regression
+        surfaces here."""
+        from dispatcharr_ranked_matchups.sources import ncaa_soccer_cup as mod
+        from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
+            NcaaSoccerCupSource,
+        )
+        # Two events: one tournament (third-round) and one regular-season.
+        # Only the tournament event should be emitted.
+        calls = {"n": 0}
+        def fake_get(url, *_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] != 1:
+                return {"events": []}
+            return {"events": [
+                {"id": "tournament-event", "date": "2030-11-30T19:00:00Z",
+                 "season": {"slug": "third-round"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"location": "Stanford"}},
+                         {"homeAway": "away", "team": {"location": "Washington"}},
+                     ],
+                 }]},
+                {"id": "regular-season-event", "date": "2030-11-30T22:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"location": "UCLA"}},
+                         {"homeAway": "away", "team": {"location": "USC"}},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        src = NcaaSoccerCupSource(gender="m")
+        games = src.fetch_upcoming(days_ahead=0)
+        ids = {(g.extra or {}).get("espn_event_id") for g in games}
+        assert ids == {"tournament-event"}, (
+            f"only the bracket slug should pass through, got {ids}"
+        )
+        # And the emitted game carries the bracket stage in extra.
+        assert games[0].extra["stage"] == "S16"
+        assert games[0].extra["fd_competition_code"] == "NCAA_MSOC_CUP"
+
+
+# =====================================================================
 # Phase N: NCAA Softball
 # =====================================================================
 


### PR DESCRIPTION
## Summary

- Adds `NcaaSoccerCupSource` (`sources/ncaa_soccer_cup.py`) — single-source class parametrized on gender, single-game-elim across 6 rounds (R64 → R32 → S16 → E8 → F4 → NCG).
- Adds `LEAGUE_CONTEXTS["NCAA_MSOC_CUP"]` and `["NCAA_WSOC_CUP"]` with `format="knockout"`; threshold bands round_of_32 / sweet_16 / elite_8 / college_cup_semis / college_cup_final / cup_winner.
- Wires both genders in `_build_sources`: regular-season `NcaaSoccerSource` paired with `NcaaSoccerCupSource`, with strength sharing via `set_regular_season_strengths` (same pattern as NHL/MLB/NBA/WNBA/NCAAW Basketball).
- Updates `enable_ncaa_mens_soccer` / `enable_ncaa_womens_soccer` help text to reflect that postseason is now modeled.

## Scope nuances

Stage labels (R64-NCG-NCG_WINNER) are reused from NCAA Women's Basketball March Madness — `KNOCKOUT_ROUND_DEPTH` already supports them and the bracket cascade behaves identically for any single-game-elim shape. Field-size asymmetry (M's 48-team with 16 byes; W's full 64-team) is handled at the slug-routing level: both genders map ESPN's per-event `season.slug` to the same canonical stage labels via `SLUG_TO_STAGE`. M's uses \`college-cup---semifinal\` / \`college-cup---championship\` for the last two rounds; W's uses \`semifinals\` / \`college-cup\` — both alias to the same `F4` / `NCG` stage labels.

## PK shootout dedup

Discovered during live verification: ESPN occasionally publishes two events for a bracket game that goes to PKs — one with the regulation 0-0 tie marked finished, another with the PK shootout final score. Observed on the 2024 M's Marshall @ SMU QF (events 723937 with 0-0 and 724472 with 3-2). `_dedupe_pk_shootout_pairs` collapses by (stage, frozenset(home, away)) preferring non-tie outcomes (FINISHED > SCHEDULED, non-tie > tie, latest > earliest). Single-game elim brackets cannot have a legitimate second leg between the same two teams at the same stage, so any collision IS data noise.

Without the dedup, the 2024 M's bracket reads 48 games (E8=5); with it, 47 games (E8=4) as expected for a 48-team single-elim bracket (47 games to crown a champion).

## Live verification

```
M's 2024 College Cup (after dedup):
  R64=16, R32=16, S16=8, E8=4, F4=2, NCG=1 = 47 games (correct)
  Vermont (Champion) → terminal_outcomes: 
    ['round_of_32', 'sweet_16', 'elite_8', 'college_cup_semis',
     'college_cup_final', 'cup_winner']
  Marshall (Finalist) → terminal_outcomes includes 'college_cup_final'
                        but NOT 'cup_winner'
W's 2024 College Cup:
  R64=32, R32=16, S16=8, E8=4, F4=2, NCG=1 = 63 games (correct)
```

## Test plan

- [x] `pytest tests/` — 904 pass (was 880 on `main`; +24 new tests covering identity/gender routing, slug parser for both genders, LEAGUE_CONTEXTS shape, depth ordering, weight monotonicity, champion cascade, loser stops at lost-stage cascade, sample_result never produces ties, strength sharing, scheduled vs finished extraction, PK shootout dedup, fetch_upcoming tournament-slug filter)
- [x] Plugin reloads cleanly in the running Dispatcharr container (`force_reload=True`, no import errors)
- [x] Live fetch of 2024 M's + W's College Cup brackets returns correct game counts after PK dedup
- [x] terminal_outcomes correctly cascades all 6 bands for the 2024 M's champion (Vermont)

🤖 Generated with [Claude Code](https://claude.com/claude-code)