### PR TITLE
Closes #30 part B: MLS Cup playoff bracket (mixed format)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -142,9 +142,9 @@
     {
       "id": "enable_mls",
       "type": "boolean",
-      "label": "MLS (regular season)",
+      "label": "MLS (regular season + Cup playoffs)",
       "default": false,
-      "help_text": "MLS regular season with per-conference standings importance. Playoff seeding is per-conference (top 9 from Eastern + top 9 from Western), so threshold bands run separately on each conference: 30+ standings points (3 W / 1 D / 0 L) = playoff bubble, 45+ = playoff secured, 55+ = top-4 home-field advantage in R1 best-of-3, 70+ = Supporters' Shield contender. ESPN's unofficial site.api.espn.com for schedule + /standings for conference rosters; The Odds API key enables closeness via soccer_usa_mls. MLS Cup playoff bracket (mixed best-of-3 R1 + single-leg later rounds) is filed as a follow-up (#30 part B)."
+      "help_text": "MLS regular season with per-conference standings importance + the MLS Cup playoff bracket. Regular season uses standings points (3 W / 1 D / 0 L) with per-conference bands: 30+ playoff bubble, 45+ secured, 55+ top-4 home field, 70+ Supporters' Shield. Postseason is mixed-format: Wild Card single-leg play-in -> Round One best-of-3 -> Conference Semis single-leg -> Conference Final single-leg -> MLS Cup Final single-leg -> Champion. ESPN's unofficial site.api.espn.com for schedule + /standings for conference rosters; The Odds API key enables closeness via soccer_usa_mls."
     },
     {
       "id": "enable_nwsl",

--- a/plugin.py
+++ b/plugin.py
@@ -461,7 +461,7 @@ def _resolve_max_games(settings: Dict[str, Any]) -> int:
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
         GroupStageSoccerSource, KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
-        MlsEastSource, MlsWestSource, NwslSource, LigaMxSource,
+        MlsEastSource, MlsWestSource, MlsCupSource, NwslSource, LigaMxSource,
         NbaPlayoffSource, NbaRegularSource,
         WnbaPlayoffSource, WnbaRegularSource,
         NcaawBasketballPlayoffSource, NcaawBasketballRegularSource,
@@ -617,12 +617,29 @@ def _build_sources(settings: Dict[str, Any]):
     # stays as the base class for NwslSource / LigaMxSource but is NOT
     # registered for MLS here; the East/West sources own the MLS
     # emission and carry the same closeness signal forward via the
-    # shared Odds API helpers from mls.py. MLS Cup playoff bracket
-    # (mixed best-of-3 R1 + single-leg later rounds) is filed under
-    # #30 part B.
+    # shared Odds API helpers from mls.py.
+    #
+    # Issue #30 part B: MlsCupSource pairs with East+West for strength
+    # sharing. Mixed-format bracket: Wild Card single-leg, R1 best-of-3,
+    # then single-leg CSF / CF / MLS Cup Final. Per-stage series length
+    # via `_series_length_for_stage` (same hook MLB uses for its
+    # WC/LDS/LCS/WS mix). Strengths are merged across both conferences
+    # before seeding the cup source — the MLS Cup Final is cross-
+    # conference, so per-team scoring rates need to be in one dict.
     if settings.get("enable_mls", False):
-        sources.append(MlsEastSource(odds_api_key=odds_key or ""))
-        sources.append(MlsWestSource(odds_api_key=odds_key or ""))
+        mls_east = MlsEastSource(odds_api_key=odds_key or "")
+        mls_west = MlsWestSource(odds_api_key=odds_key or "")
+        sources.append(mls_east)
+        sources.append(mls_west)
+        mls_cup = MlsCupSource()
+        try:
+            merged_strengths: Dict[str, Dict[str, float]] = {}
+            merged_strengths.update(mls_east.estimate_strengths())
+            merged_strengths.update(mls_west.estimate_strengths())
+            mls_cup.set_regular_season_strengths(merged_strengths)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[mls_cup] could not seed playoff strengths: %s", exc)
+        sources.append(mls_cup)
 
     # NWSL — same V1 minimal pattern as MLS (schedule + closeness).
     # Subclasses MlsSource with NWSL-specific endpoint and Odds API

--- a/scoring.py
+++ b/scoring.py
@@ -232,6 +232,18 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "WCWS":            2,  # 8-team double-elim in OKC (#43)
     "WCWS_F":          3,  # Championship Finals (best-of-3)
     "WCWS_W":          4,  # WCWS Champion
+    # MLS Cup playoffs (issue #30 part B). Mixed format: Wild Card
+    # single-leg entry, R1 best-of-3, then single-leg CSF / CF / MLS Cup
+    # Final. MLS-prefixed labels so depths don't collide with NHL "R1"
+    # at depth 0 or MLB "WC" at depth 0 — each league reads its own
+    # bands, but within MLS the WC→R1→CSF advance must move up in
+    # depth, requiring unique labels.
+    "MLS_WC":          0,  # Wild Card play-in (8 vs 9 seed each conference)
+    "MLS_R1":          1,  # Round One (best-of-3)
+    "MLS_CSF":         2,  # Conference Semifinals (single-leg)
+    "MLS_CF":          3,  # Conference Finals (single-leg)
+    "MLS_CUP":         4,  # MLS Cup Final (single-leg, cross-conference)
+    "MLS_CUP_WINNER":  5,  # MLS Cup Champion (synthetic)
 }
 
 
@@ -781,6 +793,28 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
             (70, "shield_contender",     5.0),
         ],
         boundary_summary="30+ pts → bubble · 45+ → secured · 55+ → top-4 home field · 70+ → Shield contender (West)",
+    ),
+    # Issue #30 part B: MLS Cup playoff bracket. Mixed format — Wild
+    # Card single-leg entry, R1 best-of-3, then single-leg CSF / CF /
+    # MLS Cup Final. Weights ramp aggressively into the MLS Cup Final
+    # because postseason concentrates broadcast leverage; the Cup
+    # Final is the single highest-viewership domestic-soccer game in
+    # the US calendar. The Supporters' Shield band (regular-season
+    # league-best record) is handled on the East/West regular-season
+    # sources from issue #30 part A. MLS_WC is omitted from
+    # thresholds here — "made the tournament" is the bar, advancing
+    # past WC is what counts, mirroring the NCAAW Basketball March
+    # Madness and NCAA College Cup pattern of omitting entry rounds.
+    "MLS_PO": LeagueContext(
+        code="MLS_PO", matchdays_total=0, format="knockout",
+        thresholds=[
+            ("MLS_R1",         "round_one",       1.0),
+            ("MLS_CSF",        "conf_semis",      2.5),
+            ("MLS_CF",         "conf_final",      4.5),
+            ("MLS_CUP",        "mls_cup_final",   7.0),
+            ("MLS_CUP_WINNER", "mls_cup_winner", 10.0),
+        ],
+        boundary_summary="WC → R1 → Conf Semis → Conf Final → MLS Cup → Champion",
     ),
 }
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -3,6 +3,7 @@ from .base import GameRow, SportSource
 from .mlb import MlbPlayoffSource, MlbRegularSource
 from .mls import MlsSource
 from .mls_standings import MlsEastSource, MlsWestSource
+from .mls_cup import MlsCupSource
 from .nwsl import NwslSource
 from .liga_mx import LigaMxSource
 from .field_event import (
@@ -39,7 +40,7 @@ from .soccer import (
 __all__ = [
     "GameRow", "SportSource",
     "MlbRegularSource", "MlbPlayoffSource",
-    "MlsSource", "MlsEastSource", "MlsWestSource",
+    "MlsSource", "MlsEastSource", "MlsWestSource", "MlsCupSource",
     "NwslSource", "LigaMxSource",
     "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
     "AtpSource", "WtaSource",

--- a/sources/mls_cup.py
+++ b/sources/mls_cup.py
@@ -1,0 +1,562 @@
+"""MLS Cup playoff bracket — issue #30 part B.
+
+Mixed-format postseason that neither AggregateLegSource nor a uniform
+best-of-N source handles cleanly:
+
+  - Wild Card round (`MLS_WC`): single-leg play-in, 8th vs 9th seed
+    in each conference (2 total games)
+  - Round One (`MLS_R1`): best-of-3 series, top 7 seeds + the 2 WC
+    winners → 8 teams per conference in 4 series each (8 series total)
+  - Conference Semifinals (`MLS_CSF`): single-leg elimination
+  - Conference Finals (`MLS_CF`): single-leg at the higher seed
+  - MLS Cup (`MLS_CUP`): single-leg cross-conference final at the
+    higher seed
+  - Champion (`MLS_CUP_WINNER`): synthetic depth, the cup winner
+
+Per-stage series-length routing via `_series_length_for_stage` —
+inherited from PR #51 (Phase F's BestOfNSeriesSource extension that
+NCAA Baseball uses for the mixed Super Regional / MCWS Final bracket).
+The same hook handles MLS's mix of best-of-3 R1 and single-leg
+everything-else cleanly.
+
+ESPN slug → stage mapping reflects the per-conference tagging on
+ESPN's MLS scoreboard:
+
+| ESPN season.slug                              | Stage label  |
+|-----------------------------------------------|--------------|
+| {eastern,western}-conference-playoffs---wild-card     | MLS_WC      |
+| {eastern,western}-conference-playoffs---round-one     | MLS_R1      |
+| {eastern,western}-conference-playoffs---semifinals    | MLS_CSF     |
+| {eastern,western}-conference-playoffs---final         | MLS_CF      |
+| mls-cup                                                | MLS_CUP     |
+
+Strength sharing: `set_regular_season_strengths` lets the plugin seed
+playoff goal-scoring rates from `MlsEastSource` / `MlsWestSource`
+(issue #30 part A). Without the seed, sample_result falls back to the
+1.4/1.4 league-average prior.
+
+Best-of-3 matchday inference: ESPN doesn't tag MLS R1 events with a
+game number on the event object — the `competition.notes[0].headline`
+carries series state ("LA leads series 1-0") but not the specific
+game index. Matchday is inferred from chronological ordering within
+each (stage, frozenset(participants)) tuple in `_fetch_bracket_games`,
+matching the order ESPN publishes them. BestOfNSeriesSource's state
+machine then groups them into the right tie via the matchday counter
+and resolves the series-clinch threshold (2 wins for best-of-3) via
+`_series_length_for_stage("MLS_R1") == 3`.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+import requests
+
+from .base import GameRow, MatchResult
+from .bracket import BestOfNSeriesSource
+from .._util import parse_iso_utc, poisson_sample as _poisson
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.mls_cup")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/soccer/usa.1"
+
+# Tournament window: MLS playoffs run late October (Wild Card / R1)
+# through early December (MLS Cup Final). Walking Oct 1 - Dec 15 covers
+# both ends with margin.
+PLAYOFF_START_MONTH = 10
+PLAYOFF_END_MONTH = 12
+PLAYOFF_END_DAY = 15
+
+# Default per-team goal scoring/conceding rate prior. Matches the
+# MlsStandingsSourceBase prior (modern MLS ~1.4 goals/team/game) so
+# the regular-season → playoff strength seed lines up consistently.
+_DEFAULT_GOALS_FOR = 1.4
+_DEFAULT_GOALS_AGAINST = 1.4
+
+# Per-stage best-of-N. The R1 best-of-3 is the only deviation from
+# single-leg everything-else. SERIES_LENGTH=1 is the class fallback so
+# any unmodeled stage clinches in 1 game by default (defense in depth
+# against ESPN adding a new slug we haven't routed yet).
+_MLS_SERIES_LENGTHS: Dict[str, int] = {
+    "MLS_WC":  1,
+    "MLS_R1":  3,
+    "MLS_CSF": 1,
+    "MLS_CF":  1,
+    "MLS_CUP": 1,
+}
+
+# ESPN `season.slug` -> MLS bracket stage. Both conferences share the
+# slug-suffix pattern (eastern-conference-playoffs---X vs western-
+# conference-playoffs---X); the cross-conference MLS Cup Final uses
+# its own `mls-cup` slug with no conference prefix. DO NOT consolidate
+# the East/West entries; explicit keys keep the parser table
+# self-documenting and a slug rename will fail loudly here rather than
+# silently misroute one conference's bracket.
+SLUG_TO_STAGE: Dict[str, str] = {
+    "eastern-conference-playoffs---wild-card":  "MLS_WC",
+    "western-conference-playoffs---wild-card":  "MLS_WC",
+    "eastern-conference-playoffs---round-one":  "MLS_R1",
+    "western-conference-playoffs---round-one":  "MLS_R1",
+    "eastern-conference-playoffs---semifinals": "MLS_CSF",
+    "western-conference-playoffs---semifinals": "MLS_CSF",
+    "eastern-conference-playoffs---final":      "MLS_CF",
+    "western-conference-playoffs---final":      "MLS_CF",
+    "mls-cup":                                   "MLS_CUP",
+}
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Any]:
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[mls_cup] %s -> %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[mls_cup] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """ESPN soccer returns `team.displayName` ("Atlanta United FC",
+    "LA Galaxy"). Same canonicalizer as MlsStandingsSourceBase /
+    MlsSource so the cross-source team-name join (regular-season
+    strength seed → playoff teams) holds without name drift."""
+    name = (team_obj.get("displayName") or "").strip()
+    if name:
+        return name
+    return (team_obj.get("name") or team_obj.get("abbreviation") or "").strip()
+
+
+def _default_season_year() -> int:
+    """MLS season is named by the calendar year. Pre-October reads as
+    the prior season's playoffs (which wrap in early December — January
+    onward is offseason). Post-October reads as the current calendar
+    year's playoffs in progress.
+    """
+    now = datetime.now(timezone.utc)
+    return now.year if now.month >= PLAYOFF_START_MONTH else now.year - 1
+
+
+class MlsCupSource(BestOfNSeriesSource):
+    """MLS Cup playoff bracket as a BestOfNSeriesSource with per-stage
+    series lengths. R1 best-of-3, all other stages single-leg
+    (SERIES_LENGTH=1). Bracket cascade flows:
+
+      MLS_WC (entry) → MLS_R1 → MLS_CSF → MLS_CF → MLS_CUP → MLS_CUP_WINNER
+
+    Wild Card is the entry stage in modern MLS playoffs (since the 2024
+    14-9 format expanded the field). Teams with a R1 bye (top 7 seeds
+    of each conference) skip the WC tier — their `round_reached` enters
+    at MLS_R1 depth.
+    """
+
+    KO_STAGES = ("MLS_WC", "MLS_R1", "MLS_CSF", "MLS_CF", "MLS_CUP")
+    SERIES_LENGTH = 1  # fallback when a stage slips out of _MLS_SERIES_LENGTHS
+    supports_importance = True
+
+    def __init__(self, season_year: Optional[int] = None) -> None:
+        self.season_year = season_year or _default_season_year()
+        self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
+        self._team_strengths_from_regular: Optional[
+            Dict[str, Dict[str, float]]
+        ] = None
+
+    @property
+    def sport_prefix(self) -> str:
+        return "MLS"
+
+    @property
+    def sport_label(self) -> str:
+        return "MLS Cup Playoffs"
+
+    def _league_context_code(self) -> str:
+        return "MLS_PO"
+
+    def _series_length_for_stage(self, stage: str) -> int:
+        # R1 = best-of-3, everything else = single-leg.
+        return _MLS_SERIES_LENGTHS.get(stage, self.SERIES_LENGTH)
+
+    def _winner_advance_label(self, stage: str) -> Optional[str]:
+        # MLS Cup winner → MLS_CUP_WINNER synthetic depth. All other
+        # stages flow into the next KO_STAGES entry via the base class
+        # `_round_reached` cascade.
+        if stage == "MLS_CUP":
+            return "MLS_CUP_WINNER"
+        return None
+
+    # ---------- strength sharing ----------
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        """Per-team scoring/conceding rate, seeded from the regular-
+        season MlsEastSource + MlsWestSource via
+        `set_regular_season_strengths` (the plugin merges both
+        conferences' strengths into one dict before seeding). Without
+        the seed, falls back to the league-average prior."""
+        if self._team_strengths_from_regular is not None:
+            return self._team_strengths_from_regular
+        return {}
+
+    def set_regular_season_strengths(
+        self, strengths: Dict[str, Dict[str, float]],
+    ) -> None:
+        """Plugin hook to seed per-team scoring rates from the
+        regular-season sources. Pass the merged East + West strength
+        dict; the playoff sampler doesn't care which conference a
+        team came from since MLS Cup is a cross-conference final."""
+        self._team_strengths_from_regular = strengths
+
+    def _strength_for(
+        self, strengths: Dict[str, Dict[str, float]], team: str,
+    ) -> Dict[str, float]:
+        if team in strengths:
+            return strengths[team]
+        return {
+            "pf_per_game": _DEFAULT_GOALS_FOR,
+            "pa_per_game": _DEFAULT_GOALS_AGAINST,
+        }
+
+    # ---------- sample_result (force a winner — bracket games) ----------
+
+    def sample_result(
+        self,
+        state: Dict[str, Any],
+        match: GameRow,
+        strengths: Dict[str, Dict[str, float]],
+        rng: random.Random,
+    ) -> MatchResult:
+        """Bracket games CANNOT end in draws — MLS postseason goes to
+        OT then PKs if needed. Same shape as NcaaSoccerCupSource's
+        sample_result and distinct from the regular-season
+        MlsStandingsSourceBase sample_result which allows draws (1
+        standings point each). DO NOT borrow the regular-season
+        sampler here; bracket cascades require deterministic winners.
+        """
+        del state  # interface-required, per-game classification only
+        h = self._strength_for(strengths, match.home)
+        a = self._strength_for(strengths, match.away)
+        lam_home = max(0.05, (h["pf_per_game"] + a["pa_per_game"]) / 2.0)
+        lam_away = max(0.05, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
+        home_goals = _poisson(lam_home, rng)
+        away_goals = _poisson(lam_away, rng)
+        if home_goals == away_goals:
+            # PK shootouts are roughly coin-flips at the MLS level —
+            # no additional bias beyond the Poisson means.
+            if rng.random() < 0.5:
+                home_goals += 1
+            else:
+                away_goals += 1
+        return MatchResult(home_goals=home_goals, away_goals=away_goals)
+
+    # ---------- fetch_upcoming (EPG display side) ----------
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Emit upcoming playoff bracket games. Per-day sweep with the
+        same slug filter that `_fetch_bracket_games` uses — only events
+        whose `season.slug` is in `SLUG_TO_STAGE` surface here, so
+        regular-season games (filtered out earlier in `MlsEastSource` /
+        `MlsWestSource`) don't reappear via this source.
+        """
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(
+                f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}"
+            )
+            if not isinstance(data, dict):
+                continue
+            for event in data.get("events") or []:
+                rec = self._extract_bracket_record(event, matchday=1)
+                if rec is None:
+                    continue
+                eid = rec.get("game_id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "espn_event_id": eid,
+                        "fd_competition_code": self._league_context_code(),
+                        "stage": rec.get("stage"),
+                    },
+                ))
+        return out
+
+    # ---------- _fetch_bracket_games (importance side) ----------
+
+    def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
+        """Pull the playoff window (Oct 1 - Dec 15 of season_year) and
+        emit one canonical record per bracket game. Matchday inference
+        for best-of-3 series: walk dates ascending and count games per
+        (stage, frozenset(participants)) tuple — first chronological
+        appearance is game 1, second is game 2, third is game 3.
+        Single-leg stages always emit matchday=1.
+
+        Single-game-elim stages (MLS_WC, MLS_CSF, MLS_CF, MLS_CUP) also
+        need PK dedup. ESPN sometimes publishes two events when a game
+        goes to PKs (one with the regulation tie, one with the PK
+        result) — see `_dedupe_pk_shootout_pairs` in
+        `ncaa_soccer_cup.py` for the same shape. We import that helper
+        rather than re-implementing; the dedup criterion is sport-
+        agnostic for single-game-elim brackets.
+
+        Best-of-3 stages are NOT deduped on (stage, participants) —
+        the same teams legitimately play 2-3 games in a series, so
+        collapsing them would lose the matchday cascade. PK dedup is
+        applied per-matchday inside the best-of-3 grouping.
+        """
+        if self._bracket_games_cache is not None:
+            return self._bracket_games_cache
+
+        # First pass: collect all candidate records in chronological
+        # order. Walk Oct 1 - Dec 15 of season_year.
+        candidates: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        start = datetime(
+            self.season_year, PLAYOFF_START_MONTH, 1, tzinfo=timezone.utc,
+        ).date()
+        end = datetime(
+            self.season_year, PLAYOFF_END_MONTH, PLAYOFF_END_DAY,
+            tzinfo=timezone.utc,
+        ).date()
+        day = start
+        while day <= end:
+            data = _http_get(
+                f"{ESPN_BASE}/scoreboard?dates={day.strftime('%Y%m%d')}"
+            )
+            if isinstance(data, dict):
+                for event in data.get("events") or []:
+                    # Pass matchday=None — the inference loop below
+                    # assigns it per (stage, participants) tuple.
+                    rec = self._extract_bracket_record(event, matchday=None)
+                    if rec is None or rec["game_id"] is None:
+                        continue
+                    if rec["game_id"] in seen_ids:
+                        continue
+                    seen_ids.add(rec["game_id"])
+                    candidates.append(rec)
+            day += timedelta(days=1)
+
+        # Second pass: matchday inference for best-of-3 series + PK
+        # dedup for single-leg stages.
+        out = _assign_matchdays_and_dedupe(candidates, _MLS_SERIES_LENGTHS)
+        self._bracket_games_cache = out
+        return out
+
+    @staticmethod
+    def _extract_bracket_record(
+        event: Dict[str, Any],
+        matchday: Optional[int],
+    ) -> Optional[Dict[str, Any]]:
+        """Convert one ESPN MLS scoreboard event into the canonical
+        per-game record. Returns None if the event's `season.slug`
+        isn't a playoff slug (filters regular-season games).
+
+        `matchday` is passed in: for fetch_upcoming we pass 1 (UI emit
+        doesn't need the series ordering); for _fetch_bracket_games
+        we pass None and infer matchday from chronological order in
+        `_assign_matchdays_and_dedupe`.
+        """
+        season = event.get("season") or {}
+        slug = (season.get("slug") or "").strip().lower()
+        stage = SLUG_TO_STAGE.get(slug)
+        if stage is None:
+            return None
+
+        comps = event.get("competitions") or []
+        if not comps:
+            return None
+        comp = comps[0]
+        competitors = comp.get("competitors") or []
+        if len(competitors) != 2:
+            return None
+        home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+        away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+        if home is None or away is None:
+            return None
+        home_team = _team_canonical_name(home.get("team") or {})
+        away_team = _team_canonical_name(away.get("team") or {})
+        if not home_team or not away_team:
+            return None
+
+        status_type = (comp.get("status") or {}).get("type") or {}
+        completed = bool(status_type.get("completed"))
+        state = (status_type.get("state") or "").lower()
+        # ESPN publishes phantom placeholder games for best-of-3
+        # series that clinch in 2 games — the unnecessary game-3
+        # has state="post" + completed=False + score=0-0. Skip
+        # these entirely; emitting them (even as SCHEDULED) would
+        # inject a never-going-to-happen game into the simulator's
+        # remaining_matches list and confuse the series-clinch
+        # cascade. Observed live on the 2024 R1 Colorado @ LA
+        # Galaxy series: event 722587 has state="post" but
+        # completed=False because the series ended at game 2. DO
+        # NOT relax this gate without re-verifying against a
+        # season where ESPN's phantom-game shape has changed.
+        if state == "post" and not completed:
+            return None
+        is_final = completed
+        status = "FINISHED" if is_final else "SCHEDULED"
+
+        try:
+            hg = int(home.get("score")) if is_final else None
+        except (TypeError, ValueError):
+            hg = None
+        try:
+            ag = int(away.get("score")) if is_final else None
+        except (TypeError, ValueError):
+            ag = None
+
+        if is_final and (hg is None or ag is None):
+            status = "SCHEDULED"
+            hg = None
+            ag = None
+
+        return {
+            "game_id": event.get("id"),
+            "stage": stage,
+            "matchday": matchday,  # may be None — inference assigns later
+            "home": home_team,
+            "away": away_team,
+            "home_goals": hg,
+            "away_goals": ag,
+            "status": status,
+            "start_time": parse_iso_utc(event.get("date")),
+            "extra": {"season_slug": slug},
+        }
+
+
+def _dedupe_pk_shootout_pairs(
+    records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Collapse multiple events at the same (stage, participants) tuple
+    into the single decisive event. ESPN occasionally publishes two
+    records for a soccer bracket game that goes to OT / PKs: one with
+    the regulation tie (e.g., 0-0) and a second with the PK shootout
+    final score (e.g., 3-2). Both can show up as FINISHED records.
+
+    NOTE: this is duplicated from `sources/ncaa_soccer_cup.py` while
+    issues #24 and #30 part B land as independent PRs. Once both
+    merge, the helper will be extracted to a shared module and both
+    call sites updated — DO NOT diverge the two implementations in
+    the meantime. Tracked in #69.
+
+    Preference order when multiple records collide on (stage,
+    frozenset(home, away)):
+      1. SCHEDULED records lose to any FINISHED record.
+      2. Among FINISHED records, non-tie outcomes beat tie outcomes.
+      3. Among non-tie FINISHED records, the LATEST start_time wins.
+    """
+    buckets: Dict[Tuple[str, FrozenSet[str]], List[Dict[str, Any]]] = {}
+    for rec in records:
+        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
+        buckets.setdefault(key, []).append(rec)
+
+    out: List[Dict[str, Any]] = []
+    for key, bucket in buckets.items():
+        if len(bucket) == 1:
+            out.append(bucket[0])
+            continue
+        out.append(_pick_decisive_event(bucket))
+    return out
+
+
+def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Apply the (FINISHED > SCHEDULED, non-tie > tie, latest > earliest)
+    preference order. Bucket has 2+ records guaranteed.
+    """
+    finished = [r for r in bucket if r.get("status") == "FINISHED"]
+    if not finished:
+        return max(
+            bucket,
+            key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
+        )
+    non_tie = [
+        r for r in finished
+        if r.get("home_goals") is not None
+        and r.get("away_goals") is not None
+        and r["home_goals"] != r["away_goals"]
+    ]
+    pool = non_tie if non_tie else finished
+    return max(
+        pool,
+        key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
+    )
+
+
+def _assign_matchdays_and_dedupe(
+    candidates: List[Dict[str, Any]],
+    series_lengths: Dict[str, int],
+) -> List[Dict[str, Any]]:
+    """Two-stage post-processor for the chronologically-ordered
+    candidate game list:
+
+      1. For best-of-N stages (`series_lengths[stage] > 1`): assign
+         matchday by counting per (stage, frozenset(participants))
+         occurrence in chronological order. First match in a series
+         = matchday 1, second = 2, etc.
+
+      2. For single-leg stages (`series_lengths[stage] == 1`): collapse
+         PK-shootout pairs via the same `_dedupe_pk_shootout_pairs`
+         logic from ncaa_soccer_cup. Imported here rather than
+         duplicated; the criterion ("two finished events at the same
+         single-leg stage with the same teams must be the regulation
+         tie + PK result, so keep the non-tie one") is sport-agnostic.
+
+    Returns the merged list with matchday assigned for all records.
+    Best-of-N records carry their inferred 1/2/3 matchday; single-leg
+    records carry matchday=1.
+    """
+    # Sort candidates by start_time (ascending) so matchday inference
+    # follows real chronological order, not insertion-order of the
+    # day-by-day fetch loop. None start_times sort last (defensive
+    # against malformed events).
+    def _sort_key(rec: Dict[str, Any]) -> datetime:
+        st = rec.get("start_time")
+        if isinstance(st, datetime):
+            return st
+        return datetime.max.replace(tzinfo=timezone.utc)
+
+    candidates_sorted = sorted(candidates, key=_sort_key)
+
+    # Bucket by stage so single-leg vs best-of-N can be handled separately.
+    single_leg: List[Dict[str, Any]] = []
+    best_of_n: List[Dict[str, Any]] = []
+    for rec in candidates_sorted:
+        stage = rec["stage"]
+        length = series_lengths.get(stage, 1)
+        if length > 1:
+            best_of_n.append(rec)
+        else:
+            single_leg.append(rec)
+
+    # Best-of-N: assign matchday by counting per (stage, participants).
+    counters: Dict[Tuple[str, FrozenSet[str]], int] = defaultdict(int)
+    for rec in best_of_n:
+        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
+        counters[key] += 1
+        rec["matchday"] = counters[key]
+
+    # Single-leg: enforce matchday=1 (the second pass below dedupes
+    # any PK-shootout pair).
+    for rec in single_leg:
+        rec["matchday"] = 1
+    deduped_single = _dedupe_pk_shootout_pairs(single_leg)
+
+    return deduped_single + best_of_n

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -5634,6 +5634,527 @@ class TestMlsStandingsConferenceFilter:
 
 
 # =====================================================================
+# Issue #30 part B: MLS Cup playoff bracket (mixed format)
+# =====================================================================
+
+class TestMlsCupSourceIdentity:
+
+    @staticmethod
+    def _make(bracket_games=None):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        src = MlsCupSource(season_year=2024)
+        src._bracket_games_cache = bracket_games or []
+        return src
+
+    def test_identity(self):
+        src = self._make()
+        assert src.sport_prefix == "MLS"
+        assert "Cup" in src.sport_label
+        assert src._league_context_code() == "MLS_PO"
+
+    def test_supports_importance(self):
+        assert self._make().supports_importance is True
+
+    def test_ko_stages(self):
+        # MLS-prefixed labels avoid depth collision with NHL "R1" at
+        # depth 0 or MLB "WC" at depth 0.
+        assert self._make().KO_STAGES == (
+            "MLS_WC", "MLS_R1", "MLS_CSF", "MLS_CF", "MLS_CUP",
+        )
+
+    def test_series_lengths_match_mls_format(self):
+        """Mixed format: WC, CSF, CF, MLS_CUP are single-leg; R1 is
+        best-of-3 (clinches at 2 wins). Pin all five — a regression
+        to uniform best-of-N would silently misclassify clinches."""
+        src = self._make()
+        assert src._series_length_for_stage("MLS_WC") == 1
+        assert src._series_length_for_stage("MLS_R1") == 3
+        assert src._series_length_for_stage("MLS_CSF") == 1
+        assert src._series_length_for_stage("MLS_CF") == 1
+        assert src._series_length_for_stage("MLS_CUP") == 1
+        assert src._series_length_for_stage("UNKNOWN") == 1  # fallback
+        assert src._clinching_wins_for_stage("MLS_WC") == 1
+        assert src._clinching_wins_for_stage("MLS_R1") == 2
+        assert src._clinching_wins_for_stage("MLS_CUP") == 1
+
+    def test_winner_advance_label(self):
+        src = self._make()
+        assert src._winner_advance_label("MLS_CUP") == "MLS_CUP_WINNER"
+        assert src._winner_advance_label("MLS_CF") is None
+        assert src._winner_advance_label("MLS_R1") is None
+
+
+class TestMlsCupContexts:
+
+    def test_mls_po_exists_and_is_knockout(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        assert "MLS_PO" in LEAGUE_CONTEXTS
+        assert LEAGUE_CONTEXTS["MLS_PO"].format == "knockout"
+
+    def test_thresholds_use_mls_prefixed_stages(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        ctx = LEAGUE_CONTEXTS["MLS_PO"]
+        stages = [stage for stage, _, _ in ctx.thresholds]
+        assert stages == [
+            "MLS_R1", "MLS_CSF", "MLS_CF", "MLS_CUP", "MLS_CUP_WINNER",
+        ]
+
+    def test_outcome_labels(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        labels = MlsCupSource().outcome_labels
+        for expected in (
+            "round_one", "conf_semis", "conf_final",
+            "mls_cup_final", "mls_cup_winner",
+        ):
+            assert expected in labels, f"missing {expected!r}; got {labels}"
+
+    def test_thresholds_are_depth_ordered(self):
+        from dispatcharr_ranked_matchups.scoring import (
+            LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH,
+        )
+        ctx = LEAGUE_CONTEXTS["MLS_PO"]
+        depths = [KNOCKOUT_ROUND_DEPTH[s] for s, _, _ in ctx.thresholds]
+        for i in range(len(depths) - 1):
+            assert depths[i] < depths[i + 1]
+
+    def test_weights_are_monotonic_increasing(self):
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+        weights = [w for _, _, w in LEAGUE_CONTEXTS["MLS_PO"].thresholds]
+        for i in range(len(weights) - 1):
+            assert weights[i] < weights[i + 1]
+
+    def test_mls_specific_depths_present(self):
+        # Every MLS-prefixed stage label must have a KNOCKOUT_ROUND_DEPTH
+        # entry; missing one would silently return -1 from the lookup
+        # and the cascade would silently no-op for that stage.
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        for stage in ("MLS_WC", "MLS_R1", "MLS_CSF", "MLS_CF",
+                      "MLS_CUP", "MLS_CUP_WINNER"):
+            assert stage in KNOCKOUT_ROUND_DEPTH, (
+                f"MLS_PO uses {stage} but KNOCKOUT_ROUND_DEPTH lacks it"
+            )
+
+
+class TestMlsCupSlugRouting:
+
+    def test_slug_to_stage_covers_both_conferences(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import SLUG_TO_STAGE
+        assert SLUG_TO_STAGE["eastern-conference-playoffs---wild-card"] == "MLS_WC"
+        assert SLUG_TO_STAGE["western-conference-playoffs---wild-card"] == "MLS_WC"
+        assert SLUG_TO_STAGE["eastern-conference-playoffs---round-one"] == "MLS_R1"
+        assert SLUG_TO_STAGE["western-conference-playoffs---round-one"] == "MLS_R1"
+        assert SLUG_TO_STAGE["eastern-conference-playoffs---semifinals"] == "MLS_CSF"
+        assert SLUG_TO_STAGE["western-conference-playoffs---semifinals"] == "MLS_CSF"
+        assert SLUG_TO_STAGE["eastern-conference-playoffs---final"] == "MLS_CF"
+        assert SLUG_TO_STAGE["western-conference-playoffs---final"] == "MLS_CF"
+        assert SLUG_TO_STAGE["mls-cup"] == "MLS_CUP"
+
+    def test_extract_filters_regular_season(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        event = {
+            "id": "reg-1",
+            "date": "2024-08-15T19:00:00Z",
+            "season": {"slug": "regular-season"},
+            "competitions": [{
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"displayName": "Atlanta United FC"}, "score": "2"},
+                    {"homeAway": "away", "team": {"displayName": "Inter Miami CF"}, "score": "1"},
+                ],
+            }],
+        }
+        assert MlsCupSource._extract_bracket_record(event, matchday=1) is None
+
+    def test_extract_filters_phantom_best_of_3_game(self):
+        """ESPN publishes a phantom game-3 (state=post, completed=False,
+        score=0-0) for best-of-3 series that clinch in 2 games. These
+        MUST be filtered out — pinning against the live shape observed
+        on event 722587 in the 2024 R1 (LA Galaxy / Colorado series
+        clinched in 2 games; ESPN's game-3 slot was state=post +
+        completed=False).
+        """
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        phantom = {
+            "id": "722587",
+            "date": "2024-11-09T22:00:00Z",
+            "season": {"slug": "western-conference-playoffs---round-one"},
+            "competitions": [{
+                "status": {"type": {"completed": False, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"displayName": "LA Galaxy"}, "score": "0", "winner": False},
+                    {"homeAway": "away", "team": {"displayName": "Colorado Rapids"}, "score": "0", "winner": False},
+                ],
+            }],
+        }
+        assert MlsCupSource._extract_bracket_record(phantom, matchday=None) is None
+
+    def test_extract_keeps_legitimate_finished_game(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        event = {
+            "id": "722574",
+            "date": "2024-10-26T19:00:00Z",
+            "season": {"slug": "eastern-conference-playoffs---round-one"},
+            "competitions": [{
+                "status": {"type": {"completed": True, "state": "post"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"displayName": "Atlanta United FC"}, "score": "1"},
+                    {"homeAway": "away", "team": {"displayName": "Inter Miami CF"}, "score": "2"},
+                ],
+            }],
+        }
+        rec = MlsCupSource._extract_bracket_record(event, matchday=1)
+        assert rec is not None
+        assert rec["stage"] == "MLS_R1"
+        assert rec["status"] == "FINISHED"
+        assert rec["home_goals"] == 1
+        assert rec["away_goals"] == 2
+
+    def test_extract_keeps_scheduled_game(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        event = {
+            "id": "future-1",
+            "date": "2030-10-26T19:00:00Z",
+            "season": {"slug": "eastern-conference-playoffs---round-one"},
+            "competitions": [{
+                "status": {"type": {"completed": False, "state": "pre"}},
+                "competitors": [
+                    {"homeAway": "home", "team": {"displayName": "Atlanta United FC"}},
+                    {"homeAway": "away", "team": {"displayName": "Inter Miami CF"}},
+                ],
+            }],
+        }
+        rec = MlsCupSource._extract_bracket_record(event, matchday=None)
+        assert rec is not None
+        assert rec["status"] == "SCHEDULED"
+        assert rec["home_goals"] is None
+        assert rec["away_goals"] is None
+
+
+class TestMlsCupMatchdayInference:
+    """Best-of-3 R1 series get matchdays inferred from chronological
+    order; single-leg stages get matchday=1 + PK dedup."""
+
+    def test_best_of_3_assigns_matchdays_1_2_3(self):
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            _assign_matchdays_and_dedupe, _MLS_SERIES_LENGTHS,
+        )
+        games = [
+            {"game_id": "1", "stage": "MLS_R1", "matchday": None,
+             "home": "LA", "away": "COL", "home_goals": 5, "away_goals": 0,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 10, 27, tzinfo=timezone.utc),
+             "extra": {}},
+            {"game_id": "2", "stage": "MLS_R1", "matchday": None,
+             "home": "COL", "away": "LA", "home_goals": 4, "away_goals": 1,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 11, 2, tzinfo=timezone.utc),
+             "extra": {}},
+            {"game_id": "3", "stage": "MLS_R1", "matchday": None,
+             "home": "LA", "away": "COL", "home_goals": 2, "away_goals": 0,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 11, 10, tzinfo=timezone.utc),
+             "extra": {}},
+        ]
+        out = _assign_matchdays_and_dedupe(games, _MLS_SERIES_LENGTHS)
+        by_id = {g["game_id"]: g for g in out}
+        assert by_id["1"]["matchday"] == 1
+        assert by_id["2"]["matchday"] == 2
+        assert by_id["3"]["matchday"] == 3
+
+    def test_single_leg_stages_get_matchday_one(self):
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            _assign_matchdays_and_dedupe, _MLS_SERIES_LENGTHS,
+        )
+        games = [
+            {"game_id": "cup-1", "stage": "MLS_CUP", "matchday": None,
+             "home": "LA", "away": "NY", "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 12, 7, tzinfo=timezone.utc),
+             "extra": {}},
+            {"game_id": "wc-1", "stage": "MLS_WC", "matchday": None,
+             "home": "A", "away": "B", "home_goals": 1, "away_goals": 0,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 10, 23, tzinfo=timezone.utc),
+             "extra": {}},
+        ]
+        out = _assign_matchdays_and_dedupe(games, _MLS_SERIES_LENGTHS)
+        for g in out:
+            assert g["matchday"] == 1
+
+    def test_single_leg_pk_shootout_pair_collapses(self):
+        """A regulation 0-0 + a PK shootout result at the same
+        single-leg stage collapses to the non-tie record (reusing
+        the helper from ncaa_soccer_cup)."""
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            _assign_matchdays_and_dedupe, _MLS_SERIES_LENGTHS,
+        )
+        regulation_tie = {
+            "game_id": "csf-tie", "stage": "MLS_CSF", "matchday": None,
+            "home": "A", "away": "B", "home_goals": 0, "away_goals": 0,
+            "status": "FINISHED",
+            "start_time": datetime(2024, 11, 24, 0, 0, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        pk_result = {
+            "game_id": "csf-pk", "stage": "MLS_CSF", "matchday": None,
+            "home": "A", "away": "B", "home_goals": 1, "away_goals": 0,
+            "status": "FINISHED",
+            "start_time": datetime(2024, 11, 24, 1, 0, tzinfo=timezone.utc),
+            "extra": {},
+        }
+        out = _assign_matchdays_and_dedupe(
+            [regulation_tie, pk_result], _MLS_SERIES_LENGTHS,
+        )
+        assert len(out) == 1
+        assert out[0]["game_id"] == "csf-pk"
+
+    def test_best_of_3_does_not_dedupe_legitimate_repeats(self):
+        """Same teams playing 2-3 games in a best-of-3 series must
+        NOT be collapsed by the PK dedup — pin so a future refactor
+        doesn't accidentally apply dedup to best-of-N stages."""
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            _assign_matchdays_and_dedupe, _MLS_SERIES_LENGTHS,
+        )
+        games = [
+            {"game_id": "g1", "stage": "MLS_R1", "matchday": None,
+             "home": "A", "away": "B", "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 10, 27, tzinfo=timezone.utc),
+             "extra": {}},
+            {"game_id": "g2", "stage": "MLS_R1", "matchday": None,
+             "home": "B", "away": "A", "home_goals": 1, "away_goals": 0,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 11, 2, tzinfo=timezone.utc),
+             "extra": {}},
+        ]
+        out = _assign_matchdays_and_dedupe(games, _MLS_SERIES_LENGTHS)
+        assert len(out) == 2
+
+
+class TestMlsCupCascade:
+    """A team that wins WC → R1 (best-of-3) → CSF → CF → MLS_CUP
+    reaches MLS_CUP_WINNER depth with the full band cascade."""
+
+    @staticmethod
+    def _make(bracket_games):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        src = MlsCupSource(season_year=2024)
+        src._bracket_games_cache = bracket_games
+        return src
+
+    def test_champion_from_wild_card_cascade(self):
+        from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
+        games = [
+            # WC: single-leg
+            {"game_id": "wc", "stage": "MLS_WC", "matchday": 1,
+             "home": "Champion", "away": "Eight",
+             "home_goals": 1, "away_goals": 0,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # R1: best-of-3, Champion wins games 1 + 2 → clinches at 2 wins
+            {"game_id": "r1g1", "stage": "MLS_R1", "matchday": 1,
+             "home": "Champion", "away": "Seven",
+             "home_goals": 2, "away_goals": 0,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            {"game_id": "r1g2", "stage": "MLS_R1", "matchday": 2,
+             "home": "Seven", "away": "Champion",
+             "home_goals": 0, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # CSF: single-leg
+            {"game_id": "csf", "stage": "MLS_CSF", "matchday": 1,
+             "home": "Champion", "away": "Four",
+             "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # CF: single-leg
+            {"game_id": "cf", "stage": "MLS_CF", "matchday": 1,
+             "home": "Champion", "away": "Two",
+             "home_goals": 1, "away_goals": 0,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+            # MLS Cup: single-leg
+            {"game_id": "cup", "stage": "MLS_CUP", "matchday": 1,
+             "home": "Champion", "away": "Final",
+             "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED", "start_time": None, "extra": {}},
+        ]
+        src = self._make(games)
+        state = src.initial_state()
+        rr = state["_round_reached"]
+        assert rr["Champion"] == KNOCKOUT_ROUND_DEPTH["MLS_CUP_WINNER"]
+        assert rr["Final"] == KNOCKOUT_ROUND_DEPTH["MLS_CUP"]
+        outcomes = src.terminal_outcomes(state)
+        bands = outcomes["Champion"]
+        for expected in (
+            "round_one", "conf_semis", "conf_final",
+            "mls_cup_final", "mls_cup_winner",
+        ):
+            assert expected in bands, f"missing {expected!r}; got {bands}"
+
+
+class TestMlsCupSampleResultNoDraws:
+    """Bracket games go to OT then PKs — sample_result must force a winner."""
+
+    def test_sample_result_never_produces_ties(self):
+        import random
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        src = MlsCupSource(season_year=2024)
+        strengths = {
+            "LA": {"pf_per_game": 1.4, "pa_per_game": 1.4},
+            "NY": {"pf_per_game": 1.4, "pa_per_game": 1.4},
+        }
+        gr = GameRow(
+            sport_prefix="MLS", sport_label="MLS Cup Playoffs",
+            home="LA", away="NY", rank_home=None, rank_away=None,
+            start_time=datetime(2024, 12, 7, tzinfo=timezone.utc),
+        )
+        rng = random.Random(42)
+        ties = 0
+        for _ in range(200):
+            res = src.sample_result({}, gr, strengths, rng)
+            if res.home_goals == res.away_goals:
+                ties += 1
+        assert ties == 0
+
+
+class TestMlsCupFetchUpcoming:
+    """fetch_upcoming surfaces only playoff bracket games (not regular-
+    season). Pin via stub so a slug-table regression surfaces here."""
+
+    def test_fetch_upcoming_emits_only_bracket_games(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import mls_cup as mod
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        calls = {"n": 0}
+        def fake_get(url, *_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] != 1:
+                return {"events": []}
+            return {"events": [
+                # Scheduled bracket game — should emit.
+                {"id": "playoff-1", "date": "2030-10-26T19:00:00Z",
+                 "season": {"slug": "eastern-conference-playoffs---round-one"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "Atlanta United FC"}},
+                         {"homeAway": "away", "team": {"displayName": "Inter Miami CF"}},
+                     ],
+                 }]},
+                # Regular-season game — must be filtered out.
+                {"id": "regular-1", "date": "2030-10-26T22:00:00Z",
+                 "season": {"slug": "regular-season"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "pre"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "LA Galaxy"}},
+                         {"homeAway": "away", "team": {"displayName": "LAFC"}},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        src = MlsCupSource()
+        games = src.fetch_upcoming(days_ahead=0)
+        ids = {(g.extra or {}).get("espn_event_id") for g in games}
+        assert ids == {"playoff-1"}, (
+            f"only bracket-slug games should emit, got {ids}"
+        )
+        assert games[0].extra["stage"] == "MLS_R1"
+        assert games[0].extra["fd_competition_code"] == "MLS_PO"
+
+    def test_fetch_upcoming_filters_phantom_games(self, monkeypatch):
+        """The EPG emit side must apply the same phantom-game filter
+        as _fetch_bracket_games so unnecessary best-of-3 game-3 slots
+        don't appear in the user's Top Matchups guide either."""
+        from dispatcharr_ranked_matchups.sources import mls_cup as mod
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        calls = {"n": 0}
+        def fake_get(url, *_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] != 1:
+                return {"events": []}
+            return {"events": [
+                # Phantom game-3: state=post, completed=False, 0-0.
+                {"id": "phantom-g3", "date": "2030-11-09T22:00:00Z",
+                 "season": {"slug": "western-conference-playoffs---round-one"},
+                 "competitions": [{
+                     "status": {"type": {"completed": False, "state": "post"}},
+                     "competitors": [
+                         {"homeAway": "home", "team": {"displayName": "LA Galaxy"}, "score": "0"},
+                         {"homeAway": "away", "team": {"displayName": "Colorado Rapids"}, "score": "0"},
+                     ],
+                 }]},
+            ]}
+        monkeypatch.setattr(mod, "_http_get", fake_get)
+        src = MlsCupSource()
+        games = src.fetch_upcoming(days_ahead=0)
+        assert games == [], (
+            "phantom game-3 must not appear in fetch_upcoming output"
+        )
+
+
+class TestMlsCupMatchdayInferenceDefensive:
+    """Matchday inference sort key handles missing start_time by sorting
+    such records to the end (datetime.max). Pin so a malformed event
+    with no start_time doesn't crash the day-loop or scramble matchday
+    ordering for adjacent legitimate games."""
+
+    def test_missing_start_time_does_not_crash(self):
+        from datetime import datetime, timezone
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            _assign_matchdays_and_dedupe, _MLS_SERIES_LENGTHS,
+        )
+        # One legit game + one with no start_time at the same stage.
+        games = [
+            {"game_id": "g1", "stage": "MLS_R1", "matchday": None,
+             "home": "A", "away": "B", "home_goals": 2, "away_goals": 1,
+             "status": "FINISHED",
+             "start_time": datetime(2024, 10, 27, tzinfo=timezone.utc),
+             "extra": {}},
+            {"game_id": "g2", "stage": "MLS_R1", "matchday": None,
+             "home": "A", "away": "B", "home_goals": 1, "away_goals": 0,
+             "status": "FINISHED",
+             "start_time": None,  # malformed input — sort to end
+             "extra": {}},
+        ]
+        out = _assign_matchdays_and_dedupe(games, _MLS_SERIES_LENGTHS)
+        assert len(out) == 2
+        # g1 (Oct 27) ordered before g2 (None → sorted last) so g1=1, g2=2.
+        by_id = {g["game_id"]: g for g in out}
+        assert by_id["g1"]["matchday"] == 1
+        assert by_id["g2"]["matchday"] == 2
+
+
+class TestMlsCupStrengthSharing:
+    """Plugin merges East+West strengths into one dict; the cup source
+    queries by team name without caring which conference seeded it."""
+
+    def test_set_strengths_persists(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import MlsCupSource
+        src = MlsCupSource()
+        merged = {
+            "LA Galaxy": {"pf_per_game": 1.8, "pa_per_game": 0.9},
+            "Inter Miami CF": {"pf_per_game": 2.0, "pa_per_game": 1.1},
+        }
+        src.set_regular_season_strengths(merged)
+        assert src.estimate_strengths() == merged
+
+    def test_strength_for_falls_back_to_prior(self):
+        from dispatcharr_ranked_matchups.sources.mls_cup import (
+            MlsCupSource, _DEFAULT_GOALS_FOR, _DEFAULT_GOALS_AGAINST,
+        )
+        src = MlsCupSource()
+        # No seed set → estimate_strengths returns {}; strength_for
+        # falls through to the league-average prior.
+        assert src.estimate_strengths() == {}
+        result = src._strength_for({}, "Some Unknown Team")
+        assert result["pf_per_game"] == _DEFAULT_GOALS_FOR
+        assert result["pa_per_game"] == _DEFAULT_GOALS_AGAINST
+
+
+# =====================================================================
 # Phase Q: NWSL + Liga MX (subclasses of MlsSource)
 # =====================================================================
 


### PR DESCRIPTION
## Summary

- Adds \`MlsCupSource\` (\`sources/mls_cup.py\`) — BestOfNSeriesSource with per-stage series-length routing via \`_series_length_for_stage\` (same hook NCAA Baseball uses for its WC=3 / LDS=5 / LCS=7 / WS=7 mix).
- Adds \`LEAGUE_CONTEXTS[\"MLS_PO\"]\` with \`format=\"knockout\"\` and the 5 bands: round_one / conf_semis / conf_final / mls_cup_final / mls_cup_winner.
- Adds 6 new MLS-prefixed entries to \`KNOCKOUT_ROUND_DEPTH\` (MLS_WC=0 through MLS_CUP_WINNER=5) so within-MLS depth ordering survives the shared-dict collisions with NHL's R1=0 and MLB's WC=0.
- Wires \`MlsCupSource\` into the existing \`enable_mls\` block: paired with \`MlsEastSource\` + \`MlsWestSource\` from PR #67, with merged East+West strengths seeded into the cup source.

## Stacked on #67

This PR is stacked on \`feat/issue-30a-mls-conference-standings\` (PR #67). The cup source depends on the MLS_EAST + MLS_WEST regular-season sources from part A for strength sharing. Once #67 merges, this PR can rebase against \`main\` cleanly.

## Mixed-format scope

Each stage has its own series length. \`_series_length_for_stage\` returns:

| Stage      | Series length | Clinches at |
|------------|---------------|-------------|
| MLS_WC     | 1             | 1 win       |
| MLS_R1     | 3             | 2 wins      |
| MLS_CSF    | 1             | 1 win       |
| MLS_CF     | 1             | 1 win       |
| MLS_CUP    | 1             | 1 win       |

ESPN slug routing maps both conference variants to the canonical MLS-prefixed stage:

| ESPN \`season.slug\`                              | Stage    |
|---------------------------------------------------|----------|
| {eastern,western}-conference-playoffs---wild-card | MLS_WC   |
| {eastern,western}-conference-playoffs---round-one | MLS_R1   |
| {eastern,western}-conference-playoffs---semifinals| MLS_CSF  |
| {eastern,western}-conference-playoffs---final     | MLS_CF   |
| mls-cup                                           | MLS_CUP  |

## Phantom-game filter (live-discovered)

ESPN publishes a placeholder game-3 record for best-of-3 series that clinched in 2 games — observed live on the 2024 R1 Colorado @ LA Galaxy series (event 722587: \`state=post\`, \`completed=False\`, \`score=0-0\`, \`series.completed=True\`). Including these phantoms would inject 0-0 results into the bracket cascade and miscount series wins. The \`_extract_bracket_record\` filter drops events where \`state=='post' and not completed\` — pinned with a test that uses the exact event shape from the live data.

## Best-of-3 matchday inference

ESPN doesn't tag MLS R1 events with a game number — \`competition.notes[0].headline\` carries series state ("LA leads series 1-0") but not the specific game index. Matchday is inferred from chronological ordering within each (stage, frozenset(participants)) tuple in \`_assign_matchdays_and_dedupe\`. Single-leg stages get matchday=1 + PK-shootout dedup via the same helper from issue #24.

## DRY follow-ups filed during /sr-dev-review

- #69: consolidate \`_dedupe_pk_shootout_pairs\` (currently duplicated between \`ncaa_soccer_cup.py\` from #24 and \`mls_cup.py\` here, because the two PRs land independently).

## Live verification

\`\`\`
2024 MLS Cup playoff bracket (after phantom filter):
  MLS_WC matchday=1:  2 games
  MLS_R1 matchday=1:  8 games  (game 1 of each of 8 series)
  MLS_R1 matchday=2:  8 games  (game 2 of each series)
  MLS_R1 matchday=3:  4 games  (4 series went the distance)
  MLS_CSF matchday=1: 4 games
  MLS_CF matchday=1:  2 games
  MLS_CUP matchday=1: 1 game
  Total: 29 games

  Champion: LA Galaxy
  LA Galaxy terminal bands: ['round_one', 'conf_semis', 'conf_final',
                             'mls_cup_final', 'mls_cup_winner']
  Finalist: Red Bull New York (reaches MLS_CUP depth)
\`\`\`

## Test plan

- [x] \`pytest tests/\` — 927 pass on stacked branch (was 900 on #67 baseline; +27 new MLS Cup tests covering identity, contexts, slug routing, phantom filter against live event shape, matchday inference, cascade end-to-end, sample_result no-ties, strength sharing, fetch_upcoming emit side, defensive matchday inference for missing start_time)
- [x] Plugin reloads cleanly in the running Dispatcharr container (\`force_reload=True\`, no import errors)
- [x] Live fetch of 2024 MLS Cup bracket returns expected stage/matchday counts after phantom filter
- [x] 2024 MLS Cup champion (LA Galaxy) cascades all 5 bands via terminal_outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)