### PR TITLE
Closes #77: encode FIFA Annex C exact 3rd-placer slot table for WC 2026

### DIFF
--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -1450,6 +1450,529 @@ _WC2026_FINAL_PAIRINGS: List[Tuple[int, int]] = [
     (0, 1),     # M103 = W101 vs W102
 ]
 
+# FIFA Annex C deterministic 3rd-placer slot assignment.
+#
+# Given the set of 8 group letters whose 3rd-placers advance (one of
+# C(12,8) = 495 combinations), FIFA's published Annex C deterministically
+# maps each 3rd-placer to a specific reserved LAST_32 slot. The greedy
+# backtracking below `_assign` produces a VALID assignment that satisfies
+# the same-group exclusion constraints, but it may pick a different
+# permutation than Annex C's canonical mapping. The leverage signal on
+# group games is correct in DIRECTION (the bracket validity is preserved)
+# but its MAGNITUDE may be off because the simulated R16 opponent differs
+# from the canonical one.
+#
+# This table is the canonical lookup. _build_bracket_seed prefers it,
+# falling back to backtracking if a row is missing (defensive against
+# transcription bugs; the table is parametrized-test verified at
+# tests/test_annex_c_table.py to cover all 495 combinations).
+#
+# Source: en.wikipedia.org/wiki/Template:2026_FIFA_World_Cup_third-place_table
+# (which transcribes from FIFA's "FIFA World Cup 2026 Regulations" PDF,
+# Annex C, May 2025 edition). Parsed and verified by tools/parse_annex_c.py.
+# Format: frozenset(group letters whose 3rd-placers advance) ->
+#   tuple of (l32_match_idx, side, source_group_letter), one per slot.
+# All 8 slots are the AWAY side of their respective LAST_32 match per
+# `_WC2026_LAST_32_PAIRINGS`. l32_match_idx maps to:
+#   1->M74, 4->M77, 6->M79, 7->M80, 8->M81, 9->M82, 12->M85, 14->M87.
+_WC2026_THIRD_PLACER_SLOT_TABLE: Dict[FrozenSet[str], Tuple[Tuple[int, str, str], ...]] = {
+    frozenset("ABCDEFGH"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ABCDEFGI"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEFGJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEFGK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEFGL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDEFHI"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","D")),
+    frozenset("ABCDEFHJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","D")),
+    frozenset("ABCDEFHK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","D")),
+    frozenset("ABCDEFHL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","F"), (14,"away","L")),
+    frozenset("ABCDEFIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCDEFIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","I")),
+    frozenset("ABCDEFIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCDEFJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCDEFJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDEFKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCDEGHI"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEGHJ"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEGHK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCDEGHL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDEGIJ"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDEGIK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDEGIL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDEGJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABCDEGJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDEGKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDEHIJ"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCDEHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","I")),
+    frozenset("ABCDEHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCDEHJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCDEHJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDEHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCDEIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCDEIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDEIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCDEJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDFGHI"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ABCDFGHJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ABCDFGHK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ABCDFGHL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","H"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDFGIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDFGIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDFGIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDFGJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABCDFGJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDFGKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDFHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","D")),
+    frozenset("ABCDFHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","F"), (14,"away","I")),
+    frozenset("ABCDFHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","F"), (14,"away","L")),
+    frozenset("ABCDFHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","D")),
+    frozenset("ABCDFHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","H"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDFHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","F"), (14,"away","L")),
+    frozenset("ABCDFIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCDFIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDFIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCDFJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDGHIJ"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDGHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCDGHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDGHJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABCDGHJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDGHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDGIJK"): ((1,"away","D"), (4,"away","G"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCDGIJL"): ((1,"away","D"), (4,"away","G"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDGIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCDGJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCDHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCDHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCDIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEFGHI"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCEFGHJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCEFGHK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABCEFGHL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEFGIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCEFGIK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCEFGIL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEFGJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABCEFGJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEFGKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEFHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCEFHIK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","I")),
+    frozenset("ABCEFHIL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCEFHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCEFHJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEFHKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABCEFIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCEFIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEFIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCEFJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEGHIJ"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCEGHIK"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCEGHIL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEGHJK"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABCEGHJL"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEGHKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEGIJK"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCEGIJL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEGIKL"): ((1,"away","A"), (4,"away","C"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCEGJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEHIJK"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCEHIJL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEHIKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCEHJKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCEIJKL"): ((1,"away","A"), (4,"away","C"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCFGHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCFGHIK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABCFGHIL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCFGHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABCFGHJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCFGHKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCFGIJK"): ((1,"away","F"), (4,"away","G"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCFGIJL"): ((1,"away","F"), (4,"away","G"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCFGIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCFGJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCFHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCFHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCFHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABCFHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCFIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCGHIJK"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABCGHIJL"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCGHIKL"): ((1,"away","C"), (4,"away","H"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABCGHJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCGIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABCHIJKL"): ((1,"away","C"), (4,"away","H"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEFGHI"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABDEFGHJ"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABDEFGHK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ABDEFGHL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEFGIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABDEFGIK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABDEFGIL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEFGJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABDEFGJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEFGKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEFHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABDEFHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","I")),
+    frozenset("ABDEFHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABDEFHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABDEFHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEFHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ABDEFIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDEFIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEFIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABDEFJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEGHIJ"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABDEGHIK"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABDEGHIL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEGHJK"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABDEGHJL"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEGHKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEGIJK"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDEGIJL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEGIKL"): ((1,"away","A"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDEGJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEHIJK"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDEHIJL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEHIKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABDEHJKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDEIJKL"): ((1,"away","A"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDFGHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABDFGHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABDFGHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDFGHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","J")),
+    frozenset("ABDFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","J"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDFGHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDFGIJK"): ((1,"away","D"), (4,"away","G"), (6,"away","F"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDFGIJL"): ((1,"away","D"), (4,"away","G"), (6,"away","F"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDFGJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","F"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDFHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDFHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDFHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABDFHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDGHIJK"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABDGHIJL"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDGHIKL"): ((1,"away","D"), (4,"away","H"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABDGHJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDGIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABDHIJKL"): ((1,"away","D"), (4,"away","H"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFGHIJ"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABEFGHIK"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ABEFGHIL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABEFGHJK"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","E")),
+    frozenset("ABEFGHJL"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFGHKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABEFGIJK"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABEFGIJL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFGIKL"): ((1,"away","A"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABEFGJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFHIJK"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABEFHIJL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFHIKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","I"), (14,"away","L")),
+    frozenset("ABEFHJKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEFIJKL"): ((1,"away","A"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEGHIJK"): ((1,"away","A"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABEGHIJL"): ((1,"away","A"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEGHIKL"): ((1,"away","A"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABEGHJKL"): ((1,"away","A"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEGIJKL"): ((1,"away","A"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABEHIJKL"): ((1,"away","A"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABFGHIJK"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ABFGHIJL"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABFGHIKL"): ((1,"away","A"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("ABFGHJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABFGIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABFHIJKL"): ((1,"away","A"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ABGHIJKL"): ((1,"away","A"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEFGHI"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ACDEFGHJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ACDEFGHK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ACDEFGHL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","F"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEFGIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACDEFGIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDEFGIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEFGJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACDEFGJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEFGKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEFHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","D")),
+    frozenset("ACDEFHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","E"), (14,"away","I")),
+    frozenset("ACDEFHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","F"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ACDEFHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","D")),
+    frozenset("ACDEFHJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","F"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEFHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ACDEFIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ACDEFIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEFIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ACDEFJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEGHIJ"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACDEGHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDEGHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEGHJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACDEGHJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEGHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEGIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDEGIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEGIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEGJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDEHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ACDEHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ACDEHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDEIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDFGHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ACDFGHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDFGHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","F"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFGHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","D")),
+    frozenset("ACDFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","H"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFGHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFGIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDFGIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFGJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDFHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ACDFHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","F"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDFHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","F"), (14,"away","L")),
+    frozenset("ACDFHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","F"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACDGHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACDGHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDGHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDGHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDGIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","I"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACDHIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACEFGHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACEFGHIK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACEFGHIL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFGHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ACEFGHJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFGHKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFGIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACEFGIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFGIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFGJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEFHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ACEFHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACEFHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ACEFHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACEFIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACEGHIJK"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACEGHIJL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEGHIKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEGHJKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACEGIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACEHIJKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACFGHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ACFGHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACFGHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACFGHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACFGIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ACFHIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ACGHIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADEFGHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ADEFGHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ADEFGHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFGHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","E")),
+    frozenset("ADEFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFGHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFGIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ADEFGIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFGJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEFHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","I")),
+    frozenset("ADEFHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADEFHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","E"), (14,"away","L")),
+    frozenset("ADEFHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","E"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADEFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADEGHIJK"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ADEGHIJL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEGHIKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEGHJKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADEGIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADEHIJKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADFGHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("ADFGHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADFGHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADFGHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADFGIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("ADFHIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("ADGHIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("AEFGHIJK"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","I")),
+    frozenset("AEFGHIJL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("AEFGHIKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("AEFGHJKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","A"), (12,"away","G"), (14,"away","L")),
+    frozenset("AEFGIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("AEFHIJKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("AEGHIJKL"): ((1,"away","A"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("AFGHIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","A"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEFGHI"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEFGHJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","D")),
+    frozenset("BCDEFGHK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEFGHL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEFGIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEFGIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","E"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDEFGIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","E"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEFGJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEFGJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEFGKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","E"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEFHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","E")),
+    frozenset("BCDEFHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","E"), (14,"away","I")),
+    frozenset("BCDEFHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","E"), (14,"away","L")),
+    frozenset("BCDEFHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","E")),
+    frozenset("BCDEFHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEFHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","E"), (14,"away","L")),
+    frozenset("BCDEFIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","E"), (12,"away","J"), (14,"away","I")),
+    frozenset("BCDEFIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","E"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEFIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","E"), (14,"away","L")),
+    frozenset("BCDEFJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","E"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEGHIJ"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEGHIK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDEGHIL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEGHJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCDEGHJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEGHKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEGIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDEGIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEGIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEGJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDEHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BCDEHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","I"), (14,"away","L")),
+    frozenset("BCDEHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDEIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDFGHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","D")),
+    frozenset("BCDFGHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDFGHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFGHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","D")),
+    frozenset("BCDFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","J"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFGHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFGIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDFGIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFGJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDFHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BCDFHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDFHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","I"), (14,"away","L")),
+    frozenset("BCDFHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCDGHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCDGHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDGHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDGHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDGIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCDHIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEFGHIJ"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCEFGHIK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCEFGHIL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFGHJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BCEFGHJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFGHKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFGIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCEFGIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFGIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFGJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEFHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BCEFHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEFHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","I"), (14,"away","L")),
+    frozenset("BCEFHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEFIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEGHIJK"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BCEGHIJL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEGHIKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCEGHJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEGIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCEHIJKL"): ((1,"away","C"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCFGHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BCFGHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCFGHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCFGHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCFGIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BCFHIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BCGHIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEFGHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BDEFGHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("BDEFGHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFGHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","E")),
+    frozenset("BDEFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","E"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFGHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFGIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BDEFGIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFGJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEFHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BDEFHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEFHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","I"), (14,"away","L")),
+    frozenset("BDEFHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEGHIJK"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BDEGHIJL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEGHIKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDEGHJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEGIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDEHIJKL"): ((1,"away","D"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDFGHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("BDFGHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","I"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDFGHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDFGHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDFGIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","I"), (7,"away","K"), (8,"away","B"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("BDFHIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BDGHIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BEFGHIJK"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("BEFGHIJL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","I"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BEFGHIKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("BEFGHJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BEFGIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BEFHIJKL"): ((1,"away","F"), (4,"away","H"), (6,"away","E"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("BEGHIJKL"): ((1,"away","B"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("BFGHIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","H"), (7,"away","K"), (8,"away","B"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDEFGHIJ"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","E")),
+    frozenset("CDEFGHIK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("CDEFGHIL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","E"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFGHJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","E")),
+    frozenset("CDEFGHJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","E"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFGHKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFGIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","J"), (12,"away","G"), (14,"away","I")),
+    frozenset("CDEFGIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","E"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFGIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","I"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFGJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEFHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","H"), (12,"away","J"), (14,"away","I")),
+    frozenset("CDEFHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","E"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDEFHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","E"), (14,"away","L")),
+    frozenset("CDEFHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDEFIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","E"), (9,"away","I"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDEGHIJK"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("CDEGHIJL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEGHIKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEGHJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEGIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDEHIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDFGHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("CDFGHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","I"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDFGHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDFGHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDFGIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CDFHIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","C"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CDGHIJKL"): ((1,"away","C"), (4,"away","D"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CEFGHIJK"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("CEFGHIJL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CEFGHIKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CEFGHJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("CEFGIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("CEFHIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CEGHIJKL"): ((1,"away","C"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("CFGHIJKL"): ((1,"away","C"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("DEFGHIJK"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","I")),
+    frozenset("DEFGHIJL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","I"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("DEFGHIKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("DEFGHJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","J"), (9,"away","H"), (12,"away","G"), (14,"away","L")),
+    frozenset("DEFGIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("DEFHIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("DEGHIJKL"): ((1,"away","D"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+    frozenset("DFGHIJKL"): ((1,"away","D"), (4,"away","F"), (6,"away","H"), (7,"away","K"), (8,"away","I"), (9,"away","J"), (12,"away","G"), (14,"away","L")),
+    frozenset("EFGHIJKL"): ((1,"away","F"), (4,"away","G"), (6,"away","E"), (7,"away","K"), (8,"away","I"), (9,"away","H"), (12,"away","J"), (14,"away","L")),
+}
+
 
 class GroupStageSoccerSource(SoccerSource):
     """Group-stage Monte Carlo importance for international tournaments
@@ -1773,14 +2296,13 @@ class GroupStageSoccerSource(SoccerSource):
 
         FIFA's official Annex C codifies a deterministic 495-scenario
         lookup table that pins the exact 3rd-placer slot assignment
-        for every combination of 8-advancing-groups. This
-        implementation uses a greedy approximation that honors the
-        same-group exclusion constraints. Slot ASSIGNMENTS may
-        differ from FIFA's canonical mapping, but bracket VALIDITY
-        (no same-group rematches at LAST_32) is preserved, and the
-        leverage signal for group games on R16+ outcomes is
-        approximate-but-nonzero. Filed as a follow-up: encoding the
-        full Annex C lookup table for exact bracket reconstruction.
+        for every combination of 8-advancing-groups. We prefer that
+        table (`_WC2026_THIRD_PLACER_SLOT_TABLE`) so leverage signal
+        magnitudes for group games on R16+ outcomes match FIFA's
+        canonical bracket. The backtracking DFS below remains as a
+        fallback for keys missing from the table -- this should never
+        fire in practice but is defensive against transcription bugs
+        in the table itself.
 
         Downstream rounds (LAST_16 → FINAL) use placeholder names
         wired via feeds_from per `_WC2026_LAST_16_PAIRINGS` and
@@ -1817,15 +2339,21 @@ class GroupStageSoccerSource(SoccerSource):
             return None
 
         # Constraint-respecting assignment of best-3rd-placers to
-        # reserved slots. Greedy fails on cases where the strongest-
-        # first pick locks out a later slot (e.g., the {ABCDEFGH}
-        # qualification set has only 3 candidates for M82's {A,E,H,I,J}
-        # slot: if A, E, and H are all consumed by earlier slots,
-        # M82 stalls). Backtracking DFS tries each slot in canonical
-        # order, attempts each unassigned 3rd-placer whose group is
-        # allowed (strongest-first to preserve the FIFA tiebreaker
-        # bias when multiple solutions exist), recurses, and unwinds
-        # on dead ends. Bounded by n_slots = 8 reserved slots.
+        # reserved slots. PRIMARY path: lookup in
+        # _WC2026_THIRD_PLACER_SLOT_TABLE keyed by the frozenset of
+        # advancing group letters. The table encodes FIFA's published
+        # canonical mapping, so leverage magnitudes match the real
+        # bracket.
+        #
+        # FALLBACK path (table miss): backtracking DFS in canonical
+        # slot order, attempting each unassigned 3rd-placer whose
+        # group is allowed (strongest-first to preserve the FIFA
+        # tiebreaker bias when multiple valid solutions exist),
+        # recursing, and unwinding on dead ends. Bounded by
+        # n_slots = 8. This produces a VALID but possibly non-
+        # canonical assignment; it should not fire in production
+        # because the table is parametrized-test-verified to cover
+        # all C(12,8) = 495 keys.
         qualifying_thirds = list(
             standings.best_third_order[:standings.n_best_third_advance]
         )
@@ -1836,27 +2364,49 @@ class GroupStageSoccerSource(SoccerSource):
                     third_slots.append((l32_idx, side, slot[1]))
 
         third_assignments: Dict[Tuple[int, str], str] = {}
-        used: set = set()
 
-        def _assign(slot_idx: int) -> bool:
-            if slot_idx == len(third_slots):
-                return True
-            l32_idx, side, allowed = third_slots[slot_idx]
-            for team, _row in qualifying_thirds:
-                if team in used:
-                    continue
-                letter = _letter_of(team)
-                if letter is None or letter not in allowed:
-                    continue
+        # Try the Annex C lookup first.
+        team_by_letter: Dict[str, str] = {}
+        for team, _row in qualifying_thirds:
+            letter = _letter_of(team)
+            if letter is not None:
+                team_by_letter[letter] = team
+        advancing_letters = frozenset(team_by_letter.keys())
+        canonical = _WC2026_THIRD_PLACER_SLOT_TABLE.get(advancing_letters)
+        if canonical is not None and len(team_by_letter) == 8:
+            for l32_idx, side, source_letter in canonical:
+                team = team_by_letter.get(source_letter)
+                if team is None:
+                    # Table key matched but a letter isn't in
+                    # team_by_letter -- treat as table miss and fall
+                    # through to backtracking. Shouldn't be reachable.
+                    third_assignments.clear()
+                    canonical = None
+                    break
                 third_assignments[(l32_idx, side)] = team
-                used.add(team)
-                if _assign(slot_idx + 1):
-                    return True
-                del third_assignments[(l32_idx, side)]
-                used.remove(team)
-            return False
 
-        _assign(0)
+        if not third_assignments:
+            used: set = set()
+
+            def _assign(slot_idx: int) -> bool:
+                if slot_idx == len(third_slots):
+                    return True
+                l32_idx, side, allowed = third_slots[slot_idx]
+                for team, _row in qualifying_thirds:
+                    if team in used:
+                        continue
+                    letter = _letter_of(team)
+                    if letter is None or letter not in allowed:
+                        continue
+                    third_assignments[(l32_idx, side)] = team
+                    used.add(team)
+                    if _assign(slot_idx + 1):
+                        return True
+                    del third_assignments[(l32_idx, side)]
+                    used.remove(team)
+                return False
+
+            _assign(0)
 
         # Construct LAST_32 entry ties.
         l32_ties: List[Dict[str, Any]] = []

--- a/tests/test_annex_c_table.py
+++ b/tests/test_annex_c_table.py
@@ -1,0 +1,251 @@
+"""Verify the FIFA Annex C lookup table in sources/soccer.py covers
+all C(12, 8) = 495 combinations of advancing-3rd-placer group letters,
+and that every row's slot assignment satisfies the L32 bracket
+constraints declared in _WC2026_LAST_32_PAIRINGS.
+
+This test is the integrity check for #77's data transcription. The
+table is parsed from FIFA's published Annex C via Wikipedia
+(en.wikipedia.org/wiki/Template:2026_FIFA_World_Cup_third-place_table).
+A bug in the table would silently miscompute leverage signals for
+WC group games on R16+ outcomes; the test fails fast on any drift.
+
+Coverage:
+  - Cardinality: exactly 495 keys (C(12, 8) combinations of A..L).
+  - Per-row shape: exactly 8 (l32_match_idx, side, source_letter) triples.
+  - Per-row constraint: source_letter is in the allowed_groups set
+    declared for that l32_match_idx in _WC2026_LAST_32_PAIRINGS.
+  - Per-row uniqueness: no two triples target the same slot, and the
+    source_letters in a row match the row's key letter-for-letter.
+  - Key uniqueness: implicit from dict semantics, but we also
+    enumerate combinations and assert coverage.
+"""
+import importlib.util
+import itertools
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+def _load_soccer_module():
+    if f"{PKG_NAME}.sources.soccer" in sys.modules:
+        return sys.modules[f"{PKG_NAME}.sources.soccer"]
+    # The package alias is already registered by conftest. We need to
+    # also register the `sources` subpackage before importing soccer.
+    sources_pkg = sys.modules.get(f"{PKG_NAME}.sources")
+    if sources_pkg is None:
+        import types
+        sources_pkg = types.ModuleType(f"{PKG_NAME}.sources")
+        sources_pkg.__path__ = [os.path.join(REPO_ROOT, "sources")]
+        sys.modules[f"{PKG_NAME}.sources"] = sources_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PKG_NAME}.sources.soccer",
+        os.path.join(REPO_ROOT, "sources", "soccer.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{PKG_NAME}.sources.soccer"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def soccer():
+    return _load_soccer_module()
+
+
+def _build_allowed_groups_per_slot(soccer):
+    """For each l32_match_idx that has a best_third slot, return the
+    allowed_groups frozenset and the side ('home' / 'away') the slot
+    is on. Pulls from soccer._WC2026_LAST_32_PAIRINGS so the test
+    stays consistent if the pairings table is edited."""
+    out = {}
+    for l32_idx, (home_slot, away_slot) in enumerate(soccer._WC2026_LAST_32_PAIRINGS):
+        for side, slot in (("home", home_slot), ("away", away_slot)):
+            if slot[0] == "best_third":
+                out[(l32_idx, side)] = slot[1]
+    return out
+
+
+class TestTableCardinality:
+    def test_has_exactly_495_keys(self, soccer):
+        assert len(soccer._WC2026_THIRD_PLACER_SLOT_TABLE) == 495
+
+    def test_covers_every_8_of_12_combination(self, soccer):
+        expected_keys = {frozenset(combo) for combo in itertools.combinations("ABCDEFGHIJKL", 8)}
+        actual_keys = set(soccer._WC2026_THIRD_PLACER_SLOT_TABLE.keys())
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys
+        assert not missing, f"missing {len(missing)} combinations: {sorted(missing)[:5]}..."
+        assert not extra, f"unexpected combinations: {sorted(extra)[:5]}..."
+
+    def test_keys_have_8_letters_each_in_alphabet(self, soccer):
+        alphabet = set("ABCDEFGHIJKL")
+        for key in soccer._WC2026_THIRD_PLACER_SLOT_TABLE.keys():
+            assert len(key) == 8, f"key {key} does not have 8 letters"
+            assert key <= alphabet, f"key {key} has letters outside A-L"
+
+
+class TestPerRowShape:
+    def test_every_value_has_exactly_8_triples(self, soccer):
+        for key, value in soccer._WC2026_THIRD_PLACER_SLOT_TABLE.items():
+            assert len(value) == 8, f"key {sorted(key)} value has {len(value)} triples (expected 8)"
+
+    def test_triple_shape_is_int_str_str(self, soccer):
+        for key, value in soccer._WC2026_THIRD_PLACER_SLOT_TABLE.items():
+            for t in value:
+                assert isinstance(t, tuple) and len(t) == 3
+                l32_idx, side, source_letter = t
+                assert isinstance(l32_idx, int)
+                assert side in ("home", "away")
+                assert isinstance(source_letter, str) and len(source_letter) == 1
+
+
+@pytest.mark.parametrize("key", sorted(
+    {frozenset(c) for c in itertools.combinations("ABCDEFGHIJKL", 8)},
+    key=lambda f: "".join(sorted(f)),
+))
+class TestPerRowConstraints:
+    """Parametrized over all 495 combinations -- one test instance per
+    row of the table. Fast assertions; full sweep finishes in milliseconds.
+    A constraint violation here means the table data has a transcription
+    bug; fix the source, regenerate, and rerun."""
+
+    def test_row_targets_only_best_third_slots(self, soccer, key):
+        allowed_slots = _build_allowed_groups_per_slot(soccer)
+        row = soccer._WC2026_THIRD_PLACER_SLOT_TABLE[key]
+        for l32_idx, side, _ in row:
+            assert (l32_idx, side) in allowed_slots, (
+                f"row {sorted(key)}: slot ({l32_idx}, {side}) is not a "
+                f"reserved best_third slot in _WC2026_LAST_32_PAIRINGS"
+            )
+
+    def test_source_letters_satisfy_allowed_groups(self, soccer, key):
+        allowed_slots = _build_allowed_groups_per_slot(soccer)
+        row = soccer._WC2026_THIRD_PLACER_SLOT_TABLE[key]
+        for l32_idx, side, source_letter in row:
+            allowed = allowed_slots[(l32_idx, side)]
+            assert source_letter in allowed, (
+                f"row {sorted(key)}: slot ({l32_idx}, {side}) assigned to "
+                f"group {source_letter} but only {sorted(allowed)} are allowed"
+            )
+
+    def test_no_two_slots_overlap(self, soccer, key):
+        row = soccer._WC2026_THIRD_PLACER_SLOT_TABLE[key]
+        targets = [(l32_idx, side) for l32_idx, side, _ in row]
+        assert len(set(targets)) == len(targets), (
+            f"row {sorted(key)}: duplicate target slot in {targets}"
+        )
+
+    def test_source_letters_match_key(self, soccer, key):
+        row = soccer._WC2026_THIRD_PLACER_SLOT_TABLE[key]
+        source_letters = {source for _, _, source in row}
+        assert source_letters == set(key), (
+            f"row {sorted(key)}: assigned source letters {sorted(source_letters)} "
+            f"differ from key {sorted(key)}"
+        )
+
+
+class TestBuildBracketSeedUsesCanonicalMapping:
+    """End-to-end check that _build_bracket_seed prefers the Annex C
+    table over the strongest-first greedy fallback. The two paths
+    produce different assignments for the same input -- the canonical
+    mapping pins the source group per slot regardless of best-3rd-placer
+    strength order, the greedy fallback walks the strongest-first
+    qualifying_thirds list and grabs the first allowed match.
+
+    For the {ABCDEFGH} key (Wikipedia's row 495), Annex C places
+    group C's 3rd-placer at M74 (l32_idx=1). The greedy fallback,
+    given the default test state where all 8 qualifying thirds are
+    alphabetically ordered (GA3 first), would place GA3 at M74
+    because A is in M74's allowed_groups {A,B,C,D,F}. This test
+    asserts the canonical value, which catches a regression to the
+    greedy path."""
+
+    @staticmethod
+    def _wc_source(soccer):
+        return soccer.GroupStageSoccerSource("world_cup", fd_api_key="x", odds_api_key="")
+
+    @staticmethod
+    def _state_with_thirds_abcdefgh(soccer):
+        # Lifted from test_sources.py::TestBuildBracketSeedWC2026._full_wc_state
+        # but inlined to avoid cross-file fixture coupling.
+        team_group = {}
+        state = {"_applied": frozenset(), "_team_group": team_group}
+        for gi in range(12):
+            letter = chr(ord("A") + gi)
+            grp = f"GROUP_{letter}"
+            # Top 8 advance their 3rd-placer; A-H get extra strength.
+            third_pts = 4 if letter in "ABCDEFGH" else 1
+            third_gd = 2 if letter in "ABCDEFGH" else -2
+            teams = [
+                (f"G{letter}1", 9, 5, 8),
+                (f"G{letter}2", 6, 2, 5),
+                (f"G{letter}3", third_pts, third_gd, 3),
+                (f"G{letter}4", 0, -5, 1),
+            ]
+            for team, points, gd, gf in teams:
+                team_group[team] = grp
+                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
+        return state
+
+    def test_canonical_m74_assignment(self, soccer):
+        """Annex C row {ABCDEFGH}: M74's away (the slot whose home is
+        1E, l32_idx=1) is group C's 3rd-placer."""
+        src = self._wc_source(soccer)
+        state = self._state_with_thirds_abcdefgh(soccer)
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        m74 = l32[1]
+        # Home is "GE1" (group winner E), away is the best_third per Annex C.
+        assert "GE1" in {m74["home"], m74["away"]}
+        third_team = m74["home"] if m74["away"] == "GE1" else m74["away"]
+        # Annex C maps M74 (col 1E vs) to source group C -> team GC3.
+        assert third_team == "GC3", (
+            f"M74 away should be GC3 (Annex C canonical) but is {third_team}; "
+            f"this indicates the table lookup didn't fire and the strongest-"
+            f"first greedy fallback ran instead."
+        )
+
+    def test_canonical_m82_assignment(self, soccer):
+        """Annex C row {ABCDEFGH}: M82's away (the slot whose home is
+        1G, l32_idx=9) is group A's 3rd-placer. Greedy would have
+        consumed GA3 earlier; this asserts canonical."""
+        src = self._wc_source(soccer)
+        state = self._state_with_thirds_abcdefgh(soccer)
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        m82 = l32[9]
+        assert "GG1" in {m82["home"], m82["away"]}
+        third_team = m82["home"] if m82["away"] == "GG1" else m82["away"]
+        assert third_team == "GA3", (
+            f"M82 away should be GA3 (Annex C canonical) but is {third_team}"
+        )
+
+    def test_all_eight_canonical_assignments(self, soccer):
+        """Full assignment check for {ABCDEFGH}: every best_third slot
+        gets the team Annex C names."""
+        src = self._wc_source(soccer)
+        state = self._state_with_thirds_abcdefgh(soccer)
+        seed = src._build_bracket_seed(state)
+        l32 = seed["stages"][0]["ties"]
+        # Pull the (l32_idx, away_team) pairs for slots with a best_third.
+        away_by_idx = {}
+        for idx, tie in enumerate(l32):
+            home_slot, away_slot = soccer._WC2026_LAST_32_PAIRINGS[idx]
+            if away_slot[0] == "best_third":
+                away_by_idx[idx] = tie["away"] if tie["home"].endswith("1") else tie["home"]
+        expected = {
+            1: "GC3",   # M74 from row 495 col 1E vs -> 3C
+            4: "GF3",   # M77 col 1I vs -> 3F
+            6: "GH3",   # M79 col 1A vs -> 3H
+            7: "GE3",   # M80 col 1L vs -> 3E
+            8: "GB3",   # M81 col 1D vs -> 3B
+            9: "GA3",   # M82 col 1G vs -> 3A
+            12: "GG3",  # M85 col 1B vs -> 3G
+            14: "GD3",  # M87 col 1K vs -> 3D
+        }
+        assert away_by_idx == expected

--- a/tools/parse_annex_c.py
+++ b/tools/parse_annex_c.py
@@ -1,0 +1,183 @@
+"""Parse the Annex C 495-row third-place table from Wikipedia template
+wikitext and emit a Python literal that can be pasted into
+sources/soccer.py.
+
+Usage:
+  curl -sL "https://en.wikipedia.org/wiki/Template:2026_FIFA_World_Cup_third-place_table?action=raw" > /tmp/raw.txt
+  python3 tools/parse_annex_c.py /tmp/raw.txt > /tmp/literal.py
+  # then splice /tmp/literal.py into sources/soccer.py replacing
+  # the existing _WC2026_THIRD_PLACER_SLOT_TABLE body.
+
+The script EXITS NONZERO if any of the 495 rows fails a constraint
+(slot count, allowed_groups membership, advancing/assigned letter
+mismatch, duplicate key). Don't paste output unless this script exits 0.
+
+Re-run conditions: Wikipedia's table updates (rare) or if a
+transcription bug is discovered. The parametrized test at
+tests/test_annex_c_table.py is the regression guard against drift.
+
+Wikipedia table column header:
+  1A vs, 1B vs, 1D vs, 1E vs, 1G vs, 1I vs, 1K vs, 1L vs
+
+These are the 8 reserved best_third slots in the LAST_32 bracket. Map
+each header column to the corresponding l32_match_idx in our
+_WC2026_LAST_32_PAIRINGS table:
+
+  Col 0 (1A vs) -> M79 (l32_idx=6)   away slot is best_third from {CEFHI}
+  Col 1 (1B vs) -> M85 (l32_idx=12)  away slot from {EFGIJ}
+  Col 2 (1D vs) -> M81 (l32_idx=8)   from {BEFIJ}
+  Col 3 (1E vs) -> M74 (l32_idx=1)   from {ABCDF}
+  Col 4 (1G vs) -> M82 (l32_idx=9)   from {AEHIJ}
+  Col 5 (1I vs) -> M77 (l32_idx=4)   from {CDFGH}
+  Col 6 (1K vs) -> M87 (l32_idx=14)  from {DEIJL}
+  Col 7 (1L vs) -> M80 (l32_idx=7)   from {EHIJK}
+
+Each row gives:
+  - 12 cells: which third-placers are advancing (bold letter or blank)
+  - 8 cells: 3X assignment per column (where X is the source group)
+
+Output literal: a dict mapping frozenset(advancing_group_letters) to
+a sorted tuple of (l32_match_idx, side, group_letter) triples. Side
+is always "away" because every best_third slot in our pairings is the
+away slot.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from typing import Dict, FrozenSet, List, Tuple
+
+HEADER_COL_TO_L32 = {
+    0: 6,   # 1A vs -> M79
+    1: 12,  # 1B vs -> M85
+    2: 8,   # 1D vs -> M81
+    3: 1,   # 1E vs -> M74
+    4: 9,   # 1G vs -> M82
+    5: 4,   # 1I vs -> M77
+    6: 14,  # 1K vs -> M87
+    7: 7,   # 1L vs -> M80
+}
+
+# Cross-reference: the allowed_groups frozenset for each L32 best_third
+# slot (from _WC2026_LAST_32_PAIRINGS). The parser verifies each row's
+# slot assignment satisfies the constraint.
+L32_ALLOWED_GROUPS = {
+    1: frozenset("ABCDF"),   # M74 from cols
+    4: frozenset("CDFGH"),   # M77
+    6: frozenset("CEFHI"),   # M79
+    7: frozenset("EHIJK"),   # M80
+    8: frozenset("BEFIJ"),   # M81
+    9: frozenset("AEHIJ"),   # M82
+    12: frozenset("EFGIJ"),  # M85
+    14: frozenset("DEIJL"),  # M87
+}
+
+
+def parse(text: str) -> Dict[FrozenSet[str], List[Tuple[int, str, str]]]:
+    # Split into row blocks. Each row starts with `! scope="row" | NNN`.
+    row_re = re.compile(r'!\s*scope="row"\s*\|\s*(\d+)\s*\n((?:.+\n)+?)(?=!\s*scope="row"|\|\})', re.MULTILINE)
+    out: Dict[FrozenSet[str], List[Tuple[int, str, str]]] = {}
+
+    for m in row_re.finditer(text):
+        row_num = int(m.group(1))
+        body = m.group(2)
+
+        # Flatten the body cells. Wikitext uses `|| cell` and `| cell` and `|`
+        # for empty cells. Join all lines, then split on `||` and leading `|`.
+        flat = re.sub(r'\n\s*', ' ', body).strip()
+
+        # Row 1 has a single `! rowspan="495" |` cell between the 12 advancing
+        # cells and the 8 slot cells. Replace it with `||` so the cell stream
+        # stays uniform across all rows (it functions as a column separator,
+        # not a data cell). Other rows have no such marker; we just strip.
+        flat = re.sub(r'!\s*rowspan="495"\s*\|', '||', flat)
+
+        # Strip trailing row terminator (`|-`) and the leading column delimiter.
+        flat = re.sub(r'\|-\s*$', '', flat).strip()
+        if flat.startswith('|'):
+            flat = flat[1:]
+        cells = [c.strip() for c in flat.split('||')]
+
+        # Expected: 20 cells total -- 12 advancing-group cells + 8 slot cells.
+        if len(cells) != 20:
+            print(f"Row {row_num}: expected 20 cells, got {len(cells)}: {cells}", file=sys.stderr)
+            sys.exit(1)
+
+        # Parse cells 0-11: advancing-group letters. Bold = advancing.
+        # Wikitext: `'''X'''` for a bold letter; empty cell = team didn't advance.
+        adv_cells = cells[:12]
+        advancing: List[str] = []
+        # Column-to-letter map: cell 0 is group A, cell 1 is B, ..., cell 11 is L.
+        for i, raw in enumerate(adv_cells):
+            cell_letter = chr(ord("A") + i)
+            bold_match = re.search(r"'''([A-L])'''", raw)
+            if bold_match:
+                if bold_match.group(1) != cell_letter:
+                    print(f"Row {row_num}: cell {i} expected '{cell_letter}', got '{bold_match.group(1)}'",
+                          file=sys.stderr)
+                    sys.exit(1)
+                advancing.append(cell_letter)
+
+        if len(advancing) != 8:
+            print(f"Row {row_num}: expected 8 advancing letters, got {len(advancing)}: {advancing}",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        # Parse cells 12-19: 3X slot assignments.
+        slot_cells = cells[12:20]
+        assignments: List[Tuple[int, str, str]] = []
+        for col, raw in enumerate(slot_cells):
+            slot_match = re.search(r'3\s*([A-L])', raw)
+            if not slot_match:
+                print(f"Row {row_num}: slot col {col} no 3X match in {raw!r}", file=sys.stderr)
+                sys.exit(1)
+            letter = slot_match.group(1)
+            l32_idx = HEADER_COL_TO_L32[col]
+            # Verify the group letter is in the slot's allowed_groups
+            # constraint.
+            if letter not in L32_ALLOWED_GROUPS[l32_idx]:
+                print(f"Row {row_num}: slot col {col} assigns group {letter} "
+                      f"to L32 {l32_idx} but allowed is {sorted(L32_ALLOWED_GROUPS[l32_idx])}",
+                      file=sys.stderr)
+                sys.exit(1)
+            assignments.append((l32_idx, "away", letter))
+
+        # Verify each advancing group appears exactly once in the slot
+        # assignments.
+        assigned_letters = [a[2] for a in assignments]
+        if sorted(assigned_letters) != sorted(advancing):
+            print(f"Row {row_num}: advancing {sorted(advancing)} != assigned {sorted(assigned_letters)}",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        key = frozenset(advancing)
+        if key in out:
+            print(f"Row {row_num}: duplicate key {sorted(key)}", file=sys.stderr)
+            sys.exit(1)
+        # Sort assignments by l32_match_idx for stable output.
+        out[key] = sorted(assignments, key=lambda t: t[0])
+
+    return out
+
+
+def emit_python_literal(table: Dict[FrozenSet[str], List[Tuple[int, str, str]]]) -> str:
+    """Format as a multi-line Python dict literal grouped 1 entry per line."""
+    lines = ["_WC2026_THIRD_PLACER_SLOT_TABLE: Dict[FrozenSet[str], Tuple[Tuple[int, str, str], ...]] = {"]
+    # Sort by key (sorted-letter representation) for deterministic output.
+    for key in sorted(table.keys(), key=lambda f: sorted(f)):
+        letters = "".join(sorted(key))
+        triples = ", ".join(f'({a},"{b}","{c}")' for (a, b, c) in table[key])
+        lines.append(f'    frozenset("{letters}"): ({triples}),')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        text = f.read()
+    table = parse(text)
+    print(f"# Parsed {len(table)} rows", file=sys.stderr)
+    if len(table) != 495:
+        print(f"ERROR: expected 495 unique combinations, got {len(table)}", file=sys.stderr)
+        sys.exit(1)
+    print(emit_python_literal(table))


### PR DESCRIPTION
## Summary

Adds `_WC2026_THIRD_PLACER_SLOT_TABLE` to `sources/soccer.py` — a dict of all 495 advancing-3rd-placer combinations keyed by `frozenset(group_letters)`, value = the 8 `(l32_match_idx, side, source_letter)` triples that pin each best-3rd to a specific reserved LAST_32 slot per FIFA's published Annex C. `_build_bracket_seed` looks the row up first; the existing greedy backtracking remains as a fallback for missing keys.

Before this PR: the greedy fallback satisfied bracket validity (no same-group L32 rematches) but assigned slots "strongest 3rd-placer first" — which may differ from FIFA's canonical mapping. Group games' R16+ leverage signal had correct direction but approximate magnitude because the simulated R16 opponent might not match the canonical one.

After: the canonical mapping applies whenever the qualifying-thirds set matches one of the 495 keys (which is always, since the set IS one of C(12, 8) = 495 combinations).

## Source data

Transcribed from FIFA's "FIFA World Cup 2026 Regulations" PDF (May 2025), Annex C, via the machine-readable Wikipedia template:

- https://en.wikipedia.org/wiki/Template:2026_FIFA_World_Cup_third-place_table

The parser `tools/parse_annex_c.py` ingests the raw wikitext, validates every row against the L32 allowed_groups constraints declared in `_WC2026_LAST_32_PAIRINGS`, and emits the Python literal. The parser exits nonzero on any constraint violation, so a Wikipedia edit that introduces drift can't silently propagate.

To regenerate:

```bash
curl -sL "https://en.wikipedia.org/wiki/Template:2026_FIFA_World_Cup_third-place_table?action=raw" > /tmp/raw.txt
python3 tools/parse_annex_c.py /tmp/raw.txt > /tmp/literal.py
# splice into sources/soccer.py replacing _WC2026_THIRD_PLACER_SLOT_TABLE body
```

## Files

- `sources/soccer.py`: new `_WC2026_THIRD_PLACER_SLOT_TABLE` constant (495 rows, ~500 lines). `_build_bracket_seed` updated — table lookup before backtracking; backtracking preserved verbatim as fallback. Comment block above the dict points to the source and the parser; comment in `_build_bracket_seed` calls out which path is primary.
- `tests/test_annex_c_table.py` (new): 1988 tests. Cardinality + shape checks (5), parametrized constraint checks over all 495 rows (1980 = 4 × 495), and end-to-end `_build_bracket_seed` integration tests (3) that pin specific canonical assignments the greedy fallback would NOT produce (M74→GC3, M82→GA3, full row 495 sweep).
- `tools/parse_annex_c.py` (new): the parser that emits the table from Wikipedia wikitext. Self-validates every row.

## Test plan

- [x] Full suite: 3016 pass (1028 baseline + 1988 new)
- [x] Parametrized sweep verifies all 495 keys satisfy: exactly 8 triples, each `(l32_idx, side)` is a reserved best_third slot, each source letter is in the L32 allowed_groups set, no two triples target the same slot, the assigned source letters exactly equal the key
- [x] Integration tests confirm `_build_bracket_seed` hits the table-lookup path (not the greedy fallback) for the `{ABCDEFGH}` scenario and produces the canonical M74→GC3 / M82→GA3 assignments
- [x] Existing `TestBuildBracketSeedWC2026` (7 tests) all still pass — the canonical assignment also satisfies bracket validity

## Why this matters (and the limited blast radius)

WC 2026 group stage starts June 11. Group-stage games' R16+ leverage signal becomes nonzero on June 11; before this PR that signal would have correct direction but a magnitude that's mis-targeted at non-canonical opponents. After this PR, it's pinned to the real opponents teams will face. The change is purely additive (lookup → fallback), so any future Annex C edit that breaks our table data will fail the parametrized test rather than silently corrupting leverage outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)