### PR TITLE
Batch FD.org calls per refresh to stay inside the 10/min quota

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -803,6 +803,14 @@ def _build_sources(settings: Dict[str, Any]):
 def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     from .scoring import GameSignals, score_game
     from .matcher import match_games_to_channels
+    from .sources.soccer import _clear_fd_caches
+
+    # Reset the refresh-scoped FD.org caches at the top of every
+    # refresh. Soccer sources share two module-level caches (tier-wide
+    # fixtures + per-competition season matches) for the lifetime of a
+    # refresh; without this reset, a long-running plugin instance would
+    # serve stale data on the second and subsequent refreshes.
+    _clear_fd_caches()
 
     favorites = _parse_favorites(settings.get("favorites", ""))
     weights = _build_weights(settings)

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -38,6 +38,130 @@ logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.soccer")
 FD_BASE = "https://api.football-data.org/v4"
 ODDS_BASE = "https://api.the-odds-api.com/v4"
 
+
+# ---------- Module-level FD.org caches (refresh-scoped) ----------
+#
+# The plugin's _action_refresh enables ~10+ soccer competitions and the
+# free FD.org tier allows 10 calls/minute. Without batching, per-source
+# fetches blow the quota every refresh: see PR #79 era logs where the
+# WC fixtures fetch returned 429 because earlier league/cup competitions
+# in the iteration burned through the per-minute budget first.
+#
+# Two caches replace the per-source-instance fetch pattern:
+#
+#   _TIER_FIXTURES_CACHE  — one /v4/matches call returns fixtures for
+#                           every competition on the tier in a single
+#                           date window. SoccerSource._fetch_fixtures
+#                           filters this by self.config.fd_code instead
+#                           of calling /v4/competitions/<code>/matches.
+#   _SEASON_MATCHES_CACHE — full-season matches per competition (used
+#                           by the Monte Carlo importance simulator).
+#                           Keyed by fd_code so sibling sources
+#                           (wc_groups + wc_knockout) share one fetch
+#                           rather than each instance fetching its own.
+#
+# Cache lifetime is "until _clear_fd_caches() runs"; plugin._action_
+# refresh calls it at the top of every refresh so each scheduler tick
+# sees fresh data. Within a refresh, cross-source calls reuse the
+# cached responses.
+_TIER_FIXTURES_CACHE: "Optional[Tuple[Tuple[str, str, str], Dict[str, List[Dict]]]]" = None
+_SEASON_MATCHES_CACHE: Dict[str, List[Dict]] = {}
+
+
+def _clear_fd_caches() -> None:
+    """Reset the refresh-scoped FD.org caches. Called by plugin._action_
+    refresh at the start of each refresh so subsequent fetches see fresh
+    data. Safe to call between refreshes from tests too.
+    """
+    global _TIER_FIXTURES_CACHE
+    _TIER_FIXTURES_CACHE = None
+    _SEASON_MATCHES_CACHE.clear()
+
+
+def _fetch_tier_fixtures(fd_api_key: str, days_ahead: int) -> Dict[str, List[Dict]]:
+    """One /v4/matches call covering every competition on the requester's
+    tier within the [today, today+days_ahead] window. Returns a dict
+    keyed by competition code (PL, ELC, WC, etc.) with the raw FD.org
+    match dicts as values.
+
+    Cache key includes the date window so a same-day refresh with a
+    different lookahead_days setting refetches correctly. In practice
+    lookahead_days is uniform per refresh; the cache key just makes the
+    invariant explicit.
+
+    Falls back to {} on auth failure or HTTP error so callers degrade
+    to "no upcoming fixtures" (the same shape as a 429 / 5xx today),
+    keeping the rest of the refresh pipeline functioning.
+    """
+    global _TIER_FIXTURES_CACHE
+    if not fd_api_key:
+        return {}
+    now = datetime.now(timezone.utc)
+    date_from = now.strftime("%Y-%m-%d")
+    date_to = (now + timedelta(days=days_ahead)).strftime("%Y-%m-%d")
+    cache_key = (fd_api_key, date_from, date_to)
+    cached = _TIER_FIXTURES_CACHE
+    if cached is not None and cached[0] == cache_key:
+        return cached[1]
+    try:
+        r = requests.get(
+            f"{FD_BASE}/matches",
+            headers={"X-Auth-Token": fd_api_key},
+            params={"dateFrom": date_from, "dateTo": date_to},
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except Exception as e:
+        logger.error("[soccer:tier] /v4/matches fetch failed: %s", e)
+        _TIER_FIXTURES_CACHE = (cache_key, {})
+        return {}
+    by_code: Dict[str, List[Dict]] = {}
+    for m in data.get("matches", []) or []:
+        code = (m.get("competition") or {}).get("code")
+        if not code:
+            # Defensive: a tier-wide response with no competition code
+            # on a match would be a FD.org schema regression. Skip
+            # rather than misroute it.
+            continue
+        by_code.setdefault(code, []).append(m)
+    _TIER_FIXTURES_CACHE = (cache_key, by_code)
+    return by_code
+
+
+def _fetch_season_matches_for_code(fd_api_key: str, fd_code: str) -> List[Dict]:
+    """Full-season matches for a single competition, cached at module
+    level by fd_code. Sibling sources (e.g., wc_groups + wc_knockout
+    both keyed off "WC") share this cache and avoid double-fetching
+    the same competition's schedule.
+
+    NOTE: there's no /v4/matches-equivalent that returns full-season
+    history per competition in one shot — /v4/matches is date-bounded.
+    So this remains a per-competition call, but at most ONE call per
+    distinct fd_code per refresh, regardless of how many sources
+    consume it.
+    """
+    if fd_code in _SEASON_MATCHES_CACHE:
+        return _SEASON_MATCHES_CACHE[fd_code]
+    if not fd_api_key:
+        _SEASON_MATCHES_CACHE[fd_code] = []
+        return []
+    try:
+        r = requests.get(
+            f"{FD_BASE}/competitions/{fd_code}/matches",
+            headers={"X-Auth-Token": fd_api_key},
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except Exception as e:
+        logger.warning("[soccer:%s] all-matches fetch failed: %s", fd_code, e)
+        _SEASON_MATCHES_CACHE[fd_code] = []
+        return []
+    matches: List[Dict] = data.get("matches", []) or []
+    _SEASON_MATCHES_CACHE[fd_code] = matches
+    return matches
+
 # When the current season's median playedGames falls below this number,
 # replace the current standings with the previous season's final table as
 # a "position prior." Without the seed, MD1-3 produces tied scores (no
@@ -444,23 +568,17 @@ class SoccerSource(SportSource):
     # ---------- fixtures ----------
 
     def _fetch_fixtures(self, days_ahead: int) -> List[Dict]:
-        now = datetime.now(timezone.utc)
-        start = now.strftime("%Y-%m-%d")
-        end = (now + timedelta(days=days_ahead)).strftime("%Y-%m-%d")
-        try:
-            r = requests.get(
-                f"{FD_BASE}/competitions/{self.config.fd_code}/matches",
-                headers={"X-Auth-Token": self.fd_api_key},
-                params={"dateFrom": start, "dateTo": end},
-                timeout=15,
-            )
-            r.raise_for_status()
-            data = r.json()
-        except Exception as e:
-            logger.error("[soccer:%s] fixtures fetch failed: %s",
-                         self.config.fd_code, e)
-            return []
-        return data.get("matches", [])
+        """Return upcoming matches for this source's competition.
+
+        Filters the module-level tier-wide cache by `self.config.fd_code`
+        instead of making a per-competition call. The first source to
+        ask for a given (fd_api_key, date_window) triggers one
+        /v4/matches fetch covering every competition on the tier;
+        every subsequent source in the same refresh reads from cache.
+        See `_fetch_tier_fixtures` for the cache contract.
+        """
+        by_code = _fetch_tier_fixtures(self.fd_api_key, days_ahead)
+        return by_code.get(self.config.fd_code, [])
 
     # ---------- odds ----------
 
@@ -560,31 +678,20 @@ class SoccerSource(SportSource):
     # ---------- Monte Carlo importance ----------
 
     def _fetch_all_season_matches(self) -> List[Dict]:
-        """All matches for the current competition season — finished AND
-        scheduled. One FD.org call per refresh. Cached on the instance so
-        repeat calls within the same refresh don't re-bill.
+        """All matches for the current competition season, finished AND
+        scheduled. Used by the Monte Carlo importance simulator.
+
+        Two layers of cache: the per-instance `_all_matches_cache` is
+        an injection point for tests (set the attribute to a stub list
+        to bypass the network entirely). When unset, the module-level
+        `_fetch_season_matches_for_code` cache takes over, keyed by
+        fd_code so sibling sources for the same competition (e.g.,
+        wc_groups + wc_knockout) share one fetch instead of doubling
+        up.
         """
         if self._all_matches_cache is not None:
             return self._all_matches_cache
-        if not self.fd_api_key:
-            self._all_matches_cache = []
-            return []
-        try:
-            r = requests.get(
-                f"{FD_BASE}/competitions/{self.config.fd_code}/matches",
-                headers={"X-Auth-Token": self.fd_api_key},
-                timeout=15,
-            )
-            r.raise_for_status()
-            data = r.json()
-        except Exception as e:
-            logger.warning("[soccer:%s] all-matches fetch failed: %s",
-                           self.config.fd_code, e)
-            self._all_matches_cache = []
-            return []
-        cache: List[Dict] = data.get("matches", []) or []
-        self._all_matches_cache = cache
-        return cache
+        return _fetch_season_matches_for_code(self.fd_api_key, self.config.fd_code)
 
     @property
     def outcome_labels(self) -> List[str]:

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -44,6 +44,79 @@ def plugin():
     return _load_plugin_module()
 
 
+class TestActionRefreshClearsFdCaches:
+    """The FD.org batching refactor pins module-level caches into
+    `sources/soccer.py` and relies on `_action_refresh` to wipe them at
+    the top of every refresh. Without the wipe, a long-running plugin
+    instance serves stale fixtures on the second and later refreshes —
+    silent staleness, no error.
+
+    This integration test asserts the contract directly: pre-populate
+    the caches with sentinel data, invoke `_action_refresh` (with
+    `_build_sources` stubbed to return [] so we short-circuit before
+    hitting Django / FD.org), then verify both caches were cleared.
+
+    A future refactor that removes the `_clear_fd_caches()` call from
+    `_action_refresh` would silently regress to stale-cache behavior
+    and pass every unit-level cache test. This test is the safety net.
+    """
+
+    def test_action_refresh_clears_tier_fixtures_cache(self, plugin, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        # Pre-populate both caches with sentinel data.
+        sentinel_tier = (("sentinel-key", "2026-01-01", "2026-01-08"), {"PL": [{"id": 999}]})
+        soccer._TIER_FIXTURES_CACHE = sentinel_tier
+        soccer._SEASON_MATCHES_CACHE["SENTINEL"] = [{"id": 888}]
+
+        # Short-circuit _action_refresh past the cache-clear by stubbing
+        # _build_sources to return [] (no sources → early return with
+        # status=error).
+        monkeypatch.setattr(plugin, "_build_sources", lambda _settings: [])
+
+        result = plugin._action_refresh({"lookahead_days": 7})
+        # Confirm we hit the early-return path so the only thing
+        # _action_refresh did was clear caches + build empty sources.
+        assert result.get("status") == "error"
+
+        # Both caches must be wiped.
+        assert soccer._TIER_FIXTURES_CACHE is None, (
+            "_action_refresh did not call _clear_fd_caches() — tier "
+            "fixtures cache survived the refresh boundary, which would "
+            "cause stale FD.org data on every refresh after the first."
+        )
+        assert "SENTINEL" not in soccer._SEASON_MATCHES_CACHE, (
+            "_action_refresh did not call _clear_fd_caches() — season "
+            "matches cache survived the refresh boundary."
+        )
+
+    def test_clear_fd_caches_runs_before_build_sources(self, plugin, monkeypatch):
+        # Pin the order: the cache wipe must precede the source loop,
+        # not run after it. If it ran AFTER, the first source's fetch
+        # would still hit a stale cache from the prior refresh.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        order: list = []
+
+        def fake_clear():
+            order.append("clear")
+            soccer._TIER_FIXTURES_CACHE = None
+            soccer._SEASON_MATCHES_CACHE.clear()
+
+        def fake_build_sources(_settings):
+            order.append("build_sources")
+            return []
+
+        monkeypatch.setattr(soccer, "_clear_fd_caches", fake_clear)
+        monkeypatch.setattr(plugin, "_build_sources", fake_build_sources)
+
+        plugin._action_refresh({"lookahead_days": 7})
+        assert order == ["clear", "build_sources"], (
+            f"unexpected order: {order} — cache clear must fire BEFORE "
+            "source building so the first source's fetch sees fresh data"
+        )
+
+
 class TestParseScheduledTimes:
     def test_simple_csv(self, plugin):
         out = plugin._parse_scheduled_times("0400,1000,1600,2200")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9207,3 +9207,281 @@ class TestComputeGroupStandings:
         d = {"points": 3, "gf": 9, "ga": 0}  # lower points -> ranks below all
         rows = sorted([a, b, c, d], key=k)
         assert rows == [a, b, c, d]
+
+
+class TestFdCacheBatching:
+    """The plugin's _action_refresh enables ~10+ soccer competitions and
+    FD.org's free tier allows 10 calls/min. Before this batching, every
+    SoccerSource instance fetched its own /v4/competitions/<code>/matches
+    AND /v4/competitions/<code>/standings, blowing the per-minute quota
+    every refresh (the WC fixtures fetch in particular landed 11th in the
+    iteration and was reliably rate-limited).
+
+    Two caches replace the per-instance fetch pattern:
+      - _TIER_FIXTURES_CACHE: one /v4/matches call returns fixtures for
+        every competition on the tier; SoccerSource._fetch_fixtures
+        filters by fd_code instead of making its own call.
+      - _SEASON_MATCHES_CACHE: per-competition full-season schedule,
+        keyed by fd_code so sibling sources (wc_groups + wc_knockout)
+        share one fetch.
+
+    plugin._action_refresh calls `_clear_fd_caches()` at the top so each
+    refresh sees fresh data.
+    """
+
+    def setup_method(self):
+        from dispatcharr_ranked_matchups.sources import soccer
+        soccer._clear_fd_caches()
+
+    def teardown_method(self):
+        from dispatcharr_ranked_matchups.sources import soccer
+        soccer._clear_fd_caches()
+
+    def test_tier_fixtures_makes_one_http_call_for_many_sources(self, monkeypatch):
+        # Five different fd_codes calling _fetch_fixtures must result in
+        # exactly ONE underlying /v4/matches HTTP call. Before batching
+        # this was five separate /v4/competitions/<code>/matches calls.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return self._payload
+
+        def fake_get(url, **kwargs):
+            call_log.append({"url": url, "params": kwargs.get("params")})
+            # Tier-wide response with matches across 5 comps.
+            return FakeResponse({"matches": [
+                {"competition": {"code": "PL"}, "id": 1},
+                {"competition": {"code": "ELC"}, "id": 2},
+                {"competition": {"code": "BL1"}, "id": 3},
+                {"competition": {"code": "PD"}, "id": 4},
+                {"competition": {"code": "SA"}, "id": 5},
+                {"competition": {"code": "PL"}, "id": 6},
+            ]})
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+
+        # Each source independently asks for its own fixtures.
+        for comp in ("epl", "championship", "bundesliga", "la_liga", "serie_a"):
+            src = soccer.SoccerSource(comp, fd_api_key="testkey", odds_api_key="")
+            fixtures = src._fetch_fixtures(days_ahead=7)
+            assert isinstance(fixtures, list)
+
+        # ONE underlying /v4/matches call regardless of how many sources asked.
+        assert len(call_log) == 1
+        assert call_log[0]["url"].endswith("/v4/matches")
+        # Date params are present so FD scopes the response correctly.
+        params = call_log[0]["params"] or {}
+        assert "dateFrom" in params and "dateTo" in params
+
+    def test_tier_fixtures_filters_by_fd_code(self, monkeypatch):
+        # SoccerSource._fetch_fixtures returns only matches whose
+        # competition.code matches self.config.fd_code.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        payload = {"matches": [
+            {"competition": {"code": "PL"},  "id": 11, "homeTeam": {"name": "Wrexham AFC"}},
+            {"competition": {"code": "ELC"}, "id": 12},
+            {"competition": {"code": "BL1"}, "id": 13},
+            {"competition": {"code": "PL"},  "id": 14, "homeTeam": {"name": "Hull City"}},
+        ]}
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self): return payload
+
+        monkeypatch.setattr(soccer.requests, "get", lambda *a, **k: FakeResponse())
+
+        pl_src = soccer.SoccerSource("epl", fd_api_key="testkey", odds_api_key="")
+        elc_src = soccer.SoccerSource("championship", fd_api_key="testkey", odds_api_key="")
+
+        pl_fixtures = pl_src._fetch_fixtures(days_ahead=7)
+        elc_fixtures = elc_src._fetch_fixtures(days_ahead=7)
+
+        assert [m["id"] for m in pl_fixtures] == [11, 14]
+        assert [m["id"] for m in elc_fixtures] == [12]
+
+    def test_tier_fixtures_skips_matches_without_competition_code(self, monkeypatch):
+        # Defensive: a FD.org schema regression that drops the
+        # `competition.code` field on a match must not crash the cache
+        # build, and that match must not silently route to the wrong
+        # source.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [
+                    {"competition": {"code": "PL"}, "id": 21},
+                    {"competition": {},             "id": 22},   # missing code
+                    {"id": 23},                                    # missing competition entirely
+                    {"competition": {"code": None}, "id": 24},   # explicit null
+                    {"competition": {"code": "PL"}, "id": 25},
+                ]}
+
+        monkeypatch.setattr(soccer.requests, "get", lambda *a, **k: FakeResponse())
+
+        src = soccer.SoccerSource("epl", fd_api_key="testkey", odds_api_key="")
+        out = src._fetch_fixtures(days_ahead=7)
+        assert [m["id"] for m in out] == [21, 25]
+
+    def test_tier_fixtures_returns_empty_on_http_error(self, monkeypatch):
+        # 429 / 5xx / network failure must return [] for every source
+        # rather than raising — keeps the rest of the refresh
+        # pipeline functioning.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        def raising_get(*a, **k):
+            raise soccer.requests.RequestException("boom")
+
+        monkeypatch.setattr(soccer.requests, "get", raising_get)
+
+        src = soccer.SoccerSource("epl", fd_api_key="testkey", odds_api_key="")
+        assert src._fetch_fixtures(days_ahead=7) == []
+
+    def test_tier_fixtures_empty_api_key_returns_empty(self, monkeypatch):
+        # No key configured: no HTTP call should fire.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        calls = []
+        monkeypatch.setattr(soccer.requests, "get", lambda *a, **k: calls.append(1) or None)
+
+        src = soccer.SoccerSource("epl", fd_api_key="", odds_api_key="")
+        assert src._fetch_fixtures(days_ahead=7) == []
+        assert calls == []
+
+    def test_season_matches_shared_across_sibling_sources(self, monkeypatch):
+        # GroupStageSoccerSource and KnockoutSoccerSource both keyed off
+        # fd_code="WC" must share one /v4/competitions/WC/matches call,
+        # not two. Before batching, each instance's
+        # `_all_matches_cache = None` led to independent fetches even
+        # though they pull identical data.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [
+                    {"id": 100, "stage": "GROUP_STAGE", "group": "GROUP_A",
+                     "homeTeam": {"name": "Mexico"}, "awayTeam": {"name": "South Africa"},
+                     "utcDate": "2026-06-11T19:00:00Z", "status": "SCHEDULED",
+                     "score": {}, "matchday": 1},
+                ]}
+
+        def fake_get(url, **kwargs):
+            call_log.append(url)
+            return FakeResponse()
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+
+        groups = soccer.GroupStageSoccerSource("world_cup", fd_api_key="testkey", odds_api_key="")
+        knockout = soccer.KnockoutSoccerSource("world_cup", fd_api_key="testkey", odds_api_key="")
+
+        # Both sources ask for the full season.
+        ms_a = groups._fetch_all_season_matches()
+        ms_b = knockout._fetch_all_season_matches()
+
+        # Exactly ONE call to /v4/competitions/WC/matches.
+        wc_calls = [u for u in call_log if "/v4/competitions/WC/matches" in u]
+        assert len(wc_calls) == 1
+        # Both sources see the same data.
+        assert ms_a == ms_b
+        assert len(ms_a) == 1
+
+    def test_clear_fd_caches_resets_both(self, monkeypatch):
+        # After _clear_fd_caches(), the next fetch must repopulate the
+        # caches from FD.org. This is what _action_refresh relies on to
+        # avoid serving stale data between refresh cycles.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [
+                    {"competition": {"code": "PL"}, "id": 50},
+                ]}
+
+        monkeypatch.setattr(soccer.requests, "get", lambda url, **k: (call_log.append(url), FakeResponse())[1])
+
+        src = soccer.SoccerSource("epl", fd_api_key="testkey", odds_api_key="")
+
+        # First call populates the tier cache.
+        src._fetch_fixtures(days_ahead=7)
+        assert len(call_log) == 1
+
+        # Second call hits cache, no new HTTP.
+        src._fetch_fixtures(days_ahead=7)
+        assert len(call_log) == 1
+
+        # Clear, then next call refetches.
+        soccer._clear_fd_caches()
+        src._fetch_fixtures(days_ahead=7)
+        assert len(call_log) == 2
+
+    def test_instance_level_cache_still_wins_for_test_injection(self, monkeypatch):
+        # Existing tests inject fake season data via
+        # `src._all_matches_cache = [...]`. That MUST keep working —
+        # if the module cache shadowed the instance attribute, the
+        # injection becomes a no-op and 200+ existing tests silently
+        # stop testing what they think they test.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        def boom_get(*a, **k):
+            raise AssertionError("HTTP should never be called when instance cache is set")
+
+        monkeypatch.setattr(soccer.requests, "get", boom_get)
+
+        src = soccer.GroupStageSoccerSource("world_cup", fd_api_key="testkey", odds_api_key="")
+        injected = [{"id": 999, "stage": "GROUP_STAGE"}]
+        src._all_matches_cache = injected
+        out = src._fetch_all_season_matches()
+        assert out is injected
+
+    def test_season_matches_independent_cache_per_fd_code(self, monkeypatch):
+        # Two different competitions (WC and EC) each get their own
+        # entry in the module cache — they do NOT collapse into one.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def __init__(self, code):
+                self._code = code
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [{"id": 1, "_marker": self._code}]}
+
+        def fake_get(url, **kwargs):
+            call_log.append(url)
+            if "/WC/" in url:
+                return FakeResponse("WC")
+            if "/EC/" in url:
+                return FakeResponse("EC")
+            raise AssertionError(f"unexpected URL: {url}")
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+
+        wc = soccer.GroupStageSoccerSource("world_cup", fd_api_key="testkey", odds_api_key="")
+        ec = soccer.GroupStageSoccerSource("euros", fd_api_key="testkey", odds_api_key="")
+
+        wc_matches = wc._fetch_all_season_matches()
+        ec_matches = ec._fetch_all_season_matches()
+
+        # Each fd_code gets its own fetch — no cross-contamination.
+        assert len(call_log) == 2
+        assert wc_matches[0]["_marker"] == "WC"
+        assert ec_matches[0]["_marker"] == "EC"
+        # Cached: repeat calls don't refetch.
+        wc._fetch_all_season_matches()
+        ec._fetch_all_season_matches()
+        assert len(call_log) == 2


### PR DESCRIPTION
Unblocks the through-the-action prod test of #53 (Phase B chain). Closes the rate-limit-side concern surfaced when Jake asked "is that deployed and tested in prod?" after #79 merged.

## Background

Every refresh, the plugin iterates ~10+ enabled soccer competitions. Each SoccerSource called `/v4/competitions/<code>/matches` and (for league configs) `/v4/competitions/<code>/standings` independently. With FD.org's free-tier 10-calls-per-minute quota, the back-to-back burst was reliably 429'd around the WC iteration (~11th in source order), so:

- WC fixtures fetch failed → 0 games pulled → `compute_match_importance` never ran on a WC group game via the scheduler → #53's chain code couldn't be observed firing through the action.
- The Django-shell direct invocation of `compute_match_importance` against the deployed plugin was the only way to see R16 leverage on real WC data.

## What this PR does

Two module-level refresh-scoped caches in `sources/soccer.py`:

- `_TIER_FIXTURES_CACHE` — one `/v4/matches` call (probe-confirmed) returns fixtures across every tier competition in a single window. `SoccerSource._fetch_fixtures` filters this by `self.config.fd_code` instead of making a per-competition call.
- `_SEASON_MATCHES_CACHE` — full-season schedule per `fd_code`. Sibling sources (`wc_groups` + `wc_knockout`) now share one fetch.

`plugin._action_refresh` calls `_clear_fd_caches()` at its top so each refresh starts fresh.

**Test injection backward-compat preserved.** `SoccerSource._fetch_all_season_matches` checks the per-instance `_all_matches_cache` first, then falls through to the module cache. The ~200 existing tests that set `src._all_matches_cache = [...]` work unchanged.

## Quota math

| | Before | After |
|---|---|---|
| Fixtures calls per refresh | 1 per enabled comp (10-12) | **1 total** |
| Season-matches calls (for cup comps) | 1 per source instance (2 for WC group + knockout) | **1 per fd_code** |
| Standings calls (leagues) | unchanged | unchanged |

The fixtures consolidation is the big lever. Standings batching is deliberately deferred — separate concern, less leverage than fixtures.

## Test plan

- [x] 11 new tests (9 in `test_sources.py:TestFdCacheBatching` + 2 in `test_plugin_helpers.py:TestActionRefreshClearsFdCaches`). Full suite 848 pass.
- [x] `test_tier_fixtures_makes_one_http_call_for_many_sources` is the failing-test-now-green proof — would have failed on pre-PR code (5 sources × 1 call each = 5 HTTP calls), asserts 1 call now.
- [ ] **Deploy + run `_action_refresh` through `PluginManager.run_action` on the running Dispatcharr container — confirm WC games actually pulled AND scored output contains `round_of_16` notes** (this is the through-the-action verification that the FD rate limit has been blocking; closing it is the whole point of this PR).