### PR TITLE
Add Plugin.stop() to tear down scheduler thread on reload (closes #82)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2386,6 +2386,37 @@ class Plugin:
             logger.warning("[ranked_matchups] could not read settings from DB: %s", e)
         return {}
 
+    def stop(self, context: Optional[Dict[str, Any]] = None) -> None:
+        """Tear down the scheduler thread when the loader disables /
+        reloads / deletes the plugin. The Dispatcharr plugin loader
+        contract calls this on every lifecycle change (Plugins.md). The
+        thread keeps polling settings from Postgres on a 5-min loop;
+        without this teardown each reload leaks one thread per uwsgi
+        worker, each holding a DB connection, until Postgres's
+        max_connections cap is hit and every API request 500s with
+        "FATAL: sorry, too many clients already" (#82).
+
+        Signal-then-join: the scheduler loop polls
+        `_scheduler_stop.wait(timeout=...)` between work units, so
+        setting the event drops the loop out at its next wake-up.
+        Join with a short timeout because the loader's reload path
+        blocks on stop() and we don't want a stuck thread to wedge
+        the whole reload.
+        """
+        del context  # unused; conform to loader's stop(context) shape
+        _scheduler_stop.set()
+        global _scheduler_thread
+        t = _scheduler_thread
+        if t is not None and t.is_alive():
+            t.join(timeout=5.0)
+            if t.is_alive():
+                logger.warning(
+                    "[ranked_matchups] scheduler thread did not exit "
+                    "within 5s of stop signal; loader will proceed but "
+                    "the daemon thread will linger until process exit"
+                )
+        _scheduler_thread = None
+
     def run(self, action: Optional[str] = None,
             params: Optional[Dict[str, Any]] = None,
             context: Optional[Dict[str, Any]] = None):

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1587,3 +1587,133 @@ class TestBuildStandingsPostureLine:
         st_idx = next(i for i, s in enumerate(sections) if "70 pts" in s)
         nar_idx = next(i for i, s in enumerate(sections) if "clinch the title" in s)
         assert md_idx < st_idx < nar_idx
+
+
+class TestPluginStopTeardown:
+    """The Plugin class spawns a daemon scheduler thread in __init__.
+    Without a stop() teardown, plugin reloads leak one thread per
+    uwsgi worker per reload; each thread holds a Postgres connection
+    via its 5-min settings-polling loop. Over a day of reloads, the
+    embedded Postgres's `max_connections=200` cap is hit and every
+    API request 500s with "FATAL: sorry, too many clients already"
+    (#82, reproduced live in the running Dispatcharr container on
+    2026-05-26).
+
+    Plugin.stop() signals the stop event and joins the thread so each
+    reload sees the old thread cleanly exit before the new one starts.
+    """
+
+    def test_stop_signals_and_clears_thread(self, plugin):
+        # Use a stub thread so the test isn't gated on Django being
+        # available (the real _scheduler_loop hits PluginConfig.objects
+        # on the first iteration).
+        import threading
+
+        class StubThread:
+            def __init__(self):
+                self._alive = True
+                self.join_calls = 0
+            def is_alive(self):
+                return self._alive
+            def join(self, timeout=None):
+                self.join_calls += 1
+                # Simulate the loop responding to _scheduler_stop being
+                # set: as soon as the stop event is set, the thread
+                # exits. (In production the loop calls
+                # _scheduler_stop.wait() between work units.)
+                if plugin._scheduler_stop.is_set():
+                    self._alive = False
+
+        stub = StubThread()
+        # Save/restore the module-level globals around the test so we
+        # don't disturb other tests that exercise the scheduler.
+        saved_thread = plugin._scheduler_thread
+        saved_stop_set = plugin._scheduler_stop.is_set()
+        try:
+            plugin._scheduler_thread = stub
+            plugin._scheduler_stop.clear()
+            inst = plugin.Plugin.__new__(plugin.Plugin)  # skip __init__'s thread spawn
+
+            inst.stop()
+
+            # Event was set, join was called, thread exited, module
+            # global was cleared.
+            assert plugin._scheduler_stop.is_set()
+            assert stub.join_calls == 1
+            assert not stub.is_alive()
+            assert plugin._scheduler_thread is None
+        finally:
+            plugin._scheduler_thread = saved_thread
+            if saved_stop_set:
+                plugin._scheduler_stop.set()
+            else:
+                plugin._scheduler_stop.clear()
+
+    def test_stop_is_safe_when_thread_already_dead(self, plugin):
+        # Defensive: stop() called twice in a row (e.g., loader unload
+        # races with disable signal) must not raise on the second call
+        # even though the thread is already gone.
+        saved_thread = plugin._scheduler_thread
+        saved_stop_set = plugin._scheduler_stop.is_set()
+        try:
+            plugin._scheduler_thread = None
+            plugin._scheduler_stop.clear()
+            inst = plugin.Plugin.__new__(plugin.Plugin)
+            inst.stop()  # no-op path: thread is None
+            inst.stop()  # repeated: still no-op
+            assert plugin._scheduler_thread is None
+        finally:
+            plugin._scheduler_thread = saved_thread
+            if saved_stop_set:
+                plugin._scheduler_stop.set()
+            else:
+                plugin._scheduler_stop.clear()
+
+    def test_stop_accepts_context_argument(self, plugin):
+        # The Dispatcharr loader contract is `stop(self, context)`.
+        # Plugins.md confirms: the loader passes the context dict on
+        # every lifecycle stop. The signature must accept it without
+        # complaint.
+        inst = plugin.Plugin.__new__(plugin.Plugin)
+        # No-context call AND with-context call both work.
+        inst.stop()
+        inst.stop({"settings": {}})
+        inst.stop(None)
+
+    def test_subsequent_init_after_stop_creates_fresh_thread(self, plugin, monkeypatch):
+        # After stop(), a new Plugin() must be able to spawn a fresh
+        # scheduler thread. This is the reload cycle: loader calls
+        # stop() then re-instantiates Plugin().
+        import threading
+
+        spawned = []
+        real_thread = threading.Thread
+
+        class TrackingThread(real_thread):
+            def __init__(self, *a, **kw):
+                spawned.append(kw.get("name") or "<unnamed>")
+                super().__init__(*a, **kw)
+            def start(self):
+                # Don't actually start — we don't want a live thread
+                # touching DB / FD in tests.
+                pass
+
+        monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
+        saved_thread = plugin._scheduler_thread
+        try:
+            plugin._scheduler_thread = None
+            plugin._scheduler_stop.clear()
+            # First instantiation: spawns scheduler thread.
+            inst1 = plugin.Plugin()
+            assert len(spawned) == 1
+            assert spawned[0] == "ranked_matchups-scheduler"
+
+            # Now stop + re-instantiate (the reload path).
+            inst1.stop()
+            inst2 = plugin.Plugin()
+
+            # Second spawn happened — no skipped instantiation.
+            assert len(spawned) == 2
+        finally:
+            plugin._scheduler_thread = saved_thread
+            plugin._scheduler_stop.clear()


### PR DESCRIPTION
Closes #82.

Symptom diagnosed live in the running Dispatcharr container: `pg_stat_activity` count climbed to 205 (Postgres `max_connections=200`), causing every API endpoint to 500 with "FATAL: sorry, too many clients already". `docker restart Dispatcharr` dropped it back to 30 within seconds.

Root cause: `Plugin.__init__` spawns a daemon scheduler thread but no `stop()` method existed. The Dispatcharr loader's reload path calls `Plugin.stop(context)` on every reload (`/app/Plugins.md`); without one, the old scheduler thread keeps running while a new one spawns on every reload. Each leaked thread holds a Postgres connection via its 5-min settings poll. Over a day of dev iteration (touch reload_token, settings changes), connections accumulate past the cap.

Plugin.stop() signals the existing `_scheduler_stop` event, joins the thread with a 5s timeout, and clears the module-level `_scheduler_thread` global. The scheduler loop's longest `.wait()` is 600s but it checks the event between every work unit, so a stop signal typically drops the loop out within milliseconds.

Tests: 4 new in `TestPluginStopTeardown` (signal/join flow, double-stop idempotency, context-arg shape per the loader's contract, fresh-thread-after-stop for the reload cycle).

The live reproduction (touch reload_token N times → check pg_stat_activity stays bounded) only runs against a live container; documented in the issue body for follow-up.