### PR TITLE
Chunk /v4/matches calls when lookahead_days > 10 (FD endpoint cap)

### DIFF
--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -68,6 +68,16 @@ _TIER_FIXTURES_CACHE: "Optional[Tuple[Tuple[str, str, str], Dict[str, List[Dict]
 _SEASON_MATCHES_CACHE: Dict[str, List[Dict]] = {}
 
 
+# FD.org's /v4/matches endpoint caps each call's window at 10 days
+# (HTTP 400 "Specified period must not exceed 10 days"). The
+# per-competition /v4/competitions/<code>/matches endpoint, which the
+# tier-wide fetch replaced, did NOT have this cap. To preserve the
+# pre-refactor contract for plugin configs with lookahead_days > 10,
+# windows longer than this split into back-to-back chunks inside
+# _fetch_tier_fixtures.
+_FD_TIER_MAX_WINDOW_DAYS = 10
+
+
 def _clear_fd_caches() -> None:
     """Reset the refresh-scoped FD.org caches. Called by plugin._action_
     refresh at the start of each refresh so subsequent fetches see fresh
@@ -79,19 +89,27 @@ def _clear_fd_caches() -> None:
 
 
 def _fetch_tier_fixtures(fd_api_key: str, days_ahead: int) -> Dict[str, List[Dict]]:
-    """One /v4/matches call covering every competition on the requester's
-    tier within the [today, today+days_ahead] window. Returns a dict
-    keyed by competition code (PL, ELC, WC, etc.) with the raw FD.org
-    match dicts as values.
+    """One or more /v4/matches calls covering [today, today+days_ahead].
+    Returns a dict keyed by competition code (PL, ELC, WC, etc.) with
+    the raw FD.org match dicts as values.
+
+    Windows longer than `_FD_TIER_MAX_WINDOW_DAYS` (10) are split into
+    back-to-back chunks because the endpoint rejects requests over 10
+    days with HTTP 400 ("Specified period must not exceed 10 days").
+    Each chunk's matches merge into the same `by_code` dict; the cache
+    stores the merged result keyed by the full requested window. The
+    per-competition /v4/competitions/<code>/matches endpoint does NOT
+    have this cap, so chunking preserves the contract callers had
+    before the tier-wide refactor (lookahead_days values > 10 were
+    valid).
 
     Cache key includes the date window so a same-day refresh with a
-    different lookahead_days setting refetches correctly. In practice
-    lookahead_days is uniform per refresh; the cache key just makes the
-    invariant explicit.
+    different lookahead_days setting refetches correctly.
 
-    Falls back to {} on auth failure or HTTP error so callers degrade
-    to "no upcoming fixtures" (the same shape as a 429 / 5xx today),
-    keeping the rest of the refresh pipeline functioning.
+    Returns the merged-by-code dict on partial failure too: if chunk N
+    succeeds and chunk N+1 returns 429/5xx, the chunks fetched so far
+    are still cached and returned so the rest of the refresh has at
+    least the earlier fixtures rather than nothing.
     """
     global _TIER_FIXTURES_CACHE
     if not fd_api_key:
@@ -103,28 +121,49 @@ def _fetch_tier_fixtures(fd_api_key: str, days_ahead: int) -> Dict[str, List[Dic
     cached = _TIER_FIXTURES_CACHE
     if cached is not None and cached[0] == cache_key:
         return cached[1]
-    try:
-        r = requests.get(
-            f"{FD_BASE}/matches",
-            headers={"X-Auth-Token": fd_api_key},
-            params={"dateFrom": date_from, "dateTo": date_to},
-            timeout=15,
-        )
-        r.raise_for_status()
-        data = r.json()
-    except Exception as e:
-        logger.error("[soccer:tier] /v4/matches fetch failed: %s", e)
-        _TIER_FIXTURES_CACHE = (cache_key, {})
-        return {}
+
     by_code: Dict[str, List[Dict]] = {}
-    for m in data.get("matches", []) or []:
-        code = (m.get("competition") or {}).get("code")
-        if not code:
-            # Defensive: a tier-wide response with no competition code
-            # on a match would be a FD.org schema regression. Skip
-            # rather than misroute it.
-            continue
-        by_code.setdefault(code, []).append(m)
+    chunk_start = now
+    window_end = now + timedelta(days=days_ahead)
+    while chunk_start.date() <= window_end.date():
+        chunk_end = min(
+            chunk_start + timedelta(days=_FD_TIER_MAX_WINDOW_DAYS),
+            window_end,
+        )
+        chunk_from = chunk_start.strftime("%Y-%m-%d")
+        chunk_to = chunk_end.strftime("%Y-%m-%d")
+        try:
+            r = requests.get(
+                f"{FD_BASE}/matches",
+                headers={"X-Auth-Token": fd_api_key},
+                params={"dateFrom": chunk_from, "dateTo": chunk_to},
+                timeout=15,
+            )
+            r.raise_for_status()
+            data = r.json()
+        except Exception as e:
+            logger.error(
+                "[soccer:tier] /v4/matches fetch failed [%s..%s]: %s",
+                chunk_from, chunk_to, e,
+            )
+            # Cache what we have so far and bail. Partial data beats
+            # zero data on a mid-burst quota hit.
+            _TIER_FIXTURES_CACHE = (cache_key, by_code)
+            return by_code
+        for m in data.get("matches", []) or []:
+            code = (m.get("competition") or {}).get("code")
+            if not code:
+                # Defensive: a tier-wide response with no competition
+                # code on a match would be a FD.org schema regression.
+                # Skip rather than misroute it.
+                continue
+            by_code.setdefault(code, []).append(m)
+        if chunk_end >= window_end:
+            break
+        # +1 day so the next chunk starts AFTER chunk_end and we don't
+        # re-fetch the boundary day (FD's dateFrom/dateTo are inclusive
+        # on both ends).
+        chunk_start = chunk_end + timedelta(days=1)
     _TIER_FIXTURES_CACHE = (cache_key, by_code)
     return by_code
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9485,3 +9485,148 @@ class TestFdCacheBatching:
         wc._fetch_all_season_matches()
         ec._fetch_all_season_matches()
         assert len(call_log) == 2
+
+
+class TestTierFixturesChunkingForLongWindows:
+    """FD.org's /v4/matches endpoint caps each call's window at 10 days
+    with HTTP 400 ("Specified period must not exceed 10 days"). The
+    per-competition /v4/competitions/<code>/matches endpoint, which the
+    tier-wide refactor replaced, did NOT have this cap. Plugin configs
+    with `lookahead_days > 10` were valid before the refactor; the
+    chunking behavior here preserves that contract.
+
+    Without chunking, `lookahead_days=17` (for example, to capture
+    WC kickoff on 2026-06-11 from a 2026-05-26 refresh) would return
+    HTTP 400, every soccer source would see 0 fixtures, and the chain
+    feature would silently regress to "no WC games scored" for the
+    entire pre-tournament window. That's exactly the failure mode the
+    batching was meant to fix.
+    """
+
+    def setup_method(self):
+        from dispatcharr_ranked_matchups.sources import soccer
+        soccer._clear_fd_caches()
+
+    def teardown_method(self):
+        from dispatcharr_ranked_matchups.sources import soccer
+        soccer._clear_fd_caches()
+
+    def test_window_within_cap_makes_one_call(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self): return {"matches": []}
+
+        def fake_get(url, **kwargs):
+            call_log.append(kwargs.get("params"))
+            return FakeResponse()
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+        src = soccer.SoccerSource("epl", fd_api_key="testkey", odds_api_key="")
+        src._fetch_fixtures(days_ahead=7)
+        assert len(call_log) == 1, "7-day window should be one call, not chunked"
+
+    def test_window_exceeding_cap_splits_into_chunks(self, monkeypatch):
+        # 17-day lookahead exceeds the 10-day cap → must split into 2
+        # calls. This is the WC-kickoff-capture scenario.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_log = []
+
+        class FakeResponse:
+            def __init__(self, code_prefix):
+                self._code_prefix = code_prefix
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [
+                    {"competition": {"code": self._code_prefix}, "id": len(call_log)},
+                ]}
+
+        def fake_get(url, **kwargs):
+            params = kwargs.get("params") or {}
+            call_log.append(params)
+            # Return a chunk-id'd match so we can verify both chunks
+            # merged into the result.
+            code = f"CHUNK_{len(call_log)}"
+            return FakeResponse(code)
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+
+        out = soccer._fetch_tier_fixtures("testkey", days_ahead=17)
+        # Two chunks: [today, today+10] and [today+11, today+17].
+        assert len(call_log) == 2
+        # Both chunks' matches present in the merged result.
+        assert "CHUNK_1" in out
+        assert "CHUNK_2" in out
+        # No overlap on the boundary day: chunk2.dateFrom must be
+        # AFTER chunk1.dateTo, not equal to it.
+        from datetime import datetime as _dt
+        chunk1_to = _dt.strptime(call_log[0]["dateTo"], "%Y-%m-%d")
+        chunk2_from = _dt.strptime(call_log[1]["dateFrom"], "%Y-%m-%d")
+        assert chunk2_from > chunk1_to, (
+            f"chunk2 starts {chunk2_from.date()} but chunk1 ended "
+            f"{chunk1_to.date()} — boundary overlap would double-fetch "
+            "the boundary day"
+        )
+
+    def test_chunk_size_respects_max_window_days(self, monkeypatch):
+        # Each chunk's window must be <= _FD_TIER_MAX_WINDOW_DAYS.
+        # Otherwise FD will 400 us right back where we started.
+        from dispatcharr_ranked_matchups.sources import soccer
+        from datetime import datetime as _dt
+
+        call_log = []
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self): return {"matches": []}
+
+        def fake_get(url, **kwargs):
+            call_log.append(kwargs.get("params") or {})
+            return FakeResponse()
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+        soccer._fetch_tier_fixtures("testkey", days_ahead=25)
+
+        for params in call_log:
+            d_from = _dt.strptime(params["dateFrom"], "%Y-%m-%d")
+            d_to = _dt.strptime(params["dateTo"], "%Y-%m-%d")
+            span_days = (d_to - d_from).days
+            assert span_days <= soccer._FD_TIER_MAX_WINDOW_DAYS, (
+                f"chunk {params} spans {span_days} days, exceeds the "
+                f"{soccer._FD_TIER_MAX_WINDOW_DAYS}-day FD.org cap"
+            )
+
+    def test_partial_failure_returns_chunks_fetched_so_far(self, monkeypatch):
+        # If chunk 1 succeeds and chunk 2 hits 429, the chunk-1 data
+        # is still cached and returned. Better than throwing away
+        # everything when a quota hit lands mid-burst.
+        from dispatcharr_ranked_matchups.sources import soccer
+
+        call_count = {"n": 0}
+
+        class FakeResponse:
+            def raise_for_status(self): pass
+            def json(self):
+                return {"matches": [
+                    {"competition": {"code": "PL"}, "id": call_count["n"]},
+                ]}
+
+        def fake_get(url, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return FakeResponse()
+            # Chunk 2: simulate 429.
+            raise soccer.requests.RequestException("simulated 429")
+
+        monkeypatch.setattr(soccer.requests, "get", fake_get)
+        out = soccer._fetch_tier_fixtures("testkey", days_ahead=20)
+
+        # First chunk landed; second 429'd.
+        assert call_count["n"] == 2
+        # First chunk's data is still in the result.
+        assert "PL" in out
+        assert len(out["PL"]) == 1


### PR DESCRIPTION
Fix-up on top of #80. The tier-wide /v4/matches endpoint caps each call's window at 10 days; the per-competition endpoint it replaced did not. Plugin configs with `lookahead_days > 10` (e.g., 17 to capture WC kickoff in pre-tournament window) hit HTTP 400.

Splits windows > 10 days into back-to-back chunks, merges results, partial-failure semantics preserve cached data.

Tests: 4 new (within-cap is one call; exceeds-cap splits into chunks; chunk size <= 10; partial-failure returns chunks-so-far). Suite: 852 pass.

Closes the through-the-action prod test gap that the FD cap was about to block — without this, bumping lookahead_days temporarily to capture WC for the strict #53 verification would just return HTTP 400.