### PR TITLE
Phase A of #53: extract _compute_group_standings helper

### DIFF
--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -24,7 +24,7 @@ import logging
 import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import requests
 
@@ -1138,6 +1138,16 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
 _GROUP_ADVANCE_TOP_N = 2
 
 
+class GroupStandings(NamedTuple):
+    """Positional output of `GroupStageSoccerSource._compute_group_standings`.
+    Tuple-unpackable for legacy call sites; field-accessible for new ones.
+    See the helper's docstring for field semantics.
+    """
+    by_group: Dict[str, List[Tuple[str, Dict[str, int]]]]
+    best_third_order: List[Tuple[str, Dict[str, int]]]
+    n_best_third_advance: int
+
+
 class GroupStageSoccerSource(SoccerSource):
     """Group-stage Monte Carlo importance for international tournaments
     (WC, EURO). Sibling to KnockoutSoccerSource for the same competition:
@@ -1296,25 +1306,45 @@ class GroupStageSoccerSource(SoccerSource):
             ))
         return out
 
-    def terminal_outcomes(self, state: Dict[str, Any]) -> Dict[str, List[str]]:
-        """Two-stage advancement: top-2 per group always advance, then
-        for formats that admit best-3rd-place advancement (WC 2026,
-        EURO since 2016) the top-N third-place teams across all groups
-        also advance.
+    @staticmethod
+    def _fifa_tiebreaker_key(row: Dict[str, int]) -> Tuple[int, int, int]:
+        """FIFA's group-stage tiebreaker chain (points, goal diff, goals
+        for), negated for descending sort. The same chain governs the
+        within-group ranking AND the cross-group best-3rd-place ranking
+        (the latter appends alphabetical team name as last-resort). DO
+        NOT inline this tuple at call sites; the two rankings must agree
+        or terminal_outcomes' "advance" labels and the bracket-seed
+        slot assignments diverge.
+        """
+        return (-row["points"], -(row["gf"] - row["ga"]), -row["gf"])
 
-        Within each group, sort by (points desc, goal_diff desc,
-        goals_for desc) — FIFA's group-stage tiebreaker minus
-        head-to-head and fair-play layers we don't track. Top
-        _GROUP_ADVANCE_TOP_N get "advance"; the third-place team is
-        held back for the global best-3rd ranking; everyone below 3rd
-        is eliminated.
+    def _compute_group_standings(self, state: Dict[str, Any]) -> "GroupStandings":
+        """Compute per-group standings + cross-group best-3rd ranking.
 
-        Best-3rd ranking uses the same tiebreaker chain (points → GD →
-        GF) with an alphabetical fallback for true ties — FIFA falls
-        back to fair-play points then drawing of lots, neither of which
-        we track. See #52.
+        Returns a `GroupStandings` with three fields:
+          - `by_group`: `{group_key: [(team, row), ...]}` sorted by
+            `_fifa_tiebreaker_key`. Position within the list IS the
+            team's finishing position (0 = 1st in group). The minus-
+            head-to-head and minus-fair-play caveats from
+            `terminal_outcomes` apply equally here.
+          - `best_third_order`: every group's 3rd-placer, cross-group
+            sorted by `_fifa_tiebreaker_key` plus alphabetical-name as
+            the deterministic last-resort. Front of list is the
+            strongest 3rd-placer. Includes ALL groups; the caller
+            decides how many to promote.
+          - `n_best_third_advance`: how many of `best_third_order` get
+            promoted to advance status per
+            `LEAGUE_CONTEXTS[<gs_code>].best_third_place_count`,
+            defaulting to 0 when no context is registered.
+
+        Single source of truth for `terminal_outcomes` (collapses
+        positions to advance/eliminated labels) and `_build_bracket_seed`
+        (positions to LAST_32 slot assignments per the tournament's
+        published bracket, #53).
         """
         from collections import defaultdict
+        from ..scoring import LEAGUE_CONTEXTS
+
         team_group = state.get("_team_group", {})
         by_group: Dict[str, List[Tuple[str, Dict[str, int]]]] = defaultdict(list)
         for team, row in state.items():
@@ -1325,46 +1355,47 @@ class GroupStageSoccerSource(SoccerSource):
                 continue
             by_group[group].append((team, row))
 
-        # How many third-place teams advance? Read from LEAGUE_CONTEXTS
-        # via the source's group-stage code so EURO (4) and WC (8) get
-        # their format-specific count without per-source if/else.
-        from ..scoring import LEAGUE_CONTEXTS
-        gs_code = self._group_stage_context_code()
-        ctx = LEAGUE_CONTEXTS.get(gs_code)
+        third_placers: List[Tuple[str, Dict[str, int]]] = []
+        for teams in by_group.values():
+            teams.sort(key=lambda kv: self._fifa_tiebreaker_key(kv[1]))
+            if len(teams) > _GROUP_ADVANCE_TOP_N:
+                third_placers.append(teams[_GROUP_ADVANCE_TOP_N])
+
+        third_placers.sort(key=lambda kv: (*self._fifa_tiebreaker_key(kv[1]), kv[0]))
+
+        ctx = LEAGUE_CONTEXTS.get(self._group_stage_context_code())
         n_best_third = ctx.best_third_place_count if ctx else 0
 
+        return GroupStandings(
+            by_group=dict(by_group),
+            best_third_order=third_placers,
+            n_best_third_advance=n_best_third,
+        )
+
+    def terminal_outcomes(self, state: Dict[str, Any]) -> Dict[str, List[str]]:
+        """Two-stage advancement: top-2 per group always advance, then
+        for formats that admit best-3rd-place advancement (WC 2026,
+        EURO since 2016) the top-N third-place teams across all groups
+        also advance.
+
+        Standings + tiebreaker logic lives in `_compute_group_standings`;
+        this method is the label translation layer (positions to
+        "advance"/"eliminated"). See the helper's docstring for the
+        FIFA tiebreaker chain and the caveats around head-to-head and
+        fair-play (#52).
+        """
+        standings = self._compute_group_standings(state)
+        promoted_thirds = {
+            team for team, _ in standings.best_third_order[:standings.n_best_third_advance]
+        }
+
         outcomes: Dict[str, List[str]] = {}
-        # Hold the 3rd-place team from each group for the global ranking.
-        third_placers: List[Tuple[str, Dict[str, int]]] = []
-        for group, teams in by_group.items():
-            teams.sort(key=lambda kv: (
-                -kv[1]["points"],
-                -(kv[1]["gf"] - kv[1]["ga"]),
-                -kv[1]["gf"],
-            ))
-            for i, (team, row) in enumerate(teams):
+        for teams in standings.by_group.values():
+            for i, (team, _row) in enumerate(teams):
                 if i < _GROUP_ADVANCE_TOP_N:
                     outcomes[team] = ["advance"]
-                elif i == _GROUP_ADVANCE_TOP_N:
-                    # 3rd place — eliminate provisionally; promoted below
-                    # if it ranks high enough in the cross-group sort.
-                    outcomes[team] = ["eliminated"]
-                    third_placers.append((team, row))
+                elif i == _GROUP_ADVANCE_TOP_N and team in promoted_thirds:
+                    outcomes[team] = ["advance"]
                 else:
                     outcomes[team] = ["eliminated"]
-
-        # Promote the top-N 3rd-place teams. Alphabetical name as
-        # deterministic tiebreaker — FIFA uses fair-play points / drawing
-        # of lots here, neither of which we model. Deterministic
-        # tiebreaker keeps replay results stable.
-        if n_best_third > 0 and third_placers:
-            third_placers.sort(key=lambda kv: (
-                -kv[1]["points"],
-                -(kv[1]["gf"] - kv[1]["ga"]),
-                -kv[1]["gf"],
-                kv[0],
-            ))
-            for team, _row in third_placers[:n_best_third]:
-                outcomes[team] = ["advance"]
-
         return outcomes

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8465,3 +8465,208 @@ class TestGroupStageBestThirdPlace:
         outcomes = src.terminal_outcomes(state)
         # Delta is 4th in her own group, regardless of stats — must be eliminated.
         assert outcomes["Delta"] == ["eliminated"]
+
+
+class TestComputeGroupStandings:
+    """`_compute_group_standings` is the positional-data source of truth for
+    both `terminal_outcomes` (advance/eliminated labels) and #53's
+    `_build_bracket_seed` (cross-group bracket slot assignments). The
+    contract: per-group order is by FIFA tiebreaker (pts → GD → GF),
+    best-3rd order is the same chain plus alphabetical-name as the
+    last-resort, and the 3rd-place advancement count comes from
+    LEAGUE_CONTEXTS keyed off the group-stage code.
+    """
+
+    @staticmethod
+    def _wc_source():
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        return GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+
+    @staticmethod
+    def _euro_source():
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        return GroupStageSoccerSource("euros", fd_api_key="x", odds_api_key="")
+
+    @staticmethod
+    def _make_state(group_data, team_group):
+        """Same shape as TestGroupStageBestThirdPlace's helper: per-team
+        rows with points / gf / ga; the helper computes gd = gf - ga."""
+        state = {"_applied": set(), "_team_group": team_group}
+        for _grp, rows in group_data.items():
+            for team, points, gd, gf in rows:
+                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
+        return state
+
+    def test_by_group_sorted_by_fifa_tiebreaker(self):
+        # GROUP_A: Bravo (9 pts) > Alpha (6) > Charlie (3) > Delta (0).
+        # Insertion order is shuffled to confirm the sort, not the input order.
+        src = self._wc_source()
+        team_group = {t: "GROUP_A" for t in ("Alpha", "Bravo", "Charlie", "Delta")}
+        group_data = {"GROUP_A": [
+            ("Delta", 0, -5, 1),
+            ("Bravo", 9, 5, 8),
+            ("Charlie", 3, 0, 3),
+            ("Alpha", 6, 2, 5),
+        ]}
+        state = self._make_state(group_data, team_group)
+        by_group, _, _ = src._compute_group_standings(state)
+        # Position 0 is the group winner; teams at positions 0..3.
+        assert [t for t, _ in by_group["GROUP_A"]] == ["Bravo", "Alpha", "Charlie", "Delta"]
+
+    def test_by_group_tiebreaker_gd_then_gf(self):
+        # All four teams tied on 4 pts. GD breaks first (alpha=+3, bravo=+1,
+        # charlie=0, delta=-4); within identical GD, GF breaks.
+        src = self._wc_source()
+        team_group = {t: "GROUP_A" for t in ("Alpha", "Bravo", "Charlie", "Delta")}
+        group_data = {"GROUP_A": [
+            ("Alpha", 4, 3, 5),
+            ("Bravo", 4, 1, 3),
+            ("Charlie", 4, 0, 2),
+            ("Delta", 4, -4, 1),
+        ]}
+        state = self._make_state(group_data, team_group)
+        by_group, _, _ = src._compute_group_standings(state)
+        assert [t for t, _ in by_group["GROUP_A"]] == ["Alpha", "Bravo", "Charlie", "Delta"]
+
+    def test_best_third_order_cross_group_alphabetical_fallback(self):
+        # Two 3rd-placers tied on (pts, gd, gf). Alphabetical name decides.
+        src = self._wc_source()
+        team_group = {
+            "Alpha_1": "GROUP_A", "Alpha_2": "GROUP_A",
+            "Alpha_3rd": "GROUP_A", "Alpha_4": "GROUP_A",
+            "Bravo_1": "GROUP_B", "Bravo_2": "GROUP_B",
+            "Bravo_3rd": "GROUP_B", "Bravo_4": "GROUP_B",
+        }
+        group_data = {
+            "GROUP_A": [
+                ("Alpha_1", 9, 5, 8), ("Alpha_2", 6, 2, 5),
+                ("Alpha_3rd", 3, 0, 3), ("Alpha_4", 0, -5, 1),
+            ],
+            "GROUP_B": [
+                ("Bravo_1", 9, 5, 8), ("Bravo_2", 6, 2, 5),
+                ("Bravo_3rd", 3, 0, 3), ("Bravo_4", 0, -5, 1),
+            ],
+        }
+        state = self._make_state(group_data, team_group)
+        _, best_third_order, _ = src._compute_group_standings(state)
+        # Both 3rd-placers identical on pts/gd/gf; "Alpha_3rd" < "Bravo_3rd"
+        # by string ordering, so Alpha_3rd is the stronger 3rd-placer.
+        names = [t for t, _ in best_third_order]
+        assert names == ["Alpha_3rd", "Bravo_3rd"]
+
+    def test_n_best_third_reads_wc_context(self):
+        # World Cup config maps to WC_GS in LEAGUE_CONTEXTS with
+        # best_third_place_count=8.
+        src = self._wc_source()
+        _, _, n = src._compute_group_standings(
+            {"_applied": set(), "_team_group": {}}
+        )
+        assert n == 8
+
+    def test_n_best_third_reads_euro_context(self):
+        # EURO 2024+ config maps to EC_GS with best_third_place_count=4.
+        src = self._euro_source()
+        _, _, n = src._compute_group_standings(
+            {"_applied": set(), "_team_group": {}}
+        )
+        assert n == 4
+
+    def test_metadata_keys_excluded_from_standings(self):
+        # _applied / _team_group are state-shape markers, not teams.
+        src = self._wc_source()
+        team_group = {"Alpha": "GROUP_A", "Bravo": "GROUP_A"}
+        group_data = {"GROUP_A": [
+            ("Alpha", 6, 2, 5),
+            ("Bravo", 3, 0, 3),
+        ]}
+        state = self._make_state(group_data, team_group)
+        by_group, _, _ = src._compute_group_standings(state)
+        # Only the two real teams should appear.
+        assert set(t for t, _ in by_group["GROUP_A"]) == {"Alpha", "Bravo"}
+        # No spurious "_applied" or "_team_group" group entries.
+        assert "_applied" not in by_group
+        assert "_team_group" not in by_group
+
+    def test_group_smaller_than_advance_top_n_yields_no_third_placer(self):
+        # Degenerate 2-team group can't contribute a 3rd-placer.
+        # `_GROUP_ADVANCE_TOP_N` is 2 so positions 0 and 1 exist but not 2.
+        src = self._wc_source()
+        team_group = {"Alpha": "GROUP_A", "Bravo": "GROUP_A"}
+        group_data = {"GROUP_A": [("Alpha", 6, 2, 5), ("Bravo", 3, 0, 3)]}
+        state = self._make_state(group_data, team_group)
+        _, best_third_order, _ = src._compute_group_standings(state)
+        assert best_third_order == []
+
+    def test_terminal_outcomes_consumes_helper_consistently(self):
+        # Sanity check: terminal_outcomes' "advance" / "eliminated" labels
+        # must agree with the positional data the helper returns. If the
+        # two diverge, #53's seed mapper would slot teams labeled "advance"
+        # by terminal_outcomes into 3rd-placer bracket positions (or vice
+        # versa). This test pins the contract.
+        src = self._wc_source()
+        team_group = {t: "GROUP_A" for t in ("Alpha", "Bravo", "Charlie", "Delta")}
+        group_data = {"GROUP_A": [
+            ("Alpha", 9, 5, 8),
+            ("Bravo", 6, 2, 5),
+            ("Charlie", 3, 0, 3),
+            ("Delta", 0, -5, 1),
+        ]}
+        state = self._make_state(group_data, team_group)
+        standings = src._compute_group_standings(state)
+        outcomes = src.terminal_outcomes(state)
+        promoted = {t for t, _ in standings.best_third_order[:standings.n_best_third_advance]}
+        for teams in standings.by_group.values():
+            for i, (team, _row) in enumerate(teams):
+                expected = "advance" if (i < 2 or (i == 2 and team in promoted)) else "eliminated"
+                assert outcomes[team] == [expected], (
+                    f"{team} at position {i}: outcomes={outcomes[team]!r} "
+                    f"expected {expected!r}"
+                )
+
+    def test_named_tuple_supports_tuple_unpacking(self):
+        # Field access via .by_group is the new path; tuple-unpack stays
+        # supported because Phase B's call sites and earlier ones rely on
+        # it. Pin both contracts here.
+        src = self._wc_source()
+        state = {"_applied": set(), "_team_group": {}}
+        standings = src._compute_group_standings(state)
+        # Field access shape.
+        assert standings.by_group == {}
+        assert standings.best_third_order == []
+        assert standings.n_best_third_advance == 8
+        # Tuple-unpack shape.
+        by_group, best_third_order, n_best_third = standings
+        assert by_group == standings.by_group
+        assert best_third_order == standings.best_third_order
+        assert n_best_third == standings.n_best_third_advance
+
+    def test_n_best_third_defaults_to_zero_for_unknown_competition(self):
+        # The fallback for `LEAGUE_CONTEXTS.get(<gs_code>) is None` was
+        # not exercised by the WC / EURO happy paths. Build a source
+        # whose group-stage context code resolves to a key not in
+        # LEAGUE_CONTEXTS and confirm n_best_third_advance defaults to 0.
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
+
+        # `bundesliga` is a registered competition but Bundesliga is not
+        # a group-stage tournament — its `<fd_code>_GS` ("BL1_GS") has
+        # no LEAGUE_CONTEXTS entry, so the ctx lookup falls through.
+        src = GroupStageSoccerSource("bundesliga", fd_api_key="x", odds_api_key="")
+        assert src._group_stage_context_code() not in LEAGUE_CONTEXTS
+        standings = src._compute_group_standings(
+            {"_applied": set(), "_team_group": {}}
+        )
+        assert standings.n_best_third_advance == 0
+
+    def test_fifa_tiebreaker_key_is_descending_on_all_three_axes(self):
+        # Pin the chain: higher points sort earlier; ties broken by GD,
+        # then GF. Test directly on the static helper so changes to
+        # caller code don't accidentally invert one axis (-pts vs +pts).
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        k = GroupStageSoccerSource._fifa_tiebreaker_key
+        a = {"points": 6, "gf": 5, "ga": 2}  # gd=+3
+        b = {"points": 6, "gf": 4, "ga": 1}  # gd=+3, lower gf -> ranks below a
+        c = {"points": 6, "gf": 5, "ga": 3}  # gd=+2, lower gd -> ranks below a
+        d = {"points": 3, "gf": 9, "ga": 0}  # lower points -> ranks below all
+        rows = sorted([a, b, c, d], key=k)
+        assert rows == [a, b, c, d]


### PR DESCRIPTION
Refs #53. No-behavior-change refactor; Phase B (the cross-source chain feature) will sit on top of this.

## Summary

- New `GroupStageSoccerSource._compute_group_standings(state) -> GroupStandings` helper that returns positional standings (per-group sort + cross-group best-3rd ranking) as a `NamedTuple`.
- `terminal_outcomes` becomes a thin label translation layer over the helper.
- New `_fifa_tiebreaker_key` static method so the `(-points, -GD, -GF)` chain is defined once. Per-group sort consumes it directly; cross-group best-3rd sort splats it and appends alphabetical-name as deterministic last-resort.

## Why a no-behavior-change Phase A

Phase B's `_build_bracket_seed` (the cross-source feeds_from work) needs full positional standings (1st/2nd within group + best-3rd cross-group order), not just `terminal_outcomes`' `advance` / `eliminated` labels. Sharing the helper keeps the seed mapper and the outcome labels from drifting — pinned by `test_terminal_outcomes_consumes_helper_consistently`.

## Test plan

- [x] 33 group-stage tests pass (was 22; +11 new in `TestComputeGroupStandings` covering helper contract, NamedTuple shape, unknown-context fallback, tiebreaker axes, metadata-key exclusion).
- [x] Full suite: 808 pass on this branch, matches `main`. (Excludes `tests/test_plugin_helpers.py` which has 6 Django-dep failures pre-existing on `main`.)
- [x] `terminal_outcomes` semantics unchanged: every existing assertion in `TestGroupStageBestThirdPlace` continues to pass against the refactored implementation.

## Senior-dev review findings + fixes (in this PR)

- DRY: FIFA tiebreaker tuple was duplicated in the helper (per-group sort + best-3rd sort). Extracted to `_fifa_tiebreaker_key` static method.
- Return-type clarity: 3-tuple was awkward at call sites. Switched to `GroupStandings` `NamedTuple`; tuple-unpacking still supported.
- Test gap: added direct test for `ctx is None` fallback (unknown competition → `n_best_third_advance = 0`).
- Test gap: added direct test pinning `_fifa_tiebreaker_key` axes so an accidental `+pts` vs `-pts` flip breaks loudly.
- Speculation: dropped the docstring's "EURO-pre-2016" reference (no such config exists in the codebase).
- Em dash: removed one I introduced; filed #73 to sweep the file-wide 34 pre-existing instances.
- State-shape contract: filed #74 to type the state dict + per-team row with `TypedDict`.