### PR TITLE
Phase B of #53: cross-source feeds_from chain (WC group → knockout)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -522,10 +522,20 @@ def _build_sources(settings: Dict[str, Any]):
     #   - GroupStageSoccerSource for the per-group "advance / eliminated"
     #     importance signal (top 2 per group).
     if settings.get("enable_world_cup", False) and fd_key:
-        sources.append(_make_soccer("world_cup"))
-        sources.append(GroupStageSoccerSource(
+        wc_knockout = _make_soccer("world_cup")
+        wc_groups = GroupStageSoccerSource(
             "world_cup", fd_api_key=fd_key, odds_api_key=odds_key,
-        ))
+        )
+        # Wire the cross-source chain (#53): while wc_knockout's
+        # _fetch_bracket_games returns empty (pre-tournament FD.org
+        # state), group-game importance routes through
+        # monte_carlo_importance_batch_chain so R16+ leverage fires.
+        # Once FD publishes real LAST_32 teams, the chain toggles off
+        # automatically.
+        if isinstance(wc_knockout, KnockoutSoccerSource):
+            wc_groups.set_paired_knockout_source(wc_knockout)
+        sources.append(wc_knockout)
+        sources.append(wc_groups)
     if settings.get("enable_euros", False) and fd_key:
         sources.append(_make_soccer("euros"))
         sources.append(GroupStageSoccerSource(

--- a/scoring.py
+++ b/scoring.py
@@ -247,6 +247,23 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
 }
 
 
+# FIFA World Cup knockout cascade thresholds. Shared by:
+#   - WC: the knockout source's own context (post-group bracket).
+#   - WC_GS: the group-stage context, which inherits these labels so
+#     the #53 cross-source chain can attribute downstream-cascade
+#     leverage to group games. If WC weights change, BOTH contexts
+#     need the updated values; sharing via this constant prevents
+#     drift between the knockout source and the group-stage chain.
+_WC_KNOCKOUT_THRESHOLDS: List[Tuple[str, str, float]] = [
+    ("LAST_32",        "last_32",       0.5),
+    ("LAST_16",        "round_of_16",   1.5),
+    ("QUARTER_FINALS", "quarterfinal",  3.0),
+    ("SEMI_FINALS",    "semifinal",     5.0),
+    ("FINAL",          "final",         8.0),
+    ("WINNER",         "winner",       15.0),
+]
+
+
 LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     "PL": LeagueContext(
         code="PL", matchdays_total=38,
@@ -388,14 +405,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # consequence.
     "WC": LeagueContext(
         code="WC", matchdays_total=0, format="knockout",
-        thresholds=[
-            ("LAST_32",        "last_32",       0.5),
-            ("LAST_16",        "round_of_16",   1.5),
-            ("QUARTER_FINALS", "quarterfinal",  3.0),
-            ("SEMI_FINALS",    "semifinal",     5.0),
-            ("FINAL",          "final",         8.0),
-            ("WINNER",         "winner",       15.0),
-        ],
+        thresholds=list(_WC_KNOCKOUT_THRESHOLDS),
         boundary_summary="R32 → R16 → QF → SF → Final → Champion (FIFA World Cup)",
     ),
     "EC": LeagueContext(
@@ -425,27 +435,18 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # gap above.
     "WC_GS": LeagueContext(
         code="WC_GS", matchdays_total=3, format="group_advance",
-        thresholds=[
-            (_GROUP_ADVANCE_SENTINEL, "advance", 4.0),
-            # Downstream-cascade labels carried through by the #53
-            # cross-source chain. When the chain is active (pre-
-            # tournament window, before FD.org populates real
-            # LAST_32 teams), GroupStageSoccerSource's importance
-            # query covers BOTH the group-advance signal AND the
-            # downstream-bracket signal, so a group-stage game whose
-            # result shifts the team's LAST_32 path-strength contributes
-            # cascade weight too. Weights mirror the WC knockout context
-            # entries; when the chain is inactive (single-source path),
-            # GroupStageSoccerSource.terminal_outcomes doesn't emit
-            # these labels and the leverage is 0 — net contribution 0,
-            # the addition is safe.
-            ("LAST_32",        "last_32",       0.5),
-            ("LAST_16",        "round_of_16",   1.5),
-            ("QUARTER_FINALS", "quarterfinal",  3.0),
-            ("SEMI_FINALS",    "semifinal",     5.0),
-            ("FINAL",          "final",         8.0),
-            ("WINNER",         "winner",       15.0),
-        ],
+        # `advance` is the group-stage's own signal; the WC knockout
+        # cascade is inherited from `_WC_KNOCKOUT_THRESHOLDS` so the
+        # #53 cross-source chain can attribute downstream-cascade
+        # leverage to group games. When the chain is inactive
+        # (single-source path), GroupStageSoccerSource.terminal_outcomes
+        # doesn't emit the cascade labels; the leverage on them
+        # degenerates to 0 and the contribution sums to 0. The
+        # addition is safe in both states.
+        thresholds=(
+            [(_GROUP_ADVANCE_SENTINEL, "advance", 4.0)]
+            + list(_WC_KNOCKOUT_THRESHOLDS)
+        ),
         # WC 2026 format: 12 groups × 4 teams, top 2 + 8 best 3rd-place
         # = 32 advancing teams → LAST_32. Best-3rd advancement is ~25%
         # of advancing teams and was the #52 follow-up to #20.

--- a/scoring.py
+++ b/scoring.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 # Trailing club-tag tokens (FC/AFC/etc) and generic second-words (United/City/
 # etc) live in _util so matcher.py can use them without importing scoring.
@@ -427,6 +427,24 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         code="WC_GS", matchdays_total=3, format="group_advance",
         thresholds=[
             (_GROUP_ADVANCE_SENTINEL, "advance", 4.0),
+            # Downstream-cascade labels carried through by the #53
+            # cross-source chain. When the chain is active (pre-
+            # tournament window, before FD.org populates real
+            # LAST_32 teams), GroupStageSoccerSource's importance
+            # query covers BOTH the group-advance signal AND the
+            # downstream-bracket signal, so a group-stage game whose
+            # result shifts the team's LAST_32 path-strength contributes
+            # cascade weight too. Weights mirror the WC knockout context
+            # entries; when the chain is inactive (single-source path),
+            # GroupStageSoccerSource.terminal_outcomes doesn't emit
+            # these labels and the leverage is 0 — net contribution 0,
+            # the addition is safe.
+            ("LAST_32",        "last_32",       0.5),
+            ("LAST_16",        "round_of_16",   1.5),
+            ("QUARTER_FINALS", "quarterfinal",  3.0),
+            ("SEMI_FINALS",    "semifinal",     5.0),
+            ("FINAL",          "final",         8.0),
+            ("WINNER",         "winner",       15.0),
         ],
         # WC 2026 format: 12 groups × 4 teams, top 2 + 8 best 3rd-place
         # = 32 advancing teams → LAST_32. Best-3rd advancement is ~25%
@@ -1146,7 +1164,7 @@ def compute_match_importance(
     Returns (0.0, [], []) when the league has no outcome bands (e.g., a
     knockout-only competition routed into this path by mistake).
     """
-    from .simulation import monte_carlo_importance_batch
+    from .simulation import monte_carlo_importance_batch, monte_carlo_importance_batch_chain
     if not getattr(source, "supports_importance", False):
         return 0.0, [], []
     if not league_ctx.thresholds:
@@ -1169,9 +1187,31 @@ def compute_match_importance(
         for _, label, _ in league_ctx.thresholds:
             queries.append((team, label))
 
-    leverages = monte_carlo_importance_batch(
-        source, match, queries, n_sims=n_sims, rng=rng,
+    # Chain routing (#53): if the source declares a cross-source chain
+    # AND that chain is currently active (pre-tournament FD.org state
+    # for WC group games), route through the chain simulator so the
+    # downstream knockout-cascade labels in league_ctx.thresholds get
+    # real leverage values. When the chain is inactive (or absent),
+    # the single-source path returns 0 on those labels, which is the
+    # correct degenerate behavior (the primary source doesn't emit
+    # downstream labels alone).
+    chain_fn = getattr(source, "cross_source_chain", None)
+    chain_raw = chain_fn() if callable(chain_fn) else None
+    chain = cast(
+        Optional[Tuple[Any, Callable[[Dict[str, Any]], Dict[str, Any]]]],
+        chain_raw,
     )
+    if chain is not None:
+        downstream, seed_fn = chain
+        leverages = monte_carlo_importance_batch_chain(
+            source, match, queries,
+            downstream=downstream, seed_fn=seed_fn,
+            n_sims=n_sims, rng=rng,
+        )
+    else:
+        leverages = monte_carlo_importance_batch(
+            source, match, queries, n_sims=n_sims, rng=rng,
+        )
 
     # Map label → weight once so the contribution loop is single-pass.
     weight_by_label: Dict[str, float] = {

--- a/simulation.py
+++ b/simulation.py
@@ -30,7 +30,7 @@ caller skips this module entirely.
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from .sources.base import GameRow, MatchResult, SportSource
@@ -254,6 +254,119 @@ def monte_carlo_importance_batch(
         for team, outcome in queries:
             row = _RESULT_ROW[_classify_target_result(target_result, team, home, away)]
             col = 0 if outcome in outcomes.get(team, []) else 1
+            tables[(team, outcome)][row][col] += 1
+
+    return {q: abs(kendall_tau_c(t)) for q, t in tables.items()}
+
+
+def monte_carlo_importance_batch_chain(
+    primary: "SportSource",
+    target_match: "GameRow",
+    queries: Sequence[Tuple[str, str]],
+    downstream: "SportSource",
+    seed_fn: Callable[[Dict[str, Any]], Dict[str, Any]],
+    n_sims: int = DEFAULT_N_SIMS,
+    rng: Optional[random.Random] = None,
+) -> Dict[Tuple[str, str], float]:
+    """Importance batch with a cross-source advancement chain.
+
+    Same shape as `monte_carlo_importance_batch` but runs a SECOND
+    simulation phase per sim: after the primary source drains, the
+    `seed_fn(primary_state)` callback builds the downstream's initial
+    state (typically a knockout bracket whose participants the primary's
+    standings determined), the downstream's remaining_matches are
+    drained, and the per-team outcomes of both sources are merged
+    before the tau-c contingency table is updated.
+
+    Motivation: international soccer tournaments (#53). The group source
+    ranks teams within their groups; the knockout source models the
+    post-group bracket. A group winner faces a structurally different
+    LAST_32 opponent than a runner-up, so group-game leverage on R16+
+    bands requires cross-source advancement, not just within-source
+    outcomes. The single-source `monte_carlo_importance_batch` cannot
+    express this and would return 0 leverage on every downstream band.
+
+    Contract:
+      - Primary and downstream MUST emit disjoint outcome vocabularies.
+        Otherwise the merge double-counts (a team labeled "advance" by
+        both sources would have two entries in the merged list, but
+        tau-c bucketing is membership-based so the duplicate is a no-op
+        for the query column; it's still a smell). Today the
+        GroupStageSoccerSource emits `advance` / `eliminated` and the
+        KnockoutSoccerSource emits `round_of_16` / `quarterfinal` /
+        `semifinal` / `final` / `winner` — disjoint by design.
+      - `seed_fn` returns a state dict consumable by
+        `downstream.remaining_matches` / `sample_result` / `apply_result`
+        / `terminal_outcomes`. The downstream's own `initial_state` is
+        NOT called by the chain — the seed is the entry point.
+      - Strength estimation is shared (one call to
+        `primary.estimate_strengths()` covers both phases). Today the
+        SoccerSource subclasses both inherit identical
+        `estimate_strengths` from the same fixture pool; if a future
+        chain consumer needs source-specific strengths, the contract
+        will need to be revisited.
+
+    Returns `{(team, outcome): |tau_c|}` keyed by the input queries.
+    """
+    if not getattr(primary, "supports_importance", False):
+        raise ValueError(
+            f"{type(primary).__name__} does not support importance simulation; "
+            "check supports_importance before calling."
+        )
+    if not getattr(downstream, "supports_importance", False):
+        raise ValueError(
+            f"{type(downstream).__name__} does not support importance simulation; "
+            "check supports_importance before calling."
+        )
+    rng = rng or random.Random()
+    strengths = primary.estimate_strengths()
+    primary_base = primary.initial_state()
+
+    home = target_match.home
+    away = target_match.away
+
+    tables: Dict[Tuple[str, str], List[List[int]]] = {
+        q: [[0, 0], [0, 0], [0, 0]] for q in queries
+    }
+
+    for _ in range(n_sims):
+        # Phase 1: drain primary from the target match. Same dedupe-and-
+        # drain-until-empty loop as monte_carlo_importance_batch.
+        target_result = primary.sample_result(primary_base, target_match, strengths, rng)
+        primary_state = primary.apply_result(primary_base, target_match, target_result)
+        while True:
+            rem = [m for m in primary.remaining_matches(primary_state)
+                   if not _same_match(m, target_match)]
+            if not rem:
+                break
+            for m in rem:
+                r = primary.sample_result(primary_state, m, strengths, rng)
+                primary_state = primary.apply_result(primary_state, m, r)
+
+        # Phase 2: seed and drain downstream. No target-match dedupe here:
+        # the target match lives in primary's fixture pool, not the
+        # downstream's bracket, so collision is impossible by design.
+        downstream_state = seed_fn(primary_state)
+        while True:
+            rem = downstream.remaining_matches(downstream_state)
+            if not rem:
+                break
+            for m in rem:
+                r = downstream.sample_result(downstream_state, m, strengths, rng)
+                downstream_state = downstream.apply_result(downstream_state, m, r)
+
+        # Phase 3: per-team outcome union and contingency-table update.
+        primary_outcomes = primary.terminal_outcomes(primary_state)
+        downstream_outcomes = downstream.terminal_outcomes(downstream_state)
+        all_teams = set(primary_outcomes) | set(downstream_outcomes)
+        merged: Dict[str, List[str]] = {
+            t: primary_outcomes.get(t, []) + downstream_outcomes.get(t, [])
+            for t in all_teams
+        }
+
+        for team, outcome in queries:
+            row = _RESULT_ROW[_classify_target_result(target_result, team, home, away)]
+            col = 0 if outcome in merged.get(team, []) else 1
             tables[(team, outcome)][row][col] += 1
 
     return {q: abs(kendall_tau_c(t)) for q, t in tables.items()}

--- a/sources/bracket.py
+++ b/sources/bracket.py
@@ -414,18 +414,40 @@ class BracketSportSource(SportSource):
             return None
         return home, away
 
-    @staticmethod
     def _winner_of(
+        self,
         feed_ref: Tuple[str, int],
         bracket: Dict[str, List[Dict[str, Any]]],
         tie_results: Dict[Any, Dict[str, Any]],
     ) -> Optional[str]:
+        """Resolve the winner of the feeder tie at `feed_ref`. Looks up
+        tie_results using the tie's RESOLVED participants (recursively
+        via _resolve_participants), not its source-published team names.
+
+        Two cases where the published names diverge from the simulated
+        ones:
+          1. UCL-style counterfactual — an upstream sim flipped a feeder,
+             putting a different team into this tie than FD.org's draw
+             published.
+          2. WC chain seed (#53) — the entry tie's participants come from
+             the group-stage chain rather than FD.org; downstream-round
+             tie_metas carry placeholder names ("L32_W1" etc.) that have
+             to be resolved at lookup time, not at synthesis time.
+
+        Both cases were silently broken when this method consulted
+        `tie_meta["teams"]` directly: the lookup key was the published
+        set, the stored key was the simulated set, lookup returned None,
+        and the chain stalled.
+        """
         stage, tie_idx = feed_ref
         ties = bracket.get(stage, [])
         if tie_idx >= len(ties):
             return None
         tie_meta = ties[tie_idx]
-        tk = (stage, frozenset(tie_meta["teams"]))
+        participants = self._resolve_participants(tie_meta, bracket, tie_results)
+        if participants is None:
+            return None
+        tk = (stage, frozenset(participants))
         return tie_results.get(tk, {}).get("winner")
 
 

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -1034,6 +1034,106 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
                 })
         return out
 
+    # ---------- #53 cross-source chain seeding ----------
+
+    def seed_from_chain(self, seed: Dict[str, Any]) -> Dict[str, Any]:
+        """Build initial bracket state from an explicit per-stage seed
+        rather than from `_fetch_bracket_games()`. The seed is produced
+        by the chain's primary source (`GroupStageSoccerSource.
+        _build_bracket_seed` for WC / EURO) and carries the cross-group
+        LAST_32 pairings plus the placeholder feeds_from wiring for
+        downstream rounds.
+
+        Seed shape:
+        ```
+        {"stages": [
+          {"stage": "LAST_32", "ties": [
+            {"home": "Mexico", "away": "Norway", "matchday": 1,
+             "feeds_from": {}},
+            ...16 entry ties for WC
+          ]},
+          {"stage": "LAST_16", "ties": [
+            {"home": "L32_W1", "away": "L32_W2", "matchday": 1,
+             "feeds_from": {"L32_W1": ("LAST_32", 0),
+                            "L32_W2": ("LAST_32", 1)}},
+            ...8 downstream ties with placeholder participants
+          ]},
+          ...
+        ]}
+        ```
+
+        Downstream-stage ties carry placeholder names (e.g., `L32_W1`)
+        that are resolved at lookup time by `_winner_of` via the
+        feeds_from wiring. Single source of truth for placeholder
+        naming: the seed itself. The bracket machinery does NOT depend
+        on a fixed placeholder convention; it only depends on consistent
+        keying between each tie's `feeds_from` entries and its game's
+        `home`/`away` strings.
+
+        Returns a state dict in the shape `BracketSportSource.
+        initial_state` produces: keys `_applied`, `_tie_results`,
+        `_bracket`, `_round_reached`. Compatible with `remaining_matches`,
+        `sample_result`, `apply_result`, `terminal_outcomes` as-is —
+        seed_from_chain is the entry point INSTEAD of `initial_state`,
+        not in addition to it.
+        """
+        bracket: Dict[str, List[Dict[str, Any]]] = {s: [] for s in self.KO_STAGES}
+        tie_results: Dict[Any, Dict[str, Any]] = {}
+
+        for stage_spec in seed.get("stages", []):
+            stage = stage_spec.get("stage")
+            if stage not in bracket:
+                continue
+            for tie_idx, tie_spec in enumerate(stage_spec.get("ties", [])):
+                home = tie_spec["home"]
+                away = tie_spec["away"]
+                matchday = tie_spec.get("matchday", 1)
+                feeds_from = tie_spec.get("feeds_from", {})
+                teams_set = frozenset({home, away})
+                # Synthetic game_id keyed by (stage, tie_idx, matchday).
+                # Required: AggregateLegSource._emit_remaining_games_for_tie
+                # filters by `game_id in applied`; a None game_id would
+                # cause the synthetic tie to be re-emitted every drain
+                # pass and the sim would never terminate.
+                game_id = f"chain:{stage}:{tie_idx}:leg{matchday}"
+                games = [{
+                    "game_id": game_id,
+                    "stage": stage,
+                    "matchday": matchday,
+                    "home": home,
+                    "away": away,
+                    "home_goals": None,
+                    "away_goals": None,
+                    "status": "SCHEDULED",
+                    "start_time": None,
+                    "extra": {},
+                }]
+                tie_meta = {
+                    "stage": stage,
+                    "teams": teams_set,
+                    "games": games,
+                    "feeds_from": feeds_from,
+                    "is_entry_tie": not feeds_from,
+                }
+                bracket[stage].append(tie_meta)
+                # Populate tie_results ONLY for entry ties (LAST_32 here).
+                # Downstream ties carry placeholder team names; their
+                # tie_results entry is created lazily by remaining_matches
+                # / apply_result once feeds_from resolves to real names.
+                # Eagerly populating with the placeholder set would leave
+                # dead `{L32_W1, L32_W2}`-keyed entries permanently
+                # alongside the real `{Mexico, Portugal}` entry written
+                # by apply_result.
+                if not feeds_from:
+                    tie_results[(stage, teams_set)] = self._new_tie_record(tie_meta)
+
+        return {
+            "_applied": frozenset(),
+            "_tie_results": tie_results,
+            "_bracket": bracket,
+            "_round_reached": {},
+        }
+
     # ---------- soccer-specific sampling: regulation + ET + penalty ----------
 
     def sample_result(

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -24,7 +24,7 @@ import logging
 import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional, Tuple
 
 import requests
 
@@ -1248,6 +1248,63 @@ class GroupStandings(NamedTuple):
     n_best_third_advance: int
 
 
+# WC 2026 LAST_32 bracket pairings, source: FIFA published schedule
+# (matches M73-M88). Each entry: (home_slot, away_slot).
+# Slot kinds:
+#   ("group_winner", "<letter>")     — 1st place in that group
+#   ("group_runner_up", "<letter>")  — 2nd place in that group
+#   ("best_third", frozenset(...))   — best-3rd-placer from any of the
+#                                      listed groups (FIFA Annex C
+#                                      constraint preventing same-group
+#                                      LAST_32 rematches)
+# Match-index 0 = M73, index 1 = M74, ..., index 15 = M88.
+_WC2026_LAST_32_PAIRINGS: List[Tuple[Tuple[str, Any], Tuple[str, Any]]] = [
+    (("group_runner_up", "A"), ("group_runner_up", "B")),                  # M73
+    (("group_winner", "E"),    ("best_third", frozenset("ABCDF"))),        # M74
+    (("group_winner", "F"),    ("group_runner_up", "C")),                  # M75
+    (("group_winner", "C"),    ("group_runner_up", "F")),                  # M76
+    (("group_winner", "I"),    ("best_third", frozenset("CDFGH"))),        # M77
+    (("group_runner_up", "E"), ("group_runner_up", "I")),                  # M78
+    (("group_winner", "A"),    ("best_third", frozenset("CEFHI"))),        # M79
+    (("group_winner", "L"),    ("best_third", frozenset("EHIJK"))),        # M80
+    (("group_winner", "D"),    ("best_third", frozenset("BEFIJ"))),        # M81
+    (("group_winner", "G"),    ("best_third", frozenset("AEHIJ"))),        # M82
+    (("group_runner_up", "K"), ("group_runner_up", "L")),                  # M83
+    (("group_winner", "H"),    ("group_runner_up", "J")),                  # M84
+    (("group_winner", "B"),    ("best_third", frozenset("EFGIJ"))),        # M85
+    (("group_winner", "J"),    ("group_runner_up", "H")),                  # M86
+    (("group_winner", "K"),    ("best_third", frozenset("DEIJL"))),        # M87
+    (("group_runner_up", "D"), ("group_runner_up", "G")),                  # M88
+]
+
+# Downstream-round tree, by FIFA's published mapping (W-of-MN notation
+# unpacked to 0-based feeder indices in the previous stage).
+# Index 0 = first match of the round; tuple = (feeder_idx_a, feeder_idx_b).
+_WC2026_LAST_16_PAIRINGS: List[Tuple[int, int]] = [
+    (0, 2),     # M89 = W73 vs W75
+    (1, 4),     # M90 = W74 vs W77
+    (3, 5),     # M91 = W76 vs W78
+    (6, 7),     # M92 = W79 vs W80
+    (10, 11),   # M93 = W83 vs W84
+    (8, 9),     # M94 = W81 vs W82
+    (13, 15),   # M95 = W86 vs W88
+    (12, 14),   # M96 = W85 vs W87
+]
+_WC2026_QUARTER_FINALS_PAIRINGS: List[Tuple[int, int]] = [
+    (0, 1),     # M97  = W89 vs W90
+    (4, 5),     # M98  = W93 vs W94
+    (2, 3),     # M99  = W91 vs W92
+    (6, 7),     # M100 = W95 vs W96
+]
+_WC2026_SEMI_FINALS_PAIRINGS: List[Tuple[int, int]] = [
+    (0, 1),     # M101 = W97 vs W98
+    (2, 3),     # M102 = W99 vs W100
+]
+_WC2026_FINAL_PAIRINGS: List[Tuple[int, int]] = [
+    (0, 1),     # M103 = W101 vs W102
+]
+
+
 class GroupStageSoccerSource(SoccerSource):
     """Group-stage Monte Carlo importance for international tournaments
     (WC, EURO). Sibling to KnockoutSoccerSource for the same competition:
@@ -1499,3 +1556,223 @@ class GroupStageSoccerSource(SoccerSource):
                 else:
                     outcomes[team] = ["eliminated"]
         return outcomes
+
+    # ---------- #53 cross-source chain wiring ----------
+
+    def set_paired_knockout_source(self, knockout: "KnockoutSoccerSource") -> None:
+        """Register the sibling knockout source for the cross-source
+        chain. Called by the plugin during source instantiation when
+        both group + knockout sources are enabled for the same
+        competition (WC, EURO). Without this wiring,
+        `cross_source_chain` returns None and the simulator runs the
+        single-source path (#53)."""
+        self._paired_knockout = knockout
+
+    def cross_source_chain(
+        self,
+    ) -> Optional[Tuple["KnockoutSoccerSource", Callable[[Dict[str, Any]], Dict[str, Any]]]]:
+        """Return the (downstream, seed_fn) tuple consumed by
+        `monte_carlo_importance_batch_chain`, or None if the chain
+        shouldn't run for this call.
+
+        Two cases where None is returned:
+          1. No paired knockout source was registered (not a tournament
+             with a follow-on bracket — most competitions).
+          2. The knockout source's `_fetch_bracket_games()` returned
+             non-empty, meaning FD.org has populated the bracket with
+             real team names (the group stage has ended and FIFA's
+             draw resolved). In that case the existing single-source
+             knockout path handles importance; the chain would be
+             redundant and potentially conflicting.
+
+        The toggle on `_fetch_bracket_games` is a one-line check that
+        works without time math: while every LAST_32 fixture has null
+        home/away (confirmed pre-tournament for WC 2026 via FD.org
+        probe), `_fetch_bracket_games` filters them out. As soon as
+        FIFA populates teams via FD, the toggle flips.
+        """
+        knockout = getattr(self, "_paired_knockout", None)
+        if knockout is None:
+            return None
+        if knockout._fetch_bracket_games():
+            return None
+
+        # The chain simulator calls seed_fn(primary_state) and passes
+        # the result directly to downstream.remaining_matches / apply /
+        # terminal_outcomes, so seed_fn must return the FULL bracket-
+        # state shape (`_applied`, `_tie_results`, `_bracket`,
+        # `_round_reached`), not the intermediate seed dict that
+        # `_build_bracket_seed` produces. Compose the two steps here so
+        # the simulator's contract is clean (state in, state out) and
+        # each method retains a single responsibility.
+        def chain_seed_fn(primary_state: Dict[str, Any]) -> Dict[str, Any]:
+            seed_dict = self._build_bracket_seed(primary_state)
+            return knockout.seed_from_chain(seed_dict)
+
+        return (knockout, chain_seed_fn)
+
+    def _build_bracket_seed(self, primary_state: Dict[str, Any]) -> Dict[str, Any]:
+        """Map primary group-stage standings to a downstream bracket
+        seed dict consumable by `KnockoutSoccerSource.seed_from_chain`.
+
+        For WC 2026 (the only competition currently wired):
+          - 1st and 2nd place in each group resolve to the matching
+            LAST_32 slot per `_WC2026_LAST_32_PAIRINGS`.
+          - The 8 best-3rd-place teams (per
+            `_compute_group_standings.best_third_order` top
+            `n_best_third_advance`) are assigned to the 8 reserved
+            `best_third` LAST_32 slots via constraint-respecting
+            greedy matching (each slot has an `allowed_groups` set
+            that prevents same-group LAST_32 rematches).
+
+        FIFA's official Annex C codifies a deterministic 495-scenario
+        lookup table that pins the exact 3rd-placer slot assignment
+        for every combination of 8-advancing-groups. This
+        implementation uses a greedy approximation that honors the
+        same-group exclusion constraints. Slot ASSIGNMENTS may
+        differ from FIFA's canonical mapping, but bracket VALIDITY
+        (no same-group rematches at LAST_32) is preserved, and the
+        leverage signal for group games on R16+ outcomes is
+        approximate-but-nonzero. Filed as a follow-up: encoding the
+        full Annex C lookup table for exact bracket reconstruction.
+
+        Downstream rounds (LAST_16 → FINAL) use placeholder names
+        wired via feeds_from per `_WC2026_LAST_16_PAIRINGS` and
+        siblings. Placeholder resolution is the bracket machinery's
+        job (see bracket.py:418 `_winner_of`); this method just
+        wires the references.
+        """
+        standings = self._compute_group_standings(primary_state)
+
+        # Group-key shape in standings.by_group: "GROUP_A" etc. (from
+        # FD.org's `group` field on group-stage matches). Convert
+        # WC2026 slot letters ("A") to group keys ("GROUP_A") for the
+        # winner / runner-up lookups.
+        def _group_key(letter: str) -> str:
+            return f"GROUP_{letter}"
+
+        def _resolve_fixed_slot(slot: Tuple[str, Any]) -> Optional[str]:
+            kind, payload = slot
+            if kind == "group_winner":
+                teams = standings.by_group.get(_group_key(payload), [])
+                return teams[0][0] if teams else None
+            if kind == "group_runner_up":
+                teams = standings.by_group.get(_group_key(payload), [])
+                return teams[1][0] if len(teams) >= 2 else None
+            return None
+
+        # Build the team -> group-letter lookup for the 3rd-placers.
+        team_group_map = primary_state.get("_team_group", {})
+
+        def _letter_of(team: str) -> Optional[str]:
+            grp = team_group_map.get(team)
+            if isinstance(grp, str) and grp.startswith("GROUP_"):
+                return grp[len("GROUP_"):]
+            return None
+
+        # Constraint-respecting assignment of best-3rd-placers to
+        # reserved slots. Greedy fails on cases where the strongest-
+        # first pick locks out a later slot (e.g., the {ABCDEFGH}
+        # qualification set has only 3 candidates for M82's {A,E,H,I,J}
+        # slot — if A, E, and H are all consumed by earlier slots,
+        # M82 stalls). Backtracking DFS tries each slot in canonical
+        # order, attempts each unassigned 3rd-placer whose group is
+        # allowed (strongest-first to preserve the FIFA tiebreaker
+        # bias when multiple solutions exist), recurses, and unwinds
+        # on dead ends. Bounded by n_slots = 8 reserved slots.
+        qualifying_thirds = list(
+            standings.best_third_order[:standings.n_best_third_advance]
+        )
+        third_slots: List[Tuple[int, str, FrozenSet[str]]] = []
+        for l32_idx, (home_slot, away_slot) in enumerate(_WC2026_LAST_32_PAIRINGS):
+            for side, slot in (("home", home_slot), ("away", away_slot)):
+                if slot[0] == "best_third":
+                    third_slots.append((l32_idx, side, slot[1]))
+
+        third_assignments: Dict[Tuple[int, str], str] = {}
+        used: set = set()
+
+        def _assign(slot_idx: int) -> bool:
+            if slot_idx == len(third_slots):
+                return True
+            l32_idx, side, allowed = third_slots[slot_idx]
+            for team, _row in qualifying_thirds:
+                if team in used:
+                    continue
+                letter = _letter_of(team)
+                if letter is None or letter not in allowed:
+                    continue
+                third_assignments[(l32_idx, side)] = team
+                used.add(team)
+                if _assign(slot_idx + 1):
+                    return True
+                del third_assignments[(l32_idx, side)]
+                used.remove(team)
+            return False
+
+        _assign(0)
+
+        # Construct LAST_32 entry ties.
+        l32_ties: List[Dict[str, Any]] = []
+        for l32_idx, (home_slot, away_slot) in enumerate(_WC2026_LAST_32_PAIRINGS):
+            if home_slot[0] == "best_third":
+                home = third_assignments.get((l32_idx, "home"))
+            else:
+                home = _resolve_fixed_slot(home_slot)
+            if away_slot[0] == "best_third":
+                away = third_assignments.get((l32_idx, "away"))
+            else:
+                away = _resolve_fixed_slot(away_slot)
+            if home is None or away is None:
+                # Defensive: incomplete primary_state (e.g., a group
+                # missing from the seed). Skip this tie so the rest of
+                # the bracket still resolves. With a full real
+                # primary_state from FD.org, this should never fire.
+                continue
+            l32_ties.append({
+                "home": home, "away": away,
+                "matchday": 1,
+                "feeds_from": {},
+            })
+
+        # Construct downstream stages with placeholder names + feeds_from.
+        def _placeholder_pair(stage: str, idx: int) -> Tuple[str, str]:
+            return f"{stage}_W{idx*2+1}", f"{stage}_W{idx*2+2}"
+
+        def _downstream_ties(
+            stage: str,
+            pairings: List[Tuple[int, int]],
+            feeder_stage: str,
+        ) -> List[Dict[str, Any]]:
+            ties: List[Dict[str, Any]] = []
+            for tie_idx, (feeder_a, feeder_b) in enumerate(pairings):
+                home, away = _placeholder_pair(stage, tie_idx)
+                ties.append({
+                    "home": home, "away": away,
+                    "matchday": 1,
+                    "feeds_from": {
+                        home: (feeder_stage, feeder_a),
+                        away: (feeder_stage, feeder_b),
+                    },
+                })
+            return ties
+
+        return {
+            "stages": [
+                {"stage": "LAST_32", "ties": l32_ties},
+                {"stage": "LAST_16",
+                 "ties": _downstream_ties("LAST_16", _WC2026_LAST_16_PAIRINGS, "LAST_32")},
+                {"stage": "QUARTER_FINALS",
+                 "ties": _downstream_ties("QUARTER_FINALS",
+                                          _WC2026_QUARTER_FINALS_PAIRINGS,
+                                          "LAST_16")},
+                {"stage": "SEMI_FINALS",
+                 "ties": _downstream_ties("SEMI_FINALS",
+                                          _WC2026_SEMI_FINALS_PAIRINGS,
+                                          "QUARTER_FINALS")},
+                {"stage": "FINAL",
+                 "ties": _downstream_ties("FINAL",
+                                          _WC2026_FINAL_PAIRINGS,
+                                          "SEMI_FINALS")},
+            ],
+        }

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -715,11 +715,15 @@ class TestComputeMatchImportanceChainRouting:
     def test_routes_to_chain_when_cross_source_chain_returns_tuple(
         self, monkeypatch,
     ):
-        # Patch BOTH simulator entry points to record which one was
-        # called. The chain function must fire; the regular batch must
-        # not.
+        # Patch BOTH simulator entry points. Confirm the chain function
+        # fires (not the regular batch) AND that the queries passed in
+        # include the downstream-cascade labels — otherwise WC_GS
+        # could silently drop the cascade labels and this routing test
+        # would still pass while production produces 0 contribution
+        # on R16+ bands.
         from dispatcharr_ranked_matchups import simulation
         called: Dict[str, int] = {"batch": 0, "chain": 0}
+        captured_queries: List[List[Tuple[str, str]]] = []
 
         def fake_batch(source, match, queries, n_sims, rng=None):
             called["batch"] += 1
@@ -728,6 +732,7 @@ class TestComputeMatchImportanceChainRouting:
         def fake_chain(source, match, queries, downstream, seed_fn,
                        n_sims, rng=None):
             called["chain"] += 1
+            captured_queries.append(list(queries))
             return {q: 0.0 for q in queries}
 
         monkeypatch.setattr(simulation, "monte_carlo_importance_batch", fake_batch)
@@ -750,6 +755,16 @@ class TestComputeMatchImportanceChainRouting:
         )
         assert called["chain"] == 1
         assert called["batch"] == 0
+        # Each playing team queried against EVERY threshold label,
+        # including the downstream cascade. If anyone strips cascade
+        # labels from WC_GS, this assertion catches it.
+        seen_labels = {label for _team, label in captured_queries[0]}
+        assert "advance" in seen_labels
+        assert "round_of_16" in seen_labels
+        assert "quarterfinal" in seen_labels
+        assert "semifinal" in seen_labels
+        assert "final" in seen_labels
+        assert "winner" in seen_labels
 
     def test_routes_to_batch_when_cross_source_chain_returns_none(
         self, monkeypatch,

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -692,6 +692,132 @@ class TestComputeMatchImportance:
         assert "title" in notes[2]        # 0.50
 
 
+class TestComputeMatchImportanceChainRouting:
+    """#53: when the source declares a non-None `cross_source_chain`,
+    compute_match_importance routes to `monte_carlo_importance_batch_
+    chain` instead of the regular batch. WC_GS LEAGUE_CONTEXT now
+    carries downstream cascade labels (R16/QF/SF/F/winner), so the
+    chain's per-team merged outcomes get correct weights applied.
+    """
+
+    def _wc_gs_ctx(self):
+        return LEAGUE_CONTEXTS["WC_GS"]
+
+    def test_wc_gs_thresholds_carry_downstream_cascade(self):
+        # Pin the data-model assumption that powers the chain weighting:
+        # WC_GS must include the downstream knockout labels.
+        ctx = self._wc_gs_ctx()
+        labels = {label for _, label, _ in ctx.thresholds}
+        assert "advance" in labels
+        assert {"last_32", "round_of_16", "quarterfinal",
+                "semifinal", "final", "winner"} <= labels
+
+    def test_routes_to_chain_when_cross_source_chain_returns_tuple(
+        self, monkeypatch,
+    ):
+        # Patch BOTH simulator entry points to record which one was
+        # called. The chain function must fire; the regular batch must
+        # not.
+        from dispatcharr_ranked_matchups import simulation
+        called: Dict[str, int] = {"batch": 0, "chain": 0}
+
+        def fake_batch(source, match, queries, n_sims, rng=None):
+            called["batch"] += 1
+            return {q: 0.0 for q in queries}
+
+        def fake_chain(source, match, queries, downstream, seed_fn,
+                       n_sims, rng=None):
+            called["chain"] += 1
+            return {q: 0.0 for q in queries}
+
+        monkeypatch.setattr(simulation, "monte_carlo_importance_batch", fake_batch)
+        monkeypatch.setattr(
+            simulation, "monte_carlo_importance_batch_chain", fake_chain,
+        )
+
+        class FakeDownstream:
+            supports_importance = True
+
+        class FakeGroupSource:
+            supports_importance = True
+
+            def cross_source_chain(self):
+                return (FakeDownstream(), lambda state: state)
+
+        compute_match_importance(
+            FakeGroupSource(), _FakeMatch("Mexico", "South Africa"),
+            self._wc_gs_ctx(), n_sims=10,
+        )
+        assert called["chain"] == 1
+        assert called["batch"] == 0
+
+    def test_routes_to_batch_when_cross_source_chain_returns_none(
+        self, monkeypatch,
+    ):
+        # Same shape as above but cross_source_chain returns None
+        # (chain inactive). Regular batch must fire.
+        from dispatcharr_ranked_matchups import simulation
+        called: Dict[str, int] = {"batch": 0, "chain": 0}
+
+        def fake_batch(source, match, queries, n_sims, rng=None):
+            called["batch"] += 1
+            return {q: 0.0 for q in queries}
+
+        def fake_chain(*args, **kwargs):
+            called["chain"] += 1
+            return {q: 0.0 for q in kwargs.get("queries", [])}
+
+        monkeypatch.setattr(simulation, "monte_carlo_importance_batch", fake_batch)
+        monkeypatch.setattr(
+            simulation, "monte_carlo_importance_batch_chain", fake_chain,
+        )
+
+        class FakeSource:
+            supports_importance = True
+
+            def cross_source_chain(self):
+                return None
+
+        compute_match_importance(
+            FakeSource(), _FakeMatch("Mexico", "South Africa"),
+            self._wc_gs_ctx(), n_sims=10,
+        )
+        assert called["batch"] == 1
+        assert called["chain"] == 0
+
+    def test_routes_to_batch_when_source_lacks_cross_source_chain(
+        self, monkeypatch,
+    ):
+        # Sources without the cross_source_chain method (EPL, NCAAF,
+        # etc.) take the regular batch path unconditionally.
+        from dispatcharr_ranked_matchups import simulation
+        called: Dict[str, int] = {"batch": 0, "chain": 0}
+
+        def fake_batch(source, match, queries, n_sims, rng=None):
+            called["batch"] += 1
+            return {q: 0.0 for q in queries}
+
+        def fake_chain(*args, **kwargs):
+            called["chain"] += 1
+            return {q: 0.0 for q in kwargs.get("queries", [])}
+
+        monkeypatch.setattr(simulation, "monte_carlo_importance_batch", fake_batch)
+        monkeypatch.setattr(
+            simulation, "monte_carlo_importance_batch_chain", fake_chain,
+        )
+
+        class NoChainSource:
+            supports_importance = True
+            # No cross_source_chain method at all.
+
+        compute_match_importance(
+            NoChainSource(), _FakeMatch("Wrexham", "Hull"),
+            LEAGUE_CONTEXTS["ELC"], n_sims=10,
+        )
+        assert called["batch"] == 1
+        assert called["chain"] == 0
+
+
 class TestScoreGameImportanceBranch:
     def test_importance_points_zero_no_breakdown_entry(self):
         s = GameSignals(rank_a=1, rank_b=2, importance_points=0.0)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -343,6 +343,190 @@ class TestMonteCarloImportanceBatch:
         assert out == {}
 
 
+# ---------- monte_carlo_importance_batch_chain ----------
+
+
+@dataclass
+class FakePlayoffSource(SportSource):
+    """Downstream-only FakeSource for the chain simulator. Has no matches
+    to drain (the seed alone determines outcomes), and emits
+    `qualified` / `eliminated_in_playoffs` outcome labels keyed by the
+    seed-supplied state. Used to test that the chain simulator merges
+    primary and downstream outcomes correctly.
+    """
+    _supports_importance: bool = True
+
+    @property
+    def supports_importance(self) -> bool:  # type: ignore[override]
+        return self._supports_importance
+
+    @property
+    def sport_prefix(self) -> str:
+        return "FAKE_PO"
+
+    @property
+    def sport_label(self) -> str:
+        return "Fake Playoffs"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        return []
+
+    @property
+    def outcome_labels(self) -> List[str]:
+        return ["qualified", "eliminated_in_playoffs"]
+
+    def estimate_strengths(self) -> Dict[str, Dict[str, float]]:
+        return {}
+
+    def initial_state(self) -> Dict[str, Any]:
+        return {"qualified": [], "eliminated": []}
+
+    def remaining_matches(self, state: Dict[str, Any]) -> List[GameRow]:
+        return []
+
+    def sample_result(self, state, match, strengths, rng):
+        raise AssertionError("FakePlayoffSource has no matches to sample")
+
+    def apply_result(self, state, match, result):
+        raise AssertionError("FakePlayoffSource has no matches to apply")
+
+    def terminal_outcomes(self, state):
+        out: Dict[str, List[str]] = {}
+        for team in state.get("qualified", []):
+            out[team] = ["qualified"]
+        for team in state.get("eliminated", []):
+            out[team] = ["eliminated_in_playoffs"]
+        return out
+
+
+def _group_winner_seed_fn(primary_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Map primary FakeSource standings to playoff seeding. Top finisher
+    qualifies; the bottom finisher is eliminated_in_playoffs."""
+    teams = [(n, r) for n, r in primary_state.items() if n != "_applied"]
+    teams.sort(key=lambda kv: (-kv[1]["points"], -(kv[1]["gf"] - kv[1]["ga"]), -kv[1]["gf"]))
+    if not teams:
+        return {"qualified": [], "eliminated": []}
+    return {
+        "qualified": [teams[0][0]],
+        "eliminated": [teams[-1][0]],
+    }
+
+
+class TestMonteCarloImportanceBatchChain:
+    def test_chain_emits_downstream_outcomes(self):
+        # The chain should fire `qualified` leverage on Alpha for the
+        # Alpha vs Delta game: Alpha winning strongly correlates with
+        # Alpha finishing top of the table and earning the `qualified`
+        # downstream label.
+        source, target = _make_round_robin()
+        downstream = FakePlayoffSource()
+        out = simulation.monte_carlo_importance_batch_chain(
+            source, target,
+            queries=[("Alpha", "qualified")],
+            downstream=downstream,
+            seed_fn=_group_winner_seed_fn,
+            n_sims=400, rng=random.Random(0),
+        )
+        assert ("Alpha", "qualified") in out
+        # Alpha vs Delta with Alpha as strong powerhouse: nontrivial
+        # leverage on the qualified bucket.
+        assert out[("Alpha", "qualified")] > 0.05
+
+    def test_chain_merges_primary_and_downstream_buckets(self):
+        # Same target match, two queries: one primary-only outcome
+        # (`champion`) and one downstream-only outcome (`qualified`).
+        # Both should report nonzero leverage; both are derived from
+        # the same simulated seasons in one pass.
+        source, target = _make_round_robin()
+        downstream = FakePlayoffSource()
+        out = simulation.monte_carlo_importance_batch_chain(
+            source, target,
+            queries=[("Alpha", "champion"), ("Alpha", "qualified")],
+            downstream=downstream,
+            seed_fn=_group_winner_seed_fn,
+            n_sims=400, rng=random.Random(0),
+        )
+        assert out[("Alpha", "champion")] > 0.05
+        assert out[("Alpha", "qualified")] > 0.05
+
+    def test_chain_query_for_eliminated_team_returns_low_leverage(self):
+        # Querying a downstream outcome that NEVER fires for the team
+        # (e.g., asking about Delta finishing `qualified` — Delta is
+        # the dreadful team and never wins the group) should return
+        # near-zero leverage.
+        source, target = _make_round_robin()
+        downstream = FakePlayoffSource()
+        out = simulation.monte_carlo_importance_batch_chain(
+            source, target,
+            queries=[("Delta", "qualified")],
+            downstream=downstream,
+            seed_fn=_group_winner_seed_fn,
+            n_sims=400, rng=random.Random(0),
+        )
+        # tau-c degenerates to 0 when one column is empty (the outcome
+        # never fires). Permit a tiny epsilon for sampling variance.
+        assert out[("Delta", "qualified")] < 0.05
+
+    def test_chain_unsupported_primary_raises(self):
+        source, target = _make_round_robin()
+        source._supports_importance = False
+        with pytest.raises(ValueError, match="does not support importance"):
+            simulation.monte_carlo_importance_batch_chain(
+                source, target, queries=[("Alpha", "qualified")],
+                downstream=FakePlayoffSource(),
+                seed_fn=_group_winner_seed_fn,
+                n_sims=10,
+            )
+
+    def test_chain_unsupported_downstream_raises(self):
+        source, target = _make_round_robin()
+        downstream = FakePlayoffSource(_supports_importance=False)
+        with pytest.raises(ValueError, match="does not support importance"):
+            simulation.monte_carlo_importance_batch_chain(
+                source, target, queries=[("Alpha", "qualified")],
+                downstream=downstream,
+                seed_fn=_group_winner_seed_fn,
+                n_sims=10,
+            )
+
+    def test_chain_empty_queries_returns_empty_dict(self):
+        source, target = _make_round_robin()
+        out = simulation.monte_carlo_importance_batch_chain(
+            source, target, queries=[],
+            downstream=FakePlayoffSource(),
+            seed_fn=_group_winner_seed_fn,
+            n_sims=50, rng=random.Random(0),
+        )
+        assert out == {}
+
+    def test_chain_seed_fn_receives_drained_primary_state(self):
+        # The seed_fn should see the FULL primary standings (target
+        # match applied + remaining matches drained). Capture the
+        # state via a side-channel and assert.
+        source, target = _make_round_robin()
+        downstream = FakePlayoffSource()
+        captured: List[Dict[str, Any]] = []
+
+        def capturing_seed_fn(state):
+            captured.append(state)
+            return _group_winner_seed_fn(state)
+
+        simulation.monte_carlo_importance_batch_chain(
+            source, target, queries=[("Alpha", "qualified")],
+            downstream=downstream,
+            seed_fn=capturing_seed_fn,
+            n_sims=3, rng=random.Random(0),
+        )
+        # 3 sims => 3 seed_fn invocations.
+        assert len(captured) == 3
+        # Each captured state has all 4 teams played their 3 games each
+        # (round-robin = 6 games; 4 teams playing 3 each = 12 team-games,
+        # which is 6 games × 2 teams = matches).
+        for state in captured:
+            for team in ("Alpha", "Beta", "Gamma", "Delta"):
+                assert state[team]["played"] == 3
+
+
 # ---------- _same_match ----------
 
 class TestSameMatch:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8152,6 +8152,382 @@ class TestKnockoutSoccerSourceSeedFromChain:
         assert len(all_ids) == len(set(all_ids)), "duplicate synthetic game_ids"
 
 
+class TestGroupStageSoccerSourceChainWiring:
+    """`set_paired_knockout_source` + `cross_source_chain` together
+    expose the toggle that scoring.py:compute_match_importance reads
+    to decide between the single-source path and the chain path (#53).
+    """
+
+    @staticmethod
+    def _wc_pair():
+        from dispatcharr_ranked_matchups.sources.soccer import (
+            GroupStageSoccerSource, KnockoutSoccerSource,
+        )
+        groups = GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+        knockout = KnockoutSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+        return groups, knockout
+
+    def test_unwired_returns_none(self):
+        # No `_paired_knockout` registered: single-source path.
+        groups, _ = self._wc_pair()
+        assert groups.cross_source_chain() is None
+
+    def test_wired_with_empty_bracket_returns_chain(self):
+        # Pre-tournament state: knockout's _fetch_bracket_games returns
+        # empty (FD.org publishes placeholders with null team names).
+        # The chain should activate.
+        groups, knockout = self._wc_pair()
+        knockout._fetch_bracket_games = lambda: []  # type: ignore[method-assign]
+        groups.set_paired_knockout_source(knockout)
+        result = groups.cross_source_chain()
+        assert result is not None
+        downstream, seed_fn = result
+        assert downstream is knockout
+        # seed_fn is the bracket seed builder.
+        assert callable(seed_fn)
+
+    def test_wired_with_populated_bracket_returns_none(self):
+        # Mid-tournament toggle: once FD.org has real teams in the
+        # knockout bracket, the chain steps aside and lets the
+        # existing single-source path take over.
+        groups, knockout = self._wc_pair()
+        knockout._fetch_bracket_games = lambda: [  # type: ignore[method-assign]
+            {"game_id": 1, "stage": "LAST_32", "matchday": 1,
+             "home": "Mexico", "away": "Norway",
+             "home_goals": None, "away_goals": None,
+             "status": "SCHEDULED", "start_time": None, "extra": {}},
+        ]
+        groups.set_paired_knockout_source(knockout)
+        assert groups.cross_source_chain() is None
+
+
+class TestBuildBracketSeedWC2026:
+    """`_build_bracket_seed` maps a 12-group primary_state to the WC 2026
+    bracket structure per FIFA's published M73-M103 schedule. The
+    LAST_32 pairings are exact; best-3rd-place slot assignment is a
+    constraint-respecting greedy approximation of FIFA's Annex C.
+    """
+
+    @staticmethod
+    def _wc_source():
+        from dispatcharr_ranked_matchups.sources.soccer import GroupStageSoccerSource
+        return GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+
+    @staticmethod
+    def _make_wc_state(group_data, team_group):
+        """Build a primary_state shaped like GroupStageSoccerSource produces."""
+        state = {"_applied": frozenset(), "_team_group": team_group}
+        for _grp, rows in group_data.items():
+            for team, points, gd, gf in rows:
+                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
+        return state
+
+    @classmethod
+    def _full_wc_state(cls, third_qualifiers=None):
+        """Build a full 12-group state where each group's finishing
+        order is deterministic: GA1 > GA2 > GA3 > GA4 by points.
+        `third_qualifiers`, if given, is a set of group letters whose
+        3rd-placers should have stronger stats so they advance as
+        best-3rd. Default: all 12 third-placers tied; tiebreaker by
+        alphabetical group letter (A wins, L loses) so the top 8 are A-H.
+        """
+        team_group: Dict[str, str] = {}
+        group_data: Dict[str, List[Tuple[str, int, int, int]]] = {}
+        third_qualifiers = third_qualifiers or set("ABCDEFGH")
+        for gi in range(12):
+            letter = chr(ord("A") + gi)
+            grp = f"GROUP_{letter}"
+            third_pts = 4 if letter in third_qualifiers else 1
+            third_gd = 2 if letter in third_qualifiers else -2
+            teams = [
+                (f"G{letter}1", 9, 5, 8),
+                (f"G{letter}2", 6, 2, 5),
+                (f"G{letter}3", third_pts, third_gd, 3),
+                (f"G{letter}4", 0, -5, 1),
+            ]
+            for t, _p, _g, _f in teams:
+                team_group[t] = grp
+            group_data[grp] = teams
+        return cls._make_wc_state(group_data, team_group)
+
+    def test_returns_five_stage_seed_shape(self):
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        stage_names = [s["stage"] for s in seed["stages"]]
+        assert stage_names == [
+            "LAST_32", "LAST_16", "QUARTER_FINALS", "SEMI_FINALS", "FINAL",
+        ]
+
+    def test_last_32_has_16_ties(self):
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]
+        assert l32["stage"] == "LAST_32"
+        assert len(l32["ties"]) == 16
+
+    def test_last_32_pairing_m73_runners_up_a_vs_b(self):
+        # M73 per FIFA: 2A vs 2B → "GA2" vs "GB2" in our deterministic state.
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        m73 = l32[0]
+        assert {m73["home"], m73["away"]} == {"GA2", "GB2"}
+
+    def test_last_32_pairing_m75_fixed_winner_runner_up(self):
+        # M75 per FIFA: 1F vs 2C → "GF1" vs "GC2".
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        m75 = l32[2]
+        assert {m75["home"], m75["away"]} == {"GF1", "GC2"}
+
+    def test_best_third_respects_allowed_groups_constraint(self):
+        # M74 per FIFA: 1E vs best-third from {A,B,C,D,F}. The 3rd-placer
+        # MUST come from one of those 5 groups. The bracket MUST NOT
+        # pair "1E" with "GE3" (same group).
+        src = self._wc_source()
+        # Use a scenario where all 8 best-3rd-placers come from
+        # groups that include E — so the greedy assignment MIGHT
+        # accidentally place GE3 in M74's slot if the constraint
+        # were ignored.
+        state = self._full_wc_state(third_qualifiers=set("ABCDEFGH"))
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        m74 = l32[1]
+        # Home = 1E = "GE1"; away = best-3rd from {A,B,C,D,F}.
+        assert "GE1" in {m74["home"], m74["away"]}
+        third_team = m74["home"] if m74["away"] == "GE1" else m74["away"]
+        # Constraint: that team's group letter is in {A,B,C,D,F}, NOT E.
+        team_group_letter = third_team[1]  # "GA3" -> "A"
+        assert team_group_letter in "ABCDF"
+        assert team_group_letter != "E"
+
+    def test_last_16_pairings_match_fifa_published_tree(self):
+        # M89 = W73 vs W75 → L16 tie 0 wires to L32 indices 0 and 2.
+        # M90 = W74 vs W77 → L16 tie 1 wires to L32 indices 1 and 4.
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        l16 = seed["stages"][1]["ties"]
+        # Tie 0: feeds_from should reference LAST_32 indices 0 and 2.
+        feeds_m89 = list(l16[0]["feeds_from"].values())
+        assert set(feeds_m89) == {("LAST_32", 0), ("LAST_32", 2)}
+        # Tie 1: indices 1 and 4.
+        feeds_m90 = list(l16[1]["feeds_from"].values())
+        assert set(feeds_m90) == {("LAST_32", 1), ("LAST_32", 4)}
+
+    def test_quarter_finals_pairings_match_fifa_published_tree(self):
+        # M97 = W89 vs W90 → QF tie 0 wires to LAST_16 indices 0 and 1.
+        # M99 = W91 vs W92 → QF tie 2 wires to LAST_16 indices 2 and 3.
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        qf = seed["stages"][2]["ties"]
+        feeds_m97 = list(qf[0]["feeds_from"].values())
+        assert set(feeds_m97) == {("LAST_16", 0), ("LAST_16", 1)}
+        feeds_m99 = list(qf[2]["feeds_from"].values())
+        assert set(feeds_m99) == {("LAST_16", 2), ("LAST_16", 3)}
+
+    def test_semi_finals_and_final_have_correct_feeder_counts(self):
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        sf = seed["stages"][3]["ties"]
+        final = seed["stages"][4]["ties"]
+        assert len(sf) == 2
+        assert len(final) == 1
+        # FINAL feeds from SF indices 0 and 1.
+        feeds_final = list(final[0]["feeds_from"].values())
+        assert set(feeds_final) == {("SEMI_FINALS", 0), ("SEMI_FINALS", 1)}
+
+    def test_no_same_group_pairings_in_last_32(self):
+        # Hard invariant: no two teams from the same group can meet in
+        # the LAST_32. The greedy 3rd-placer assignment honors this
+        # via the allowed-groups constraint.
+        src = self._wc_source()
+        state = self._full_wc_state()
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        for tie in l32:
+            assert tie["home"][1] != tie["away"][1], (
+                f"same-group L32 pairing: {tie['home']} vs {tie['away']}"
+            )
+
+    def test_only_top_n_third_placers_advance(self):
+        # 12 groups → 12 third-placers; with WC's
+        # best_third_place_count=8, exactly 8 should appear in L32 ties.
+        src = self._wc_source()
+        state = self._full_wc_state(third_qualifiers=set("ABCDEFGH"))
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        # Pull all 3rd-placers (team names ending in "3") that landed
+        # in L32 slots.
+        thirds_in_bracket = [
+            t for tie in l32 for t in (tie["home"], tie["away"])
+            if t.endswith("3")
+        ]
+        assert len(thirds_in_bracket) == 8
+        # All from the 8 strong groups (A-H), per the deterministic
+        # test setup.
+        for team in thirds_in_bracket:
+            assert team[1] in "ABCDEFGH"
+
+
+class TestWC2026ChainEndToEnd:
+    """The #53 acceptance criterion: a WC group-stage match must produce
+    nonzero leverage on R16 / QF / SF / FINAL / WINNER bands via the
+    cross-source chain.
+
+    This test bypasses FD.org by patching `_fetch_all_season_matches`
+    and `estimate_strengths` on the primary group source so the chain
+    runs against a deterministic 12-group, 72-match fixture set.
+    """
+
+    @staticmethod
+    def _wc_pair_with_fixtures():
+        """Build a GroupStageSoccerSource + KnockoutSoccerSource pair
+        with patched fetchers returning a synthetic WC 2026 fixture.
+        Each of 12 groups (A-L) has 4 teams playing 6 games. All games
+        SCHEDULED so the simulator drains them all per sim.
+        """
+        from dispatcharr_ranked_matchups.sources.soccer import (
+            GroupStageSoccerSource, KnockoutSoccerSource,
+        )
+        groups_src = GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+        knockout_src = KnockoutSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+
+        fixtures: List[Dict[str, Any]] = []
+        fid = 0
+        for gi in range(12):
+            letter = chr(ord("A") + gi)
+            grp = f"GROUP_{letter}"
+            teams = [f"G{letter}{n}" for n in (1, 2, 3, 4)]
+            # Round-robin 6 games per group.
+            pairs = [(0, 1), (2, 3), (0, 2), (1, 3), (0, 3), (1, 2)]
+            for pi, (a, b) in enumerate(pairs):
+                fid += 1
+                fixtures.append({
+                    "id": fid,
+                    "stage": "GROUP_STAGE",
+                    "group": grp,
+                    "matchday": pi % 3 + 1,
+                    "homeTeam": {"name": teams[a]},
+                    "awayTeam": {"name": teams[b]},
+                    "status": "SCHEDULED",
+                    "utcDate": "2026-06-11T19:00:00Z",
+                    "score": {},
+                })
+        groups_src._all_matches_cache = fixtures
+        knockout_src._all_matches_cache = fixtures  # the knockout filters down
+
+        # Synthetic strengths: G[L]1 strongest, G[L]4 weakest in each group.
+        # Stronger groups (earlier alphabet) have higher absolute strengths
+        # so the cross-group standings settle into a deterministic-ish
+        # qualification pattern across sims.
+        strengths: Dict[str, Dict[str, float]] = {}
+        for gi in range(12):
+            letter = chr(ord("A") + gi)
+            base = 2.5 - gi * 0.05
+            strengths[f"G{letter}1"] = {"sh": base + 1.2, "sa": base + 0.9, "ch": 0.5, "ca": 0.7}
+            strengths[f"G{letter}2"] = {"sh": base + 0.4, "sa": base + 0.2, "ch": 1.0, "ca": 1.2}
+            strengths[f"G{letter}3"] = {"sh": base - 0.2, "sa": base - 0.4, "ch": 1.5, "ca": 1.7}
+            strengths[f"G{letter}4"] = {"sh": base - 1.0, "sa": base - 1.2, "ch": 2.0, "ca": 2.2}
+        groups_src.estimate_strengths = lambda: strengths  # type: ignore[method-assign]
+        knockout_src.estimate_strengths = lambda: strengths  # type: ignore[method-assign]
+
+        # Knockout source's bracket fetcher returns empty (pre-tournament
+        # state). Without this the chain toggles off.
+        knockout_src._fetch_bracket_games = lambda: []  # type: ignore[method-assign]
+
+        groups_src.set_paired_knockout_source(knockout_src)
+        return groups_src, knockout_src
+
+    def test_chain_runs_end_to_end_and_emits_knockout_outcomes(self):
+        # Smoke test: the chain runs without exceptions and the merged
+        # outcomes include knockout-stage labels for at least one team
+        # in the simulated bracket.
+        import random
+        from dispatcharr_ranked_matchups import simulation
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+
+        groups_src, _ = self._wc_pair_with_fixtures()
+        chain = groups_src.cross_source_chain()
+        assert chain is not None
+        knockout_src, seed_fn = chain
+
+        # Target a group A MD1 game (GA1 vs GA2).
+        target = GameRow(
+            sport_prefix="WC", sport_label="FIFA World Cup",
+            home="GA1", away="GA2",
+            rank_home=None, rank_away=None, start_time=None,
+            extra={"fd_id": 1, "stage": "GROUP_STAGE",
+                   "fd_competition_code": "WC_GS"},
+        )
+
+        # Query a knockout-stage outcome for one of the playing teams.
+        queries = [("GA1", "round_of_16"), ("GA1", "quarterfinal")]
+        out = simulation.monte_carlo_importance_batch_chain(
+            groups_src, target, queries=queries,
+            downstream=knockout_src, seed_fn=seed_fn,
+            n_sims=20, rng=random.Random(0),
+        )
+        # Result dict has both queries; values in [0, 1].
+        assert set(out.keys()) == set(queries)
+        for v in out.values():
+            assert 0.0 <= v <= 1.0
+
+    def test_chain_emits_nonzero_r16_leverage_for_group_game(self):
+        # Acceptance criterion from #53: a group-stage game should
+        # report NONZERO leverage on R16+ outcomes via the chain.
+        # Without the chain, the single-source path returns 0 on every
+        # knockout band for a group source (the group source's
+        # outcome vocabulary is just advance/eliminated).
+        import random
+        from dispatcharr_ranked_matchups import simulation
+        from dispatcharr_ranked_matchups.sources.base import GameRow
+
+        groups_src, _ = self._wc_pair_with_fixtures()
+        chain = groups_src.cross_source_chain()
+        assert chain is not None
+        knockout_src, seed_fn = chain
+
+        target = GameRow(
+            sport_prefix="WC", sport_label="FIFA World Cup",
+            home="GA1", away="GA2",
+            rank_home=None, rank_away=None, start_time=None,
+            extra={"fd_id": 1, "stage": "GROUP_STAGE",
+                   "fd_competition_code": "WC_GS"},
+        )
+
+        # Query several knockout bands on the strong team. With 200
+        # sims and the synthetic strength gradient, at least one
+        # downstream band should show measurable leverage.
+        queries = [
+            ("GA1", "round_of_16"),
+            ("GA1", "quarterfinal"),
+            ("GA1", "semifinal"),
+        ]
+        out = simulation.monte_carlo_importance_batch_chain(
+            groups_src, target, queries=queries,
+            downstream=knockout_src, seed_fn=seed_fn,
+            n_sims=200, rng=random.Random(0),
+        )
+        # At least one knockout band fires with measurable leverage.
+        # The exact band that fires depends on the strength gradient;
+        # the test passes as long as the chain isn't returning 0 on
+        # every downstream query (which would be the bug #53 reports).
+        max_leverage = max(out.values())
+        assert max_leverage > 0.01, (
+            f"chain returned ~zero leverage on all knockout queries: {out!r} — "
+            "the #53 bug pattern (group games show 0 on every downstream "
+            "band) appears to be unfixed"
+        )
+
+
 class TestGroupStageContextCodes:
     """LEAGUE_CONTEXTS entries for WC_GS / EC_GS must exist with the
     `advance` outcome label so the GroupStageSoccerSource's

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7991,6 +7991,167 @@ class TestKnockoutSoccerSourceSkipsGroupStage:
         assert {r.extra["fd_id"] for r in out} == {1, 2}
 
 
+class TestKnockoutSoccerSourceSeedFromChain:
+    """`seed_from_chain` is the #53 entry point for chain-driven bracket
+    simulation. The seed dict carries an explicit per-stage tie shape so
+    the bracket doesn't need to be present in FD.org pre-tournament
+    (probed and confirmed empty: WC LAST_32 endpoint returns 16 timed
+    placeholders with null team names).
+
+    Downstream stages use placeholder team names ("L32_W1" etc.) wired
+    to L32 ties via feeds_from. The bracket machinery resolves them at
+    each remaining_matches call via `_winner_of` recursively walking
+    `_resolve_participants` against the simulated tie_results — see
+    bracket.py:418.
+    """
+
+    @staticmethod
+    def _src():
+        from dispatcharr_ranked_matchups.sources.soccer import KnockoutSoccerSource
+        return KnockoutSoccerSource("world_cup", fd_api_key="x")
+
+    def test_returns_initial_state_shape(self):
+        src = self._src()
+        state = src.seed_from_chain({"stages": []})
+        # Same keys as BracketSportSource.initial_state.
+        assert set(state.keys()) == {"_applied", "_tie_results", "_bracket", "_round_reached"}
+        assert state["_applied"] == frozenset()
+        assert state["_round_reached"] == {}
+        # Empty seed yields per-stage empty lists for every KO_STAGE.
+        assert set(state["_bracket"].keys()) == set(src.KO_STAGES)
+        for ties in state["_bracket"].values():
+            assert ties == []
+
+    def test_minimal_two_team_l32_drains_and_emits_round_reached(self):
+        # One LAST_32 tie. After draining, the loser hits round_of_16
+        # depth (eliminated at L32) and the winner advances.
+        import random
+        src = self._src()
+        seed = {
+            "stages": [{
+                "stage": "LAST_32",
+                "ties": [{"home": "Mexico", "away": "Norway",
+                          "matchday": 1, "feeds_from": {}}],
+            }],
+        }
+        state = src.seed_from_chain(seed)
+        # Stub strengths so Mexico is ~certain to win.
+        strengths = {
+            "Mexico": {"sh": 3.0, "sa": 2.5, "ch": 0.5, "ca": 0.5},
+            "Norway": {"sh": 0.3, "sa": 0.3, "ch": 3.0, "ca": 3.0},
+        }
+        rng = random.Random(0)
+        while True:
+            rem = src.remaining_matches(state)
+            if not rem:
+                break
+            for m in rem:
+                r = src.sample_result(state, m, strengths, rng)
+                state = src.apply_result(state, m, r)
+        # One tie resolved; the tie_results entry exists keyed by simulated
+        # participants.
+        tr = state["_tie_results"]
+        assert ("LAST_32", frozenset({"Mexico", "Norway"})) in tr
+        # round_reached should mark both teams; the loser caps at L32 depth.
+        rr = state["_round_reached"]
+        assert "Mexico" in rr and "Norway" in rr
+
+    def test_two_stage_chain_resolves_via_winner_of_fix(self):
+        # 2 L32 ties + 1 L16 tie wired via feeds_from with placeholder
+        # participant names. After both L32 ties resolve, the L16 tie
+        # must emit a game with the REAL winners (not the placeholders).
+        # This validates the bracket.py _winner_of recursive-resolution
+        # fix end-to-end: without it, the L16 tie would never emit
+        # because _winner_of would key tie_results by placeholder names
+        # and miss the simulated-name entries.
+        import random
+        src = self._src()
+        seed = {
+            "stages": [
+                {"stage": "LAST_32", "ties": [
+                    {"home": "Mexico", "away": "Norway",
+                     "matchday": 1, "feeds_from": {}},
+                    {"home": "Brazil", "away": "Iceland",
+                     "matchday": 1, "feeds_from": {}},
+                ]},
+                {"stage": "LAST_16", "ties": [
+                    {"home": "L32_W1", "away": "L32_W2",
+                     "matchday": 1,
+                     "feeds_from": {"L32_W1": ("LAST_32", 0),
+                                    "L32_W2": ("LAST_32", 1)}},
+                ]},
+            ],
+        }
+        state = src.seed_from_chain(seed)
+        strengths = {
+            "Mexico":  {"sh": 3.0, "sa": 2.5, "ch": 0.5, "ca": 0.5},
+            "Norway":  {"sh": 0.3, "sa": 0.3, "ch": 3.0, "ca": 3.0},
+            "Brazil":  {"sh": 3.5, "sa": 3.0, "ch": 0.4, "ca": 0.4},
+            "Iceland": {"sh": 0.4, "sa": 0.3, "ch": 3.2, "ca": 3.2},
+        }
+        rng = random.Random(1)
+        # Drain until empty. Each pass should emit eligible games.
+        passes_with_games = 0
+        for _ in range(10):  # safety cap; should converge in <=3 passes
+            rem = src.remaining_matches(state)
+            if not rem:
+                break
+            passes_with_games += 1
+            for m in rem:
+                r = src.sample_result(state, m, strengths, rng)
+                state = src.apply_result(state, m, r)
+        # If _winner_of were broken, L16 would never emit a game and the
+        # drain would converge after the L32 round, not iterate.
+        assert passes_with_games >= 2, (
+            "L16 tie failed to emit after L32 resolved — _winner_of fix "
+            "regression suspected"
+        )
+        # L16 tie_results should exist with REAL team names (the L32 winners).
+        l16_keys = [k for k in state["_tie_results"] if k[0] == "LAST_16"]
+        assert len(l16_keys) == 1
+        _, teams = l16_keys[0]
+        # Placeholders should NEVER appear in resolved tie_results keys.
+        assert "L32_W1" not in teams
+        assert "L32_W2" not in teams
+        # The teams are the strong-team winners (deterministic-ish with
+        # the strength gradient + seed=1).
+        assert teams == frozenset({"Mexico", "Brazil"})
+
+    def test_seed_from_chain_skips_unknown_stages_defensively(self):
+        # Stages not in KO_STAGES are silently dropped (defensive against
+        # FIFA introducing a new stage label we haven't mapped).
+        src = self._src()
+        seed = {"stages": [
+            {"stage": "ROUND_OF_128", "ties": [
+                {"home": "Foo", "away": "Bar",
+                 "matchday": 1, "feeds_from": {}},
+            ]},
+        ]}
+        state = src.seed_from_chain(seed)
+        for ties in state["_bracket"].values():
+            assert ties == []
+
+    def test_seed_from_chain_synthesizes_unique_game_ids(self):
+        # Synthetic game_ids must be unique across the bracket; otherwise
+        # the `applied` set conflates ties and an already-played L32 tie
+        # would re-emit when L16 starts up.
+        src = self._src()
+        seed = {"stages": [
+            {"stage": "LAST_32", "ties": [
+                {"home": f"T{i}A", "away": f"T{i}B", "matchday": 1,
+                 "feeds_from": {}} for i in range(3)
+            ]},
+        ]}
+        state = src.seed_from_chain(seed)
+        all_ids = [
+            g["game_id"]
+            for ties in state["_bracket"].values()
+            for tie_meta in ties
+            for g in tie_meta["games"]
+        ]
+        assert len(all_ids) == len(set(all_ids)), "duplicate synthetic game_ids"
+
+
 class TestGroupStageContextCodes:
     """LEAGUE_CONTEXTS entries for WC_GS / EC_GS must exist with the
     `advance` outcome label so the GroupStageSoccerSource's


### PR DESCRIPTION
Closes #53. (Continues from #76, which auto-closed when Phase A's branch was deleted on merge of #75. This PR is now rebased onto `main`.)

## Summary

Adds the cross-source advancement chain so a WC group-stage game (#53's acceptance criterion: Mexico vs South Africa MD1, the Group A opener) reports nonzero leverage on R16 / QF / SF / FINAL / WINNER bands. Before this change, those bands always read 0 because group-source `terminal_outcomes` only emits `advance` / `eliminated`.

5 commits, each atomic:
- **#53.1** — `monte_carlo_importance_batch_chain` in `simulation.py`. New entry point that drains primary, seeds downstream, drains downstream, and merges per-team outcomes into one tau-c contingency table.
- **#53.2** — `KnockoutSoccerSource.seed_from_chain` builds bracket state from an explicit seed dict (FD.org publishes empty placeholders for WC pre-tournament, confirmed via probe). Also fixes a **latent bug in `bracket.py:_winner_of`** that misses tie_results entries when source-published team names differ from simulated participants (UCL-style counterfactual case noted in `apply_result`'s comment but never tested).
- **#53.3** — `_WC2026_LAST_32_PAIRINGS` per FIFA's published M73-M88 schedule + LAST_16 / QF / SF / FINAL feeder index tables. `GroupStageSoccerSource._build_bracket_seed` uses backtracking DFS for the best-3rd-place slot constraints (greedy locked out the {ABCDEFGH} qualification case). FIFA's Annex C 495-scenario canonical mapping is NOT encoded; the backtracking produces a VALID assignment (no same-group LAST_32 rematches) but permutations may differ from FIFA's chart. Filed as #77 for the canonical encoding.
- **#53.4** — `plugin.py` wires `set_paired_knockout_source` for WC. `scoring.py` `WC_GS` LEAGUE_CONTEXT now carries the downstream cascade labels. `compute_match_importance` routes to `monte_carlo_importance_batch_chain` when the source declares a chain.
- **#53.5** — senior-dev review fixes: extracted `_WC_KNOCKOUT_THRESHOLDS` constant so `WC` and `WC_GS` share the cascade definition; tightened the routing test to also pin the queries shape.

## Live verification

Mexico vs South Africa MD1, run on the actual Dispatcharr container after deploying the diff:

```
target: Mexico vs South Africa, fd_id=537327
chain active: True
thresholds hit: ['advance', 'last_32', 'round_of_16']
Mexico round_of_16: 0.35 leverage × 1.5 = 0.52
South Africa round_of_16: 0.33 leverage × 1.5 = 0.50
```

R16 leverage went from 0 (the #53 bug) to 0.33-0.35. Acceptance criterion met.

## Test plan

- [x] 31 new tests; full suite passes 839/839 (excluding the pre-existing Django-dep file that fails on `main` too).
- [x] Existing 808 tests still pass — confirms the `_winner_of` recursive-resolution fix in `bracket.py` doesn't regress UCL / NHL / NBA / NCAA bracket sources.
- [x] Live-verified end-to-end via the running Dispatcharr container (output above).
- [x] `test_chain_emits_nonzero_r16_leverage_for_group_game` is the regression test for the #53 bug pattern — it asserts leverage > 0.01 on knockout bands, which would have failed on pre-PR code.

## Toggle behavior

The chain runs while `knockout._fetch_bracket_games()` is empty (pre-tournament FD.org state). The moment FIFA populates real LAST_32 teams via FD (typically 2-3 days after the last group game), the toggle in `cross_source_chain` flips to None and the existing single-source knockout path takes over. No time math, no manual cutoff.

## Tracked separately

- #77 — encode FIFA Annex C exact 3rd-placer slot mapping (the 495-scenario lookup). The backtracking here produces valid brackets but may permute slot assignments vs FIFA canonical.
- #78 — wire EURO 2028 chain when UEFA publishes the bracket structure (12-18 months pre-tournament). The chain infrastructure is sport-agnostic; only the pairing data is competition-specific.