### PR TITLE
Closes #73: em-dash sweep across all .py files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-"""Dispatcharr Ranked Matchups — interestingness curator for sports channels."""
+"""Dispatcharr Ranked Matchups: interestingness curator for sports channels."""
 
 from .plugin import Plugin
 

--- a/_util.py
+++ b/_util.py
@@ -29,7 +29,7 @@ def parse_iso_utc(s: Optional[str]) -> Optional[datetime]:
 
 def stable_hash_int(s: str) -> int:
     """Process-stable hash of a string. Python's builtin hash() is salted by
-    PYTHONHASHSEED — same input gives different output across restarts. This
+    PYTHONHASHSEED: same input gives different output across restarts. This
     uses md5 truncated to 16 hex chars (~64 bits) which is plenty for marker
     uniqueness and is identical across processes / restarts."""
     digest = hashlib.md5(s.encode("utf-8")).hexdigest()
@@ -77,7 +77,7 @@ def poisson_sample(lam: float, rng: random.Random) -> int:
 
     Shared by every points-based / goals-based sport source. Soccer uses
     lam ~ 1.4 (goals/match). NCAAF / NCAAM use lam ~ 28 / 75 (points/team).
-    Knuth's algorithm is O(lam) — for lam > ~50 a normal-approximation
+    Knuth's algorithm is O(lam): for lam > ~50 a normal-approximation
     would be measurably faster, but the per-refresh sim cost is dominated
     by season iteration, not the inner Poisson, so we keep one
     implementation for simplicity. Swap in a normal approx here if profiling
@@ -98,7 +98,7 @@ def poisson_sample(lam: float, rng: random.Random) -> int:
 # matcher._team_keywords need to know these to match against shortened forms.
 TEAM_SUFFIX_TOKENS = ("afc", "fc", "cf", "sc")
 
-# Common second-word soccer suffixes that look distinctive but aren't —
+# Common second-word soccer suffixes that look distinctive but aren't:
 # 'United' alone false-matches Manchester/West Ham/Newcastle/Leeds/Sheffield;
 # 'City' alone false-matches Manchester/Leicester/Hull/Cardiff/Swansea/etc.
 # matcher._team_keywords excludes these from the last-word fallback so

--- a/llm_descriptions.py
+++ b/llm_descriptions.py
@@ -7,10 +7,10 @@ returned prose to `ProgramData.description` instead of the deterministic
 
 Failure modes (missing key, API error, non-200, malformed body, network
 timeout, JSON decode) all return `fallback_description` unchanged. The cache
-file is a sidecar — cache.json's structured fields (score, breakdown,
+file is a sidecar: cache.json's structured fields (score, breakdown,
 score_notes) stay deterministic and untouched.
 
-The HTTP call is intentionally `urllib` (stdlib only) — Dispatcharr does not
+The HTTP call is intentionally `urllib` (stdlib only): Dispatcharr does not
 ship the `anthropic` SDK and we do not want to add a transitive dependency
 for a 30-line wrapper.
 """
@@ -46,7 +46,7 @@ Hard rules:
 - 2-3 sentences. Max ~50 words.
 - Skip generic openings ("This match features..."). Drop the reader into the
   stakes.
-- If a favorite team for this user is playing, that's a "personal interest" —
+- If a favorite team for this user is playing, that's a "personal interest":
   ground the preview in their angle.
 - Plain text only. No markdown, no asterisks, no bullet points.
 """
@@ -107,7 +107,7 @@ def _standings_window(table: List[Dict[str, Any]], focus_positions: List[Any]) -
 def build_llm_context(g: Dict[str, Any], tagline: str, boundary_summary: str = "") -> str:
     """Build the user-message context block for the LLM.
 
-    Pulls only from data already in the cache row — no new API calls. The
+    Pulls only from data already in the cache row: no new API calls. The
     standings window includes the two teams playing plus their immediate
     neighbors, so the model can write "one point above the drop zone" without
     being told the threshold name.
@@ -233,7 +233,7 @@ def llm_describe_or_fallback(
 
     Mutates `cache` in place on a successful call (caller is responsible for
     persisting the cache dict to disk). The enable-flag, the API-key existence
-    check, and the placeholder skip are the caller's job — this function
+    check, and the placeholder skip are the caller's job: this function
     assumes it should attempt the call.
     """
     context = build_llm_context(g, tagline, boundary_summary)

--- a/logos.py
+++ b/logos.py
@@ -63,7 +63,7 @@ _FIELD_AWAY_SENTINEL = "Field"
 # Plugin sport_prefix -> substring that must appear in SportsDB's strLeague or
 # strSport for the result to be accepted. Disambiguates same-name cross-sport
 # collisions (e.g. "Alabama vs Auburn" is both a football and basketball
-# fixture). Missing entries mean no disambiguation — date filter alone.
+# fixture). Missing entries mean no disambiguation: date filter alone.
 _SPORT_HINT: dict[str, str] = {
     "CFB": "NCAA",
     "CBB": "NCAA",
@@ -142,7 +142,7 @@ def _date_in_tolerance(event_date_str: str, expected_dt: datetime) -> bool:
 def _hint_matches(event: dict, sport_prefix: Optional[str]) -> bool:
     """Verify the SportsDB event matches the expected sport, if we have a hint.
 
-    Falls open (returns True) when the prefix isn't in the hint map — better
+    Falls open (returns True) when the prefix isn't in the hint map: better
     to accept a slightly-wrong match than to miss every game from an unmapped
     sport.
     """
@@ -180,7 +180,7 @@ def resolve_thumb_url(
     """Search SportsDB for a matchup event and return its strThumb URL.
 
     Returns None when:
-      - away == "Field" (field-event sentinel — no h2h matchup)
+      - away == "Field" (field-event sentinel: no h2h matchup)
       - the search returns no events
       - no event matches both the date tolerance AND the sport hint
       - the matched event has no strThumb
@@ -250,7 +250,7 @@ class ThumbCache:
 
     Negative entries (URL is None) are cached too so we don't re-probe every
     apply, but with a shorter TTL than positives because SportsDB indexes
-    fixtures gradually — a miss this morning can be a hit by evening.
+    fixtures gradually: a miss this morning can be a hit by evening.
     """
 
     def __init__(self, cache_path: str):

--- a/matcher.py
+++ b/matcher.py
@@ -29,7 +29,7 @@ from ._util import GENERIC_TEAM_SECOND_WORDS, TEAM_SUFFIX_TOKENS
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.matcher")
 
 
-# Team-name aliases — broadcaster-side abbreviations broadcasters use in
+# Team-name aliases: broadcaster-side abbreviations broadcasters use in
 # EPG titles ("Man United", "Man Utd") that don't appear in Football-Data.org's
 # canonical names ("Manchester United FC"). Loaded once per process from
 # team_aliases.json. See #4.
@@ -39,7 +39,7 @@ _ALIASES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "team_a
 def _load_team_aliases() -> Dict[str, List[str]]:
     """Load team-name aliases from team_aliases.json.
 
-    Missing or malformed file logs a warning and returns empty dict — the
+    Missing or malformed file logs a warning and returns empty dict: the
     matcher still works without aliases, just with the v1 keyword set.
     """
     try:
@@ -109,7 +109,7 @@ def _team_keywords(team_name: str) -> List[str]:
     United' never reduces to just 'United' (which would false-match
     'Brentford v West Ham United').
 
-    Pulls broadcaster aliases from team_aliases.json — "Manchester United"
+    Pulls broadcaster aliases from team_aliases.json: "Manchester United"
     expands to include "Man United" / "Man Utd" / "Man U" / "MUFC" so
     abbreviated EPG titles still match. Lookup tries the canonical name
     AND its trailing-suffix-stripped form to catch FD.org names that
@@ -292,7 +292,7 @@ MATCHER_SYSTEM_PROMPT = (
     # for European soccer (German DAZN, Spanish Movistar, Italian Sky,
     # French Canal+, Portuguese SportTV). Match on team names even when
     # the surrounding 'matchday' vocabulary is in another language:
-    "EPG titles in other languages are common — match team names even when surrounding "
+    "EPG titles in other languages are common: match team names even when surrounding "
     "text is foreign. Common 'matchday' translations: DE Spieltag, ES jornada, "
     "IT giornata, FR journee, PT jornada. Common 'highlights' translations: "
     "DE Zusammenfassung, ES resumen, IT sintesi, FR resume. "
@@ -325,7 +325,7 @@ def match_games_to_channels(
             continue
 
         # Tier 1 (strongest signal): channels whose NAME contains both teams.
-        # These are dedicated match channels — typically multiple regional /
+        # These are dedicated match channels: typically multiple regional /
         # quality variants of the same fixture. Stack all of them.
         strict = _regex_filter_channel_name(candidates, game.home, game.away)
         if strict:
@@ -344,7 +344,7 @@ def match_games_to_channels(
             continue
 
         # Tier 2: program-title regex, with previews ('Next Game:', 'Preview:',
-        # 'Pre-game ...') stripped — those mark team-branded home channels
+        # 'Pre-game ...') stripped: those mark team-branded home channels
         # that surface upcoming-game EPG cards but don't broadcast the match.
         filtered = _strip_preview_titles(
             _regex_filter(candidates, game.home, game.away)
@@ -365,7 +365,7 @@ def match_games_to_channels(
             if wider:
                 ambiguous.append((i, game, wider))
         else:
-            # Multiple regex matches survived preview stripping — Claude resolves.
+            # Multiple regex matches survived preview stripping: Claude resolves.
             ambiguous.append((i, game, filtered))
 
     if ambiguous and api_key:
@@ -409,7 +409,7 @@ def match_games_to_channels(
             results[idx].channel_ids = [chosen.channel_id]
             results[idx].method = "llm"
     elif ambiguous:
-        # No API key — best-effort: pick first candidate to surface SOMETHING.
+        # No API key: best-effort: pick first candidate to surface SOMETHING.
         for idx, _game, cands in ambiguous:
             if cands:
                 c = cands[0]

--- a/plugin.py
+++ b/plugin.py
@@ -84,7 +84,7 @@ EPG_POST_HOURS = 4    # 4 hours after game starts (default; covers OT)
 
 # Per-sport match-window override (used by _build_epg_lookup to constrain
 # the regex pre-filter's time bucket). The ProgramData slot we emit for
-# our virtual channel still uses the defaults above — those control
+# our virtual channel still uses the defaults above: those control
 # user-facing display, not match recall. See #4.
 #
 # Soccer leagues / international tournaments. Soccer games run ~95-120 min
@@ -119,7 +119,7 @@ TVG_ID_PREFIX = "ranked_matchups:"
 
 # Legacy tvg_id values earlier versions of this plugin wrote. The rename
 # cleanup pass needs these to recognize leftover EPGData rows on a renamed-from
-# EPGSource — a TVG_ID_PREFIX-only check misses sources whose only remaining
+# EPGSource: a TVG_ID_PREFIX-only check misses sources whose only remaining
 # rows are legacy-shaped, leaving the orphan visible in the UI with
 # status='error' forever after a target-group rename.
 # Add to this tuple when the tvg_id scheme changes; never remove an entry.
@@ -143,17 +143,17 @@ def _owned_tvg_id_q(field_prefix: str = ""):
     )
 
 # Default starting channel number when the user hasn't configured one. Sentinel
-# 0 means "auto" — pick the first channel number after the highest existing
+# 0 means "auto": pick the first channel number after the highest existing
 # non-virtual channel, so we slot in cleanly without colliding with real
 # channels.
 DEFAULT_VIRTUAL_CHANNEL_BASE = 0
 
 # Default fallback when DEFAULT_VIRTUAL_CHANNEL_BASE is sentinel-0 AND there
-# are zero existing channels (fresh install) — picked high enough not to
+# are zero existing channels (fresh install): picked high enough not to
 # collide with auto-channel-sync ranges.
 _AUTO_BASE_FALLBACK = 9000
 
-# EPGSource fields. DO NOT use source_type="dummy" — Dispatcharr's
+# EPGSource fields. DO NOT use source_type="dummy": Dispatcharr's
 # EPGGridAPIView treats every channel attached to a dummy source as needing
 # joke filler ("Rush Hour - X's alternative to traffic", "What's For Dinner?
 # Debate", etc.) and overlays it in the web UI on top of our real ProgramData.
@@ -204,7 +204,7 @@ def _stream_sort_key(stream_stats, name):
          Sub-sort by -height (1080p before 720p) then -bitrate.
       1. No probe data at all (Dispatcharr never crawled this stream).
          Sub-sort by name-keyword bucket (UHD > FHD > HD > unknown > SD).
-      2. Probe ran and got 0x0 — typically a dead/broken stream. Sort last
+      2. Probe ran and got 0x0: typically a dead/broken stream. Sort last
          even if the name claims UHD, because the probe data overrides
          marketing.
     """
@@ -267,7 +267,7 @@ def _format_kickoff(start_utc: datetime, tz) -> str:
 
 
 def _format_matchup(home: str, away: str) -> str:
-    """Team-pair string for EPG program titles. Plain `Home vs Away` —
+    """Team-pair string for EPG program titles. Plain `Home vs Away`:
     deliberately omits the ★ score prefix the channel name carries, so
     the EPG entry reads like a real broadcast EPG title rather than a
     debug breadcrumb."""
@@ -299,7 +299,7 @@ def _build_program_title(state: str, matchup: str, kickoff_local: str) -> str:
 
 
 def _compute_past_slot_end(prog_end_utc: datetime, settings: Dict[str, Any]) -> datetime:
-    """End time for the post-event EPG slot — runs until the next
+    """End time for the post-event EPG slot: runs until the next
     scheduled refresh fire-time, so the slot disappears the moment the
     refresh that would replace this channel runs.
 
@@ -370,7 +370,7 @@ def _dedup_series_games(games: List[Any], sources: List[Any]) -> Tuple[List[Any]
     """Collapse a best-of-N playoff series to its next-scheduled game.
 
     NHL / NBA / MLB / NCAA-tournament source `fetch_upcoming` calls
-    return every scheduled game in a series — including future entries
+    return every scheduled game in a series: including future entries
     whose date is a placeholder for "Game 5/6/7 IF NEEDED". The user
     sees that as 4-7 redundant virtual channels for the same matchup.
     Group rows by `(sport_prefix, frozenset({home, away}))` and keep
@@ -378,12 +378,12 @@ def _dedup_series_games(games: List[Any], sources: List[Any]) -> Tuple[List[Any]
     `(deduped_games, deduped_sources, n_dropped)` preserving the
     parallel-index relationship between games and sources.
 
-    DO NOT key on `(sport_prefix, home, away)` with order preserved —
+    DO NOT key on `(sport_prefix, home, away)` with order preserved:
     NHL playoff Games 2 and 4 swap home-ice (the lower-seed gets
     "Carolina at Montreal" alternating with "Montreal at Carolina")
     and a strict ordered key would treat them as distinct.
 
-    League sources also flow through this — same team-pair appearing
+    League sources also flow through this: same team-pair appearing
     twice in a 7-day lookahead is genuinely rare (would have to be a
     midweek + weekend cup pairing, or a replay), and "show only the
     next one" is the same UX as for playoffs. If a future scenario
@@ -429,7 +429,7 @@ def _parse_favorites(raw: str) -> List[str]:
 # - "high_curation": narrow to ~10 high-leverage games; weights emphasize
 #   structural importance + rank, downweight favorites/spread so they don't
 #   dominate the list when the user wants tight curation.
-# - "balanced": ~25 games with default weights — mirrors the v0 default.
+# - "balanced": ~25 games with default weights: mirrors the v0 default.
 # - "high_coverage": ~50 games with permissive weights so smaller-stakes
 #   matchups still show up even on quiet days.
 #
@@ -444,7 +444,7 @@ _CURATION_PRESETS: Dict[str, Dict[str, float]] = {
         "max_games": 10,
     },
     "balanced": {
-        # Mirrors Weights() dataclass defaults — kept here for the SAME
+        # Mirrors Weights() dataclass defaults: kept here for the SAME
         # reason _build_weights pulls from Weights(): if defaults change,
         # the "balanced" preset SHOULD track them. DRY check pinned by tests.
         "rank": 1.0, "spread": 3.0, "favorite": 6.0, "rivalry": 2.0,
@@ -461,7 +461,7 @@ _CURATION_PRESETS: Dict[str, Dict[str, float]] = {
 
 def _build_weights(settings: Dict[str, Any]):
     # Source of truth for default values is scoring.Weights's dataclass
-    # declaration. Do NOT duplicate the numbers here — when a default
+    # declaration. Do NOT duplicate the numbers here: when a default
     # changes, the duplicate ALWAYS gets missed and the runtime silently
     # uses the old value until somebody runs the tests.
     from .scoring import Weights
@@ -540,7 +540,7 @@ def _build_sources(settings: Dict[str, Any]):
         """Pick the right SoccerSource subclass for a given competition based
         on its LEAGUE_CONTEXTS format. League-format (PL, ELC, BL1, etc.)
         uses SoccerSource. Knockout-format (CL, EL, etc.) uses
-        KnockoutSoccerSource — a different state machine for bracket shape.
+        KnockoutSoccerSource: a different state machine for bracket shape.
         """
         cfg = COMPETITIONS.get(comp_key)
         ctx = LEAGUE_CONTEXTS.get(cfg.fd_code) if cfg else None
@@ -602,11 +602,11 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_brazilian_serie_a", False) and fd_key:
         sources.append(_make_soccer("brazilian_serie_a"))
 
-    # NFL — no API key required (ESPN unofficial). Same pair-and-seed
+    # NFL: no API key required (ESPN unofficial). Same pair-and-seed
     # pattern as NHL/MLB/NBA. Bracket is single-game elimination
     # (SERIES_LENGTH=1 per stage) across 4 rounds: WC -> DIV -> CONF
     # -> SB. Strength sharing matters most here because NFL teams
-    # play only 17 regular-season games — even fewer baseline games
+    # play only 17 regular-season games: even fewer baseline games
     # than WNBA.
     if settings.get("enable_nfl", False):
         nfl_reg = NflRegularSource()
@@ -618,7 +618,7 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[nfl] could not seed playoff strengths: %s", exc)
         sources.append(nfl_po)
 
-    # NHL — no API key required (api-web.nhle.com is free). Pair the
+    # NHL: no API key required (api-web.nhle.com is free). Pair the
     # regular and playoff sources together: the playoff source borrows
     # regular-season strength estimates from the regular source so a
     # 70-game per-team baseline informs playoff-game sampling instead
@@ -635,11 +635,11 @@ def _build_sources(settings: Dict[str, Any]):
             nhl_po.set_regular_season_strengths(nhl_reg.estimate_strengths())
         except Exception as exc:  # noqa: BLE001
             # Don't let a strengths-seeding hiccup gate the playoff
-            # source — it can still run on the default prior.
+            # source: it can still run on the default prior.
             logger.warning("[nhl] could not seed playoff strengths: %s", exc)
         sources.append(nhl_po)
 
-    # MLB — no API key required (statsapi.mlb.com is free). Same pair-and-
+    # MLB: no API key required (statsapi.mlb.com is free). Same pair-and-
     # seed pattern as NHL: the playoff source borrows regular-season
     # strength estimates from the regular source so postseason game-
     # sampling reflects per-team scoring skill instead of the 4.5/4.5
@@ -654,7 +654,7 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[mlb] could not seed playoff strengths: %s", exc)
         sources.append(mlb_po)
 
-    # NBA — no API key required. ESPN unofficial API is used (stats.nba.com
+    # NBA: no API key required. ESPN unofficial API is used (stats.nba.com
     # is WAF-blocked from most homelab egress); same pair-and-seed pattern
     # as NHL/MLB: the playoff source borrows regular-season strength
     # estimates from the regular source so a 60-game per-team baseline
@@ -671,7 +671,7 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[nba] could not seed playoff strengths: %s", exc)
         sources.append(nba_po)
 
-    # MLS — issue #30 part A: register MlsEastSource + MlsWestSource
+    # MLS: issue #30 part A: register MlsEastSource + MlsWestSource
     # for per-conference standings importance (playoff seeding is per-
     # conference, not aggregate league). The closeness-only MlsSource
     # stays as the base class for NwslSource / LigaMxSource but is NOT
@@ -684,7 +684,7 @@ def _build_sources(settings: Dict[str, Any]):
     # then single-leg CSF / CF / MLS Cup Final. Per-stage series length
     # via `_series_length_for_stage` (same hook MLB uses for its
     # WC/LDS/LCS/WS mix). Strengths are merged across both conferences
-    # before seeding the cup source — the MLS Cup Final is cross-
+    # before seeding the cup source: the MLS Cup Final is cross-
     # conference, so per-team scoring rates need to be in one dict.
     if settings.get("enable_mls", False):
         mls_east = MlsEastSource(odds_api_key=odds_key or "")
@@ -701,19 +701,19 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[mls_cup] could not seed playoff strengths: %s", exc)
         sources.append(mls_cup)
 
-    # NWSL — same V1 minimal pattern as MLS (schedule + closeness).
+    # NWSL: same V1 minimal pattern as MLS (schedule + closeness).
     # Subclasses MlsSource with NWSL-specific endpoint and Odds API
     # key. No importance / playoff bracket in V1.
     if settings.get("enable_nwsl", False):
         sources.append(NwslSource(odds_api_key=odds_key or ""))
 
-    # Liga MX — Mexican top-flight. Same V1 minimal pattern.
+    # Liga MX: Mexican top-flight. Same V1 minimal pattern.
     if settings.get("enable_liga_mx", False):
         sources.append(LigaMxSource(odds_api_key=odds_key or ""))
 
     # Field events (racing + golf). No two-team head-to-head;
     # each row is one race or tournament. Low event volume (~1/week)
-    # means "surface if toggled" is the right product — no importance
+    # means "surface if toggled" is the right product: no importance
     # ranking needed.
     if settings.get("enable_f1", False):
         sources.append(F1Source())
@@ -722,7 +722,7 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_golf", False):
         sources.append(GolfSource())
 
-    # UFC. Same field-event shape — each fight card is one
+    # UFC. Same field-event shape: each fight card is one
     # row with home=card title ("UFC 309: Jones vs. Miocic"). PPVs
     # (numbered UFC events) get MAJOR tier, Fight Nights get EVENT.
     if settings.get("enable_ufc", False):
@@ -730,7 +730,7 @@ def _build_sources(settings: Dict[str, Any]):
 
     # Tennis. ESPN's tennis scoreboard returns whole
     # tournaments (one entry per active event), not individual
-    # matches — so tennis fits the FieldEventSource model. Grand
+    # matches: so tennis fits the FieldEventSource model. Grand
     # Slams + year-end Finals get MAJOR; regular tour stops get
     # EVENT.
     if settings.get("enable_atp", False):
@@ -738,7 +738,7 @@ def _build_sources(settings: Dict[str, Any]):
     if settings.get("enable_wta", False):
         sources.append(WtaSource())
 
-    # WNBA — ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
+    # WNBA: ESPN unofficial API; same pair-and-seed pattern as NHL/MLB/
     # NBA. Per-stage series lengths via BestOfNSeriesSource hooks: R1
     # best-of-3, SF best-of-5, FINALS best-of-5 in 2024 / best-of-7
     # in 2025+.
@@ -752,7 +752,7 @@ def _build_sources(settings: Dict[str, Any]):
             logger.warning("[wnba] could not seed playoff strengths: %s", exc)
         sources.append(wnba_po)
 
-    # NCAA Women's Basketball + March Madness — no API key required.
+    # NCAA Women's Basketball + March Madness: no API key required.
     # Single-game-elim bracket (SERIES_LENGTH=1 per stage). Pair-and-
     # seed strength sharing identical to NHL/MLB/NBA/WNBA.
     if settings.get("enable_ncaaw_basketball", False):
@@ -793,7 +793,7 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(ncbsb_br)
 
     # NCAA Division I softball. Same two-playoff-source fan-out as
-    # baseball above — NcaaSoftballPlayoffSource owns the best-of-3
+    # baseball above: NcaaSoftballPlayoffSource owns the best-of-3
     # stages (SB_SR + WCWS_F), NcaaSoftballPlayoffBracketSource owns
     # the Regional + 8-team WCWS bracket (SB_REG + WCWS).
     if settings.get("enable_ncaa_softball", False):
@@ -812,13 +812,13 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(ncsbl_br)
 
     # NCAA D1 men's + women's soccer. One source class
-    # parametrized on gender — same structure / endpoints / threshold
+    # parametrized on gender: same structure / endpoints / threshold
     # semantics for both, only the ESPN URL slug differs. Standings
     # points (3 W / 1 D / 0 L) drive the importance signal because
     # draws are common in college soccer.
     #
     # Issue #24: NcaaSoccerCupSource (College Cup bracket) pairs with
-    # the regular-season source like NHL/MLB/NBA/WNBA — playoff
+    # the regular-season source like NHL/MLB/NBA/WNBA: playoff
     # source borrows regular-season strength estimates via
     # `set_regular_season_strengths`. Without the seed, College Cup
     # samples fall back to the 1.5/1.5 league-average prior; with it,
@@ -871,7 +871,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     if not sources:
         return {"status": "error", "message": "No sport sources enabled."}
 
-    # 1. Fetch. Keep the (source, game) association — compute_match_importance
+    # 1. Fetch. Keep the (source, game) association: compute_match_importance
     # needs the source object per game to run the season-replay simulator. Plain
     # game rows lose the link to which adapter produced them, and reconstructing
     # it from extra["fd_competition_code"] only works for soccer.
@@ -906,7 +906,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     # appear after the prior one is removed by a later refresh. Group
     # by (sport_prefix, frozenset of teams) and keep the chronologically
     # earliest start_time in each group; the rest are dropped from this
-    # refresh. League sources are unaffected — same team-pair appearing
+    # refresh. League sources are unaffected: same team-pair appearing
     # twice in a 7-day window is rare and means a real fixture/replay.
     all_games, game_sources, deduped_count = _dedup_series_games(
         all_games, game_sources,
@@ -942,7 +942,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
         # build_impact_narratives (which writes the natural-language
         # "rooting against X" prose for the EPG description). The
         # importance signal pulls its standings from the simulator's
-        # initial_state, not this table — they're built from the same
+        # initial_state, not this table: they're built from the same
         # FD.org payload so they agree.
         standings_table = extra.get("standings_table") or []
         favs_with_standings: List[Dict[str, Any]] = []
@@ -1041,7 +1041,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     def _sort_key(item):
         # Favorites-first within today's bucket: even a lukewarm Tottenham
         # game should beat a 9.5-rated title-race contender for THIS user.
-        # The favorite-weight bump alone wasn't enough — Man City still
+        # The favorite-weight bump alone wasn't enough: Man City still
         # dominated the top-5 because their stakes+rank pile was bigger
         # than weight_favorite=6 could overcome. Adding favorite-match as
         # a hard sort key guarantees slots 1..N_favorites belong to the
@@ -1068,7 +1068,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
         scored = sorted(favs + keep_non_favs, key=_sort_key)
 
     # 4. EPG match each game to a Dispatcharr channel.
-    # _build_epg_lookup excludes ALL our virtual channels by tvg_id prefix —
+    # _build_epg_lookup excludes ALL our virtual channels by tvg_id prefix:
     # covers both the current target group and any orphans from a renamed group.
     epg_lookup = _build_epg_lookup()
     api_key = _resolve_key(settings, "anthropic_api_key", ANTHROPIC_KEY_PATH)
@@ -1135,7 +1135,7 @@ def _build_epg_lookup():
     """Return a callable: GameRow -> List[ChannelCandidate]. Closure over ORM.
 
     Excludes any channel that is one of OUR virtual channels (see
-    _owned_tvg_id_q) — covers the configured target group AND any old groups
+    _owned_tvg_id_q): covers the configured target group AND any old groups
     left over from a prior target_group_name. Without this, the matcher
     self-matches against our prior-run channels because their EPG titles
     literally contain the team names.
@@ -1143,7 +1143,7 @@ def _build_epg_lookup():
     Pre-filters at the DB level: only fetches programs that are TEAM-relevant
     (program title contains a team keyword OR program's channel has a team
     keyword in its name). Prime-time windows can carry 4000+ programs across
-    a Dispatcharr instance — fetching all of them and filtering in Python had
+    a Dispatcharr instance: fetching all of them and filtering in Python had
     a 2000-row hard cap that silently dropped real matches (regression
     against the old uncapped path was ch_id=111919 'EPL 07ⓧ: ... vs Brentford
     FC' getting omitted from the candidate list for the live game window).
@@ -1154,7 +1154,7 @@ def _build_epg_lookup():
     from django.db.models import Q
 
     def lookup(game) -> List[ChannelCandidate]:
-        # Per-sport match window — soccer needs a tighter window to avoid
+        # Per-sport match window: soccer needs a tighter window to avoid
         # false-matching pre-game preview shows earlier in the day; NCAAF
         # / NFL keep the wide default for long pre-game shows + OT. See #4.
         pre_min, post_hours = _epg_match_window(game.sport_prefix)
@@ -1177,7 +1177,7 @@ def _build_epg_lookup():
         )
 
         # Path B: channels whose NAME mentions any team keyword. Include
-        # them even without EPG entries in window — provider channels often
+        # them even without EPG entries in window: provider channels often
         # advertise the match in the channel NAME but have no program data
         # (e.g. 'AU (STAN 01) | Manchester United v Brentford ...'). Tier-1
         # strict still discriminates by 'both teams in channel name', so
@@ -1332,7 +1332,7 @@ def _build_signals_score_from_payload(g: Dict[str, Any]):
         closeness=g.get("closeness"),
         is_rivalry=rivalry_from_cache,
         tournament_stage=g.get("tournament_stage"),
-        # Cache files predating this signal default to 0.0 / [] — graceful
+        # Cache files predating this signal default to 0.0 / []: graceful
         # degradation: the importance block in score_game just contributes
         # nothing for that entry.
         importance_points=float(g.get("importance_points") or 0.0),
@@ -1419,7 +1419,7 @@ def _league_context_for(g: Dict[str, Any]):
 
 # A fixture's matchday is "catch-up" when it's at least this many rounds
 # behind the league's current matchday (= max playedGames across the table).
-# 1 isn't enough — normal weekly scheduling routinely puts midweek games at
+# 1 isn't enough: normal weekly scheduling routinely puts midweek games at
 # matchday N-1 vs weekend games at matchday N. 2 catches genuine
 # rescheduled-postponed fixtures (FA Cup, weather) without false-firing.
 _CATCHUP_MATCHDAY_GAP = 2
@@ -1452,7 +1452,7 @@ _ORDINAL_SUFFIXES = ("th", "st", "nd", "rd")
 def _ordinal(n: int) -> str:
     """1 → '1st', 2 → '2nd', 4 → '4th', 11 → '11th', 23 → '23rd'.
 
-    DO NOT use `min(n%10, 3)` to index the suffixes — that clamps 4..9 to
+    DO NOT use `min(n%10, 3)` to index the suffixes: that clamps 4..9 to
     "rd", yielding "4rd"/"5rd"/etc. The teen rule (11-13 are "th", not
     "st"/"nd"/"rd") handles n%100 in [11..13]; everything else uses the
     last digit, defaulting to "th" for 0 and 4..9.
@@ -1468,7 +1468,7 @@ def _ordinal(n: int) -> str:
 def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
     """One-line standings summary for league fixtures.
 
-    Format: "<home> <pos>, <pts> pts. <away> <pos>, <pts> pts — <gap>."
+    Format: "<home> <pos>, <pts> pts. <away> <pos>, <pts> pts: <gap>."
     where <gap> is computed for the away team relative to the home team.
 
     Returns None if there's no standings table (knockout / non-soccer), if
@@ -1476,7 +1476,7 @@ def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
     promoted teams), or if essential fields are missing.
 
     Surfaces the position+points data the soccer source already cached
-    under extra.standings_table — see #10.
+    under extra.standings_table: see #10.
     """
     extra = g.get("extra") or {}
     table = extra.get("standings_table") or []
@@ -1490,7 +1490,7 @@ def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
 
     # Exact-name lookup against the FD.org table. The home/away names in
     # the GameRow come from the SAME FD.org fixture payload as the table,
-    # so they match byte-for-byte — no fuzzy matching needed.
+    # so they match byte-for-byte: no fuzzy matching needed.
     by_name = {entry.get("name"): entry for entry in table if entry.get("name")}
     home_entry = by_name.get(home_name)
     away_entry = by_name.get(away_name)
@@ -1515,8 +1515,8 @@ def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
     if not away_str:
         return home_str + "."
 
-    # Both teams in the table — add a gap descriptor for the away team
-    # relative to the home team. Reads naturally: "...69 pts — 1 pt behind."
+    # Both teams in the table: add a gap descriptor for the away team
+    # relative to the home team. Reads naturally: "...69 pts: 1 pt behind."
     home_pts = int(home_entry["points"])
     away_pts = int(away_entry["points"])
     diff = away_pts - home_pts
@@ -1528,7 +1528,7 @@ def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
         unit = "pt" if n == 1 else "pts"
         gap = f"{n} {unit} behind"
     else:
-        # Tied on points — goal difference is the actual league
+        # Tied on points: goal difference is the actual league
         # tiebreaker, so surface it when both entries have GD cached
         # (older caches predating #10 won't have it; fall through to the
         # bare "level on points" framing in that case).
@@ -1545,7 +1545,7 @@ def _build_standings_posture_line(g: Dict[str, Any]) -> Optional[str]:
         else:
             gap = "level on points"
 
-    return f"{home_str}. {away_str} — {gap}."
+    return f"{home_str}. {away_str}: {gap}."
 
 
 def _build_description(
@@ -1557,9 +1557,9 @@ def _build_description(
 
     Layout (each block separated by a blank line):
       1. Placeholder note (only if EPG hasn't matched a source yet)
-      2. Headline: tagline + spread descriptor ("A title race — toss-up.")
+      2. Headline: tagline + spread descriptor ("A title race: toss-up.")
       3. Matchday + league boundary summary (where applicable)
-      4. Standings posture line (league fixtures only — see #10)
+      4. Standings posture line (league fixtures only: see #10)
       5. Favorite-impact narratives (rooting framing, both deltas)
       6. "Favorite is your team" line if the favorite is playing this game
       7. Source channel line (only if matched)
@@ -1567,7 +1567,7 @@ def _build_description(
     Deliberately dropped: kickoff time (already shown by EPG client time
     blocks), score breakdown (already in channel name as ★X.X), spread's
     raw line value (just say "toss-up"), late-season multiplier
-    annotation (uniform across all current league games — adds no signal).
+    annotation (uniform across all current league games: adds no signal).
     """
     extra = g.get("extra") or {}
     favorites_matched = g.get("favorites_matched") or []
@@ -1596,7 +1596,7 @@ def _build_description(
     if spread_desc:
         headline_parts.append(spread_desc)
     if headline_parts:
-        sections.append(" — ".join(headline_parts) + ".")
+        sections.append(": ".join(headline_parts) + ".")
 
     # 3. Matchday line + league boundary reminder. Both are league-based
     # ("why is this a race"). Matchday tells you where in the season we
@@ -1609,7 +1609,7 @@ def _build_description(
     matchday_line_parts: List[str] = []
     if matchday and matchdays_total:
         # "Catch-up matchday X of Y" when fixture is meaningfully behind
-        # the league's current pacing — see _is_catchup_matchday and #3.
+        # the league's current pacing: see _is_catchup_matchday and #3.
         # Without the label, an end-of-season "Matchday 40 of 46" reads as
         # if the team has 6 games left when really it's a postponement
         # being replayed late and they have 1.
@@ -1620,7 +1620,7 @@ def _build_description(
     if matchday_line_parts:
         sections.append(" ".join(matchday_line_parts))
 
-    # 4. Standings posture (league fixtures only — knockout cups have no
+    # 4. Standings posture (league fixtures only: knockout cups have no
     # standings table, so this renders None and is skipped). Comes BEFORE
     # the favorite-impact narratives so the reader gets the raw "where are
     # they in the table?" before the editorial "why should you care?"
@@ -1656,7 +1656,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
       1. Get-or-create a virtual Channel in 'Top Matchups' ChannelGroup,
          linked to the same streams as the source channel (so playback works).
       2. Get-or-create an EPGData entry on our 'Top Matchups' EPGSource
-         (source_type=xmltv, is_active=False — we write programs directly,
+         (source_type=xmltv, is_active=False: we write programs directly,
          and we mustn't be source_type=dummy or Dispatcharr's UI overlays
          joke-filler descriptions on top of ours).
          Then replace its ProgramData for the game's airtime with title=matchup
@@ -1681,7 +1681,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     dry_run = bool(settings.get("dry_run", True))
 
     # 1. Ensure target ChannelGroup. Also detect any old groups/sources we own
-    # (from a previous target_group_name) and clean them up — fixes the case
+    # (from a previous target_group_name) and clean them up: fixes the case
     # where the user renames "Top Matchups" → "!Top Matchups" between runs.
     target_group = ChannelGroup.objects.filter(name=group_name).first()
 
@@ -1715,14 +1715,14 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                     target_group.id, group_name)
 
     # Migrate any virtual channels in old groups INTO the target group, in
-    # place. DO NOT delete + recreate — Channel.id is the stable handle that
+    # place. DO NOT delete + recreate: Channel.id is the stable handle that
     # ChannelProfileMembership, IPTV-client playlist caches, and the user's
     # pinned-channel state all key off. A delete-then-create cycle silently
     # orphans every one of those: profile memberships are gone (Dispatcharr
     # auto-adds new channels to existing profiles ONLY at profile-creation
     # time, never on channel-creation), and IPTV clients that cached the old
     # tvg-id render an empty slot for the renamed channel until the user
-    # manually refreshes — exactly what bit us during the #1 live-verify.
+    # manually refreshes: exactly what bit us during the #1 live-verify.
     #
     # The .update() bypasses Django's post_save signal (mirroring the same
     # signal-bypass pattern at apps/channels/signals.py:60 / our epg_data
@@ -1835,7 +1835,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     # Optional Claude-rewritten EPG descriptions. Default off; when on, prose
     # replaces the deterministic `_build_description` output for non-placeholder
     # games. Failures fall back silently. cache.json (scores, breakdown,
-    # score_notes) is untouched — only ProgramData.description changes.
+    # score_notes) is untouched: only ProgramData.description changes.
     from . import llm_descriptions
     llm_enabled = bool(settings.get("llm_descriptions_enabled", False))
     llm_api_key = ""
@@ -1860,7 +1860,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     # team-name pair, download to /data/logos/ranked_matchups_<hash>.jpg, and
     # point Channel.logo at it. On any miss (no event indexed, network failure,
     # field-event source, dry_run) we fall through to the source channel's
-    # logo — preserving the v0 behavior for the long tail. Per-marker thumb
+    # logo: preserving the v0 behavior for the long tail. Per-marker thumb
     # URLs cached on disk to keep API hits to once per fixture per ~14 days.
     from . import logos as matchup_logos
     matchup_logos_enabled = bool(settings.get("enable_matchup_logos", True))
@@ -2071,7 +2071,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 if changed and not dry_run:
                     existing.save(update_fields=["name", "logo", "channel_number"])
                 if not dry_run:
-                    # Compare by ORDERED list, not set — when our sort key
+                    # Compare by ORDERED list, not set: when our sort key
                     # changes (e.g. probe-aware quality re-ranks an existing
                     # set of streams) we need to rewrite the ChannelStream
                     # rows to flip their order, even if the membership is
@@ -2126,14 +2126,14 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                     epg_data.name = new_name
                     epg_data.save(update_fields=["name"])
                 if vc.epg_data_id != epg_data.id:
-                    # DO NOT use vc.save(update_fields=["epg_data"]) —
+                    # DO NOT use vc.save(update_fields=["epg_data"]):
                     # apps/channels/signals.py post_save fires
                     # parse_programs_for_tvg_id which unconditionally deletes
                     # ProgramData for the tvg_id (apps/epg/tasks.py:1308) before
                     # attempting an EPG-source refetch. Our EPGSource has no
                     # URL/file (we write programs directly), so the refetch
                     # fails and the rows stay deleted until the next plugin
-                    # tick — wiping the EPG grid for 0–3 minutes per new
+                    # tick: wiping the EPG grid for 0–3 minutes per new
                     # channel attach. .update() bypasses the post_save signal,
                     # mirroring the pattern at apps/channels/signals.py:60.
                     Channel.objects.filter(pk=vc.pk).update(epg_data_id=epg_data.id)
@@ -2147,7 +2147,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 # "Home vs Away ᴸᶦᵛᵉ" during the window, "Past: Home vs Away"
                 # after the game ends until the next refresh. The matchup
                 # string deliberately drops the ★ score prefix the channel
-                # name carries — the EPG entry should read like a program,
+                # name carries: the EPG entry should read like a program,
                 # not a debug breadcrumb.
                 matchup = _format_matchup(g["home"], g["away"])
                 kickoff_local = g.get("kickoff_local", "")
@@ -2177,7 +2177,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                     description=description,
                     tvg_id=marker,
                 )
-                # Past slot — bridges game-end to the next scheduled refresh
+                # Past slot: bridges game-end to the next scheduled refresh
                 # so the channel doesn't go blank in the EPG between the
                 # final whistle and the apply that drops the channel. The
                 # past slot's end_time is computed against the scheduler
@@ -2223,7 +2223,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
 
     # Persist the LLM-description cache (prune entries whose marker is no
     # longer in this refresh; keep file bounded to live games). Save outside
-    # the atomic block — sidecar JSON file is independent of the DB.
+    # the atomic block: sidecar JSON file is independent of the DB.
     if llm_enabled and not dry_run:
         pruned = llm_descriptions.prune_cache(llm_cache, seen_markers)
         llm_descriptions.write_cache(LLM_DESCRIPTIONS_CACHE_PATH, pruned)
@@ -2232,7 +2232,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     # from /data/logos/. Both prune to the live marker set so disk usage
     # doesn't grow unbounded across many refresh cycles. Logo rows pointing
     # at deleted files are left for Dispatcharr's own cleanup_unused_logos
-    # endpoint — deleting them here would race with concurrent UI reads.
+    # endpoint: deleting them here would race with concurrent UI reads.
     stale_logo_files_swept = 0
     if matchup_logos_enabled and not dry_run and thumb_cache is not None:
         thumb_cache.prune(seen_markers)
@@ -2247,7 +2247,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             f"moved (same Channel.id) from {deleted_old_groups} old group(s), "
             f"{deleted_old_sources} old EPGSource(s) deleted."
         )
-    # `placeholders` is a *subset* of (created + updated) — placeholder games
+    # `placeholders` is a *subset* of (created + updated): placeholder games
     # go through the same upsert path as matched ones, so they're already
     # counted there. Report as "(placeholders=N included)" to avoid the
     # "10 created + 3 placeholders == 13?" misread.

--- a/rivalries.py
+++ b/rivalries.py
@@ -6,13 +6,13 @@ team-name pairs. At plugin import, the JSON is read once and indexed by sport;
 appears in either order in the list for that sport.
 
 Substring matching (in both directions per token) handles source-side name
-variations — Football-Data.org returns "Manchester City FC" but our list
+variations: Football-Data.org returns "Manchester City FC" but our list
 stores the bare "Manchester City"; ESPN returns "Boston Celtics" while we
 store the same. See #8.
 
 To extend: edit `rivalries.json`. The match runs once per refresh per game, so
 even a 10,000-entry list would barely register on the profile. No LLM-judged
-path here — that's a deferred follow-up if the static list proves too narrow.
+path here: that's a deferred follow-up if the static list proves too narrow.
 """
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ def _load_rivalries() -> Dict[str, List[Tuple[str, str]]]:
     """Load and normalize the rivalries map. Returns {sport_prefix: [(a, b), ...]}.
 
     Failure modes (file missing, JSON corrupt) log a warning and return an
-    empty map so the plugin still works — rivalries are an enhancement, not
+    empty map so the plugin still works: rivalries are an enhancement, not
     a hard dependency.
     """
     try:
@@ -76,8 +76,8 @@ def is_rivalry(home: str, away: str, sport_prefix: str) -> bool:
 
     Match is case-insensitive substring in both directions: the rivalry entry
     'Manchester City' matches 'Manchester City FC' (rivalry-string is a
-    substring of team-string). The reverse — entry 'Manchester City FC FC FC'
-    matching team 'Manchester City' — also matches, which is a feature for
+    substring of team-string). The reverse: entry 'Manchester City FC FC FC'
+    matching team 'Manchester City': also matches, which is a feature for
     occasional source-side abbreviations.
     """
     pairs = _RIVALRIES_BY_SPORT.get(sport_prefix)
@@ -85,7 +85,7 @@ def is_rivalry(home: str, away: str, sport_prefix: str) -> bool:
         return False
     h, a = _normalize(home), _normalize(away)
     for rival_a, rival_b in pairs:
-        # Order in the JSON pair is incidental — match against both orderings.
+        # Order in the JSON pair is incidental: match against both orderings.
         if _name_matches(h, rival_a) and _name_matches(a, rival_b):
             return True
         if _name_matches(h, rival_b) and _name_matches(a, rival_a):
@@ -98,7 +98,7 @@ def _name_matches(team_name: str, rivalry_name: str) -> bool:
 
     Both arguments must already be normalized via _normalize. We allow either
     direction so e.g. 'manchester city' (rivalry) matches 'manchester city fc'
-    (team) AND 'paris sg' (team) matches 'paris saint-germain' (rivalry — if
+    (team) AND 'paris sg' (team) matches 'paris saint-germain' (rivalry: if
     the file stored the longer form).
     """
     return rivalry_name in team_name or team_name in rivalry_name

--- a/scoring.py
+++ b/scoring.py
@@ -32,7 +32,7 @@ UNRANKED = 26
 
 # Sentinel value used in the `cutoff` slot of LEAGUE_CONTEXTS thresholds
 # for group-stage contexts (WC_GS, EC_GS). The cutoff is unused by
-# compute_match_importance for group_advance format — advancement is
+# compute_match_importance for group_advance format: advancement is
 # decided by top-N-per-group sort in GroupStageSoccerSource.terminal_
 # outcomes, not by a flat threshold comparator. The sentinel exists so
 # accidental code that DOES try to compare against this value raises a
@@ -57,7 +57,7 @@ class Weights:
     # bookmaker probabilities (for soccer; NCAAF / NCAAM still convert
     # spread to coinflip-ness via score_game's fallback). Default bumped
     # from 0.1 to 3.0 because the underlying range is now [0, 1] instead
-    # of [0, 7] — same per-game magnitude (~3 raw for a pick'em).
+    # of [0, 7]: same per-game magnitude (~3 raw for a pick'em).
     spread: float = 3.0
     favorite: float = 6.0
     rivalry: float = 2.0
@@ -65,7 +65,7 @@ class Weights:
     narrative: float = 0.0       # LLM narrative score (disabled by default)
     # Lahvička Monte Carlo importance. Per-game raw points are
     # sum_over_(team,outcome) of leverage × consequence_weight (leverage in
-    # [0,1] from Kendall tau-c, weight from LEAGUE_CONTEXTS thresholds —
+    # [0,1] from Kendall tau-c, weight from LEAGUE_CONTEXTS thresholds:
     # relegation=5, UCL=4, title=5, etc.). 3.0 calibrates such that a
     # typical high-leverage relegation six-pointer reads ~15 raw points
     # (0.5 leverage × 5 weight × 2 teams = 5, × 3.0 = 15).
@@ -85,7 +85,7 @@ class GameSignals:
     # devigged moneyline probabilities; NCAAF / NCAAM still populate
     # `spread`. score_game prefers closeness when present, falls back
     # to a normalized spread otherwise. DO NOT populate BOTH on the
-    # same signal — pick the right path per source. See sources/base.py.
+    # same signal: pick the right path per source. See sources/base.py.
     closeness: Optional[float] = None
 
     tournament_stage: Optional[str] = None  # 'FINAL', 'SEMI_FINALS', 'QUARTER_FINALS', etc.
@@ -155,7 +155,7 @@ class LeagueContext:
 # Knockout-round depth ordering. Higher = deeper. The bracket source's
 # `terminal_outcomes` uses this to assign every band a team has reached
 # (a finalist reached the final AND the semis AND the quarters etc.).
-# DO NOT use stage names not present here as knockout thresholds — the
+# DO NOT use stage names not present here as knockout thresholds: the
 # round-rank lookup would silently return -1 and no team would qualify.
 KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # UEFA cup soccer (UCL / UEL / UECL):
@@ -178,7 +178,7 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "CUP_WINNER":      4,  # Stanley Cup champion
     # MLB postseason: Wild Card best-of-3 (6 series across both leagues),
     # Division Series best-of-5 (4 series), LCS best-of-7 (2 series),
-    # World Series best-of-7. WC and LDS depths differ — a team that
+    # World Series best-of-7. WC and LDS depths differ: a team that
     # wins the WC reaches LDS, etc.
     "WC":              0,  # Wild Card Series (entry round)
     "LDS":             1,  # Division Series
@@ -186,14 +186,14 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "WS":              3,  # World Series
     "WS_WINNER":       4,  # World Series champion
     # NBA playoffs: 4 rounds, best-of-7 each. R1 depth 0 is shared with
-    # NHL above — terminal_outcomes reads per-league band cutoffs so
+    # NHL above: terminal_outcomes reads per-league band cutoffs so
     # there's no cross-contamination.
     "CSF":             1,  # Conference Semifinals (4 series)
     "CF":              2,  # Conference Finals (2 series)
     "FINALS":          3,  # NBA Finals (1 series) / WNBA Finals (1 series)
     "FINALS_WINNER":   4,  # NBA Champion
     # WNBA playoffs: 3 rounds, mixed series lengths. R1 (depth 0) and
-    # FINALS (depth 3) reuse labels already above — terminal_outcomes
+    # FINALS (depth 3) reuse labels already above: terminal_outcomes
     # reads per-league bands so no cross-contamination. SF needs its
     # own depth between R1 and FINALS.
     "SF":              1,  # WNBA Semifinals (between R1 and FINALS)
@@ -208,7 +208,7 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     "NCG":             5,  # National Championship Game
     "NCG_WINNER":      6,  # National Champion
     # NFL playoffs: 4 rounds, single-game elimination. The "WC" label
-    # above (depth 0) is shared with MLB Wild Card Series — both happen
+    # above (depth 0) is shared with MLB Wild Card Series: both happen
     # to be at depth 0 in their respective brackets, and
     # terminal_outcomes reads per-league bands.
     "DIV":             1,  # Divisional Playoffs
@@ -235,7 +235,7 @@ KNOCKOUT_ROUND_DEPTH: Dict[str, int] = {
     # MLS Cup playoffs (issue #30 part B). Mixed format: Wild Card
     # single-leg entry, R1 best-of-3, then single-leg CSF / CF / MLS Cup
     # Final. MLS-prefixed labels so depths don't collide with NHL "R1"
-    # at depth 0 or MLB "WC" at depth 0 — each league reads its own
+    # at depth 0 or MLB "WC" at depth 0: each league reads its own
     # bands, but within MLS the WC→R1→CSF advance must move up in
     # depth, requiring unique labels.
     "MLS_WC":          0,  # Wild Card play-in (8 vs 9 seed each conference)
@@ -363,7 +363,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
     # Primeira Liga (Portugal). 18 teams, 34 matchdays. Same
-    # slot semantics as Eredivisie — 2 direct UCL spots, 3rd UCL
+    # slot semantics as Eredivisie: 2 direct UCL spots, 3rd UCL
     # qualifying, 4-5 Europa, bottom 3 relegation.
     "PPL": LeagueContext(
         code="PPL", matchdays_total=34,
@@ -376,7 +376,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         boundary_summary="Top 3 → UCL · 4-5 → Europa · bottom 3 → relegation",
     ),
     # Brazilian Série A. 20 teams, 38 matchdays. Different
-    # slot semantics from Euro leagues — continental qualifications
+    # slot semantics from Euro leagues: continental qualifications
     # are for Copa Libertadores (top 6 in modern era) and Copa
     # Sudamericana (7-12). No UCL line. Bottom 4 relegated to Série B.
     "BSA": LeagueContext(
@@ -425,7 +425,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # sort in terminal_outcomes, not by a flat threshold). Each tuple's
     # label + consequence_weight are what compute_match_importance reads.
     # The `format="group_advance"` tag isn't pattern-matched anywhere
-    # yet — it's documentation that distinguishes this from "league" /
+    # yet: it's documentation that distinguishes this from "league" /
     # "knockout" / "win_count" / "points_count" formats so a future
     # refactor doesn't accidentally route a group-stage context into
     # one of the threshold-cascade code paths.
@@ -467,7 +467,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # NCAA Division I baseball regular season. Win-count
     # thresholds tuned against historical NCAA Tournament selection
-    # criteria — ~35 wins is the rough at-large cutoff, 45+ wins puts
+    # criteria: ~35 wins is the rough at-large cutoff, 45+ wins puts
     # a team in national-seed (top 16) contention. Seasons run Feb-June
     # with ~55 regular-season games + conference tournament; matchdays_total
     # is approximate because non-conference scheduling varies by team.
@@ -486,7 +486,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # NCAA Baseball postseason. The cleanly-labeled best-of-3 stages
     # (Super Regional, MCWS Finals) are modeled. Regional double-elim
     # and the 8-team MCWS bracket lack game-level ESPN metadata and
-    # require chronological inference — tracked in #43. Threshold
+    # require chronological inference: tracked in #43. Threshold
     # weights match the MLB_PO scale: each round-deeper reach roughly
     # doubles consequence. The "omaha_bound" band fires for Super
     # Regional winners (depth 2 reached via the _winner_advance_label
@@ -533,7 +533,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # Issue #24: NCAA Men's + Women's College Cup brackets. Six rounds
     # of single-game elimination (R64 → R32 → S16 → E8 → F4 → NCG)
-    # reusing the same stage labels as NCAA Women's March Madness —
+    # reusing the same stage labels as NCAA Women's March Madness:
     # the depth ordering in KNOCKOUT_ROUND_DEPTH already supports them
     # and the bracket-cascade behaves identically for any single-game
     # elim shape. Field-size asymmetry handled at the source level
@@ -543,7 +543,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # because postseason is when these channels get real broadcast
     # pickup. The NCG is the single highest-viewership D1 soccer game
     # by an order of magnitude; the cup_winner band concentrates that
-    # consequence. Entry round (R64) is NOT in the threshold list —
+    # consequence. Entry round (R64) is NOT in the threshold list:
     # making the tournament is the bar, advancing past R64 is what
     # counts. Same pattern as NCAA Women's Basketball March Madness
     # context which also omits R64 from its thresholds.
@@ -572,7 +572,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         boundary_summary="R1 → R2 → Sweet 16 → Elite 8 → College Cup Semis → Final → Champion (Women's)",
     ),
     # NCAA football and men's basketball. Format is
-    # "win_count" — threshold cutoffs are MINIMUM win counts rather than
+    # "win_count": threshold cutoffs are MINIMUM win counts rather than
     # position cutoffs (the SoccerSource interpretation). The points-
     # based source's `terminal_outcomes` assigns a label when a team's
     # win total >= cutoff. Bands chosen to differentiate marquee from
@@ -644,7 +644,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # MLB postseason. Series lengths vary (WC=3, LDS=5, LCS=7,
     # WS=7), so the leverage ramp into the World Series is sharper than
-    # NHL's Stanley Cup ramp — fewer total games means each single game
+    # NHL's Stanley Cup ramp: fewer total games means each single game
     # carries more series-decision weight. Weights tuned to put a Game 7
     # World Series at the top of the season's importance distribution
     # while keeping Wild Card games meaningful (otherwise a single-elim
@@ -663,7 +663,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # NBA regular season. 82-game season; play-in tournament
     # (since 2020) opens 9th and 10th seeds onto the bracket via a
     # mini-playoff, but the play-in is structurally between the
-    # regular season and the bracket — we treat it as separate from
+    # regular season and the bracket: we treat it as separate from
     # the 16-team bracket the playoff source models. Threshold field
     # is `wins` (LEAGUE_CONTEXTS["NBA"].format="win_count").
     # Modern NBA (post-2010): the play-in cutoff has hovered around
@@ -682,7 +682,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # NBA playoffs. 4 rounds (R1 / CSF / CF / FINALS),
     # best-of-7 each. Same structural shape as NHL Stanley Cup
-    # Playoffs — weights mirror NHL's ramp because the
+    # Playoffs: weights mirror NHL's ramp because the
     # consequence-weight calibration is consistent across pro
     # sports' bracket leverage.
     "NBA_PO": LeagueContext(
@@ -699,7 +699,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # make playoffs (since 2022's expansion). The playoff bubble has
     # historically settled around 19-21 wins; top seed pace is ~28-32
     # in the current era. Thresholds are tighter than NBA's because
-    # the season is shorter — equal "strength" of a 25-win WNBA team
+    # the season is shorter: equal "strength" of a 25-win WNBA team
     # ≈ 50-win NBA team relative to the league.
     "WNBA": LeagueContext(
         code="WNBA", matchdays_total=40, format="win_count",
@@ -742,7 +742,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # NCAA Women's March Madness. 6 rounds, single-game
     # elimination at each step. Weights ramp steeper than the pro
     # bracket leagues because single-game elim concentrates leverage
-    # — every game IS the series for the round.
+    #: every game IS the series for the round.
     "NCAAW_BBALL_PO": LeagueContext(
         code="NCAAW_BBALL_PO", matchdays_total=0, format="knockout",
         thresholds=[
@@ -757,7 +757,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # NCAA Division I Softball regular season. ~55-game season,
     # 64-team NCAA Tournament. Selection bands mirror BSB but tuned
-    # slightly tighter — softball's RPI bar tends to clear at lower
+    # slightly tighter: softball's RPI bar tends to clear at lower
     # win totals because the field is smaller / more concentrated.
     # WCWS bracket is double-elimination and not modeled in V1
     # (follow-up).
@@ -802,7 +802,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # NFL playoffs. 4 rounds, single-game elimination.
     # Weights ramp aggressively because single-elim concentrates
-    # leverage — a Wild Card upset eliminates a 12-win team in one
+    # leverage: a Wild Card upset eliminates a 12-win team in one
     # game. Same shape as March Madness above but 4 rounds
     # instead of 6 because the field is 14 teams (7 per conference)
     # not 64.
@@ -818,7 +818,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     ),
     # Issue #30 part A: MLS conference standings importance. Playoff
     # seeding is per-conference (top 9 from Eastern, top 9 from Western
-    # in the 14-9 modern format), not aggregate league points — so the
+    # in the 14-9 modern format), not aggregate league points: so the
     # threshold bands MUST be per-conference. Two separate sources
     # (MlsEastSource / MlsWestSource) route to MLS_EAST / MLS_WEST
     # respectively; cutoffs are the same on both because the historical
@@ -852,7 +852,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
         ],
         boundary_summary="30+ pts → bubble · 45+ → secured · 55+ → top-4 home field · 70+ → Shield contender (West)",
     ),
-    # Issue #30 part B: MLS Cup playoff bracket. Mixed format — Wild
+    # Issue #30 part B: MLS Cup playoff bracket. Mixed format: Wild
     # Card single-leg entry, R1 best-of-3, then single-leg CSF / CF /
     # MLS Cup Final. Weights ramp aggressively into the MLS Cup Final
     # because postseason concentrates broadcast leverage; the Cup
@@ -860,7 +860,7 @@ LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     # the US calendar. The Supporters' Shield band (regular-season
     # league-best record) is handled on the East/West regular-season
     # sources from issue #30 part A. MLS_WC is omitted from
-    # thresholds here — "made the tournament" is the bar, advancing
+    # thresholds here: "made the tournament" is the bar, advancing
     # past WC is what counts, mirroring the NCAAW Basketball March
     # Madness and NCAA College Cup pattern of omitting entry rounds.
     "MLS_PO": LeagueContext(
@@ -894,7 +894,7 @@ class GameScore:
 
 # Compression knee. Lower N = scores saturate faster; higher N = more
 # headroom. Set to 16.0 because sim runs across EPL+ELC 2025-26 showed
-# 70% of games ending up at score >= 9.5 with knee=8.0 — the 0-10 scale
+# 70% of games ending up at score >= 9.5 with knee=8.0: the 0-10 scale
 # became indistinguishable noise above 9. With knee=16.0, a typical good
 # game (raw=20-30) lands at 7.7-8.6 and the differentiation comes back.
 # See TUNING_REPORT.md finding #1 (score saturation) in
@@ -920,13 +920,13 @@ def _compress_to_10(raw: float) -> float:
 
 
 # Minimum batch size for adaptive normalization to engage. With fewer
-# samples than this the in-batch median is too noisy to scale against —
+# samples than this the in-batch median is too noisy to scale against:
 # fall through to absolute compression in that case.
 _ADAPTIVE_MIN_SAMPLES = 5
 
 # Target: median raw in the batch maps to ~5 stars. tanh(1/1.6) ≈ 0.55,
 # so 10 × tanh(median / (scale × 1.6)) where scale = median / 5 yields:
-#   tanh(5/1.6) ≈ 0.998 × 10 = 9.98 — too steep, the median outlier saturates.
+#   tanh(5/1.6) ≈ 0.998 × 10 = 9.98: too steep, the median outlier saturates.
 # Instead use scale = median itself and target factor 1.6 to land median at:
 #   10 × tanh(median / median / 1.6) = 10 × tanh(0.625) ≈ 10 × 0.555 = 5.55.
 # Below the median compresses to under 5; well above saturates near 10.
@@ -938,7 +938,7 @@ def adaptive_compress(raw_scores: List[float]) -> List[float]:
 
     Each raw score gets compressed to 0-10 using a scale derived from the
     batch's median raw score. Effect: top games in any given refresh feel
-    like top games regardless of where in the season they fall — early-
+    like top games regardless of where in the season they fall: early-
     season low-stakes weeks no longer compress to all-low; late-season
     saturation no longer flattens every game to ★10.
 
@@ -970,7 +970,7 @@ def adaptive_compress(raw_scores: List[float]) -> List[float]:
 
 # Spread (point-spread sports) fallback: scale where 0 = full
 # closeness, _SPREAD_BLOWOUT = zero closeness. Anchored to 14 because
-# the pre-B.3 formula maxed at spread=14 too — keeps NCAAF / NCAAM
+# the pre-B.3 formula maxed at spread=14 too: keeps NCAAF / NCAAM
 # magnitudes continuous through the B.3 weight bump.
 _SPREAD_BLOWOUT = 14.0
 
@@ -982,7 +982,7 @@ def _effective_closeness(closeness: Optional[float], spread: Optional[float]) ->
     Precedence: closeness (probability-based, B.3 soccer path) wins
     when populated. Spread (point-based, NCAAF / NCAAM path) is the
     fallback for sources that haven't migrated to moneylines. Returns
-    None when neither is available — score_game then skips the signal.
+    None when neither is available: score_game then skips the signal.
     """
     if closeness is not None:
         if closeness < 0:
@@ -997,7 +997,7 @@ def _effective_closeness(closeness: Optional[float], spread: Optional[float]) ->
 
 # Trailing tokens that mean "same team" (typically the team-type / club suffix).
 # When these follow a favorite name, we allow the match. Superset of the
-# matcher's GENERIC_TEAM_SECOND_WORDS — adds the dotted club-tag variants and
+# matcher's GENERIC_TEAM_SECOND_WORDS: adds the dotted club-tag variants and
 # a few extras that show up in compound club names ("Brighton & Hove Albion").
 TEAM_QUALIFIER_TOKENS = {
     *TEAM_SUFFIX_TOKENS, "f.c.", "a.f.c.",
@@ -1089,7 +1089,7 @@ def score_game(signals: GameSignals, weights: Weights) -> GameScore:
             # Field events (F1 GP, NASCAR race, golf tour weekly
             # events). These have no two-team head-to-head
             # structure so the rank / favorite / closeness signals
-            # don't apply — the tournament_stage band is what gets
+            # don't apply: the tournament_stage band is what gets
             # them into the guide at all. "MAJOR" is for golf's four
             # majors (Masters / PGA / US Open / British Open) and
             # marquee racing events the source flags as MAJOR.
@@ -1114,7 +1114,7 @@ def score_game(signals: GameSignals, weights: Weights) -> GameScore:
     # consequence inside compute_match_importance; multiply only by the
     # user's weight_importance tunable here. Gating BOTH the points AND
     # the weight keeps the breakdown clean when the user disables the
-    # signal via weight_importance=0 — no 0.0 stub entries.
+    # signal via weight_importance=0: no 0.0 stub entries.
     if signals.importance_points > 0 and weights.importance > 0:
         imp_pts = signals.importance_points * weights.importance
         breakdown["importance"] = round(imp_pts, 2)
@@ -1148,7 +1148,7 @@ def compute_match_importance(
     Queries cover:
       - The two teams playing the target match (home, away)
       - Every favorite in `favorites_in_league` who ISN'T already in the
-        match (cross-team importance — this match's result affects the
+        match (cross-team importance: this match's result affects the
         favorite's standings outcome, even though the favorite isn't
         playing).
 
@@ -1182,7 +1182,7 @@ def compute_match_importance(
                 continue
             teams_to_query.append(fav)
 
-    # (team, outcome_label) query list — len(teams) × N bands.
+    # (team, outcome_label) query list: len(teams) × N bands.
     queries: List[Tuple[str, str]] = []
     for team in teams_to_query:
         for _, label, _ in league_ctx.thresholds:
@@ -1232,7 +1232,7 @@ def compute_match_importance(
         contrib = leverage * weight
         raw += contrib
         # Format: "Tottenham FC relegation: 0.42 leverage × 5.0 = 2.10".
-        # Strip the team suffix for the note so the line stays readable —
+        # Strip the team suffix for the note so the line stays readable:
         # the underlying signal still uses the canonical name.
         notes.append(
             f"{strip_team_suffix(team)} {label}: "
@@ -1339,7 +1339,7 @@ def format_channel_name(
         EFL 4v6 ⭐ ★10.0 · Middlesbrough at Wrexham · playoff race
 
     The rank pair is normalized so the better (lower-number) rank always
-    appears first — "1v5" not "5v1" — for at-a-glance scanning.
+    appears first: "1v5" not "5v1": for at-a-glance scanning.
 
     Team-name suffixes (FC / AFC / CF / SC) are stripped: 'Manchester
     United FC' renders as 'Manchester United'.
@@ -1379,12 +1379,12 @@ def render_favorite_impact(
       <Favorite> fans: rooting against <Nearby> (<spots> and <pts> <dir>).
       [Optional outcome clause when the gap is interesting, ≤ 9 pts.]
 
-    Examples (the favorite isn't playing — these games are between OTHER
+    Examples (the favorite isn't playing: these games are between OTHER
     teams whose result moves the favorite's standings):
 
       Manchester City fans: rooting against Manchester United (1 spot and
         12 pts back).
-        # No outcome clause — 12 pts is too large for a single result.
+        # No outcome clause: 12 pts is too large for a single result.
 
       Manchester City fans: rooting against Manchester United (1 spot and
         3 pts back). A Manchester United win flips them past you.
@@ -1458,7 +1458,7 @@ def build_impact_narratives(
         fav_name = fav["name"]
         fav_lc = fav_name.lower()
         if fav_lc in home_lc or fav_lc in away_lc:
-            continue  # favorite is playing — skip impact narrative
+            continue  # favorite is playing: skip impact narrative
         fav_pos = fav.get("position")
         if fav_pos is None:
             continue

--- a/simulation.py
+++ b/simulation.py
@@ -1,7 +1,7 @@
 """Sport-agnostic Monte Carlo match importance per Lahvička (2012).
 
 For each (target_match, team, outcome) tuple, this module estimates the
-*importance* of the match — the strength of association between the match's
+*importance* of the match: the strength of association between the match's
 W/D/L result and whether `team` reaches `outcome` at season end.
 
 The algorithm, mirrored from the SOTA section of TUNING_REPORT.md:
@@ -71,7 +71,7 @@ def kendall_tau_c(table: Sequence[Sequence[int]]) -> float:
     don't contribute.
 
     Returns 0.0 if the table has fewer than 2 non-trivial rows/cols or zero
-    total observations (degenerate cases — caller already had no signal).
+    total observations (degenerate cases: caller already had no signal).
     """
     rows = len(table)
     if rows < 2:
@@ -132,7 +132,7 @@ def monte_carlo_importance(
     in or eliminated); higher means more association.
 
     Caller is responsible for matching `target_team` and `target_outcome` to
-    `source.outcome_labels` — passing an outcome the source doesn't track
+    `source.outcome_labels`: passing an outcome the source doesn't track
     returns 0 (the team will never be in that bucket; tau-c degenerates).
     """
     if not getattr(source, "supports_importance", False):
@@ -180,7 +180,7 @@ def monte_carlo_importance(
 
 def _same_match(a: "GameRow", b: "GameRow") -> bool:
     """Match-identity check for the simulator's "skip target on second pass"
-    deduplication. Compares the (home, away, start_time, fd_id) tuple — using
+    deduplication. Compares the (home, away, start_time, fd_id) tuple: using
     `is` would only catch reference identity, which breaks once
     `remaining_matches` materializes fresh GameRow instances every call.
     """
@@ -210,7 +210,7 @@ def monte_carlo_importance_batch(
     target match, sharing one set of N season simulations.
 
     A naive loop over `monte_carlo_importance(team, outcome)` re-runs N sims
-    per query. Batching reuses the simulated seasons — for K queries this
+    per query. Batching reuses the simulated seasons: for K queries this
     drops the cost from K*N to N seasons regardless of K. Critical for
     in-loop scoring where score_game needs importance per (home/away) team
     per outcome band (typically K=8 for EPL: 2 teams × 4 outcome bands).
@@ -237,7 +237,7 @@ def monte_carlo_importance_batch(
     for _ in range(n_sims):
         target_result = source.sample_result(base_state, target_match, strengths, rng)
         state = source.apply_result(base_state, target_match, target_result)
-        # Same drain-until-empty loop as monte_carlo_importance — see there
+        # Same drain-until-empty loop as monte_carlo_importance: see there
         # for the reasoning. Identical behavior for league sources;
         # essential for knockout sources where downstream bracket matches
         # only become eligible after their feeder ties resolve.
@@ -294,11 +294,11 @@ def monte_carlo_importance_batch_chain(
         for the query column; it's still a smell). Today the
         GroupStageSoccerSource emits `advance` / `eliminated` and the
         KnockoutSoccerSource emits `round_of_16` / `quarterfinal` /
-        `semifinal` / `final` / `winner` — disjoint by design.
+        `semifinal` / `final` / `winner`: disjoint by design.
       - `seed_fn` returns a state dict consumable by
         `downstream.remaining_matches` / `sample_result` / `apply_result`
         / `terminal_outcomes`. The downstream's own `initial_state` is
-        NOT called by the chain — the seed is the entry point.
+        NOT called by the chain: the seed is the entry point.
       - Strength estimation is shared (one call to
         `primary.estimate_strengths()` covers both phases). Today the
         SoccerSource subclasses both inherit identical

--- a/sources/base.py
+++ b/sources/base.py
@@ -5,7 +5,7 @@ ranks (if any) and returns GameRow records. The plugin then scores each row
 and matches it to a Dispatcharr channel via EPG.
 
 Sources optionally implement a Monte Carlo importance interface (Lahvička
-2012) — 7 methods plus a `supports_importance` flag. Sources that flip the
+2012): 7 methods plus a `supports_importance` flag. Sources that flip the
 flag MUST override all 7; the simulator (simulation.py) inspects the flag
 before calling and falls through gracefully when it's false.
 """
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 @dataclass
 class GameRow:
     """One upcoming game from one sport. Sport-agnostic."""
-    sport_prefix: str           # "CFB", "CBB", "EPL", "EFL", etc. — used in channel name
+    sport_prefix: str           # "CFB", "CBB", "EPL", "EFL", etc.: used in channel name
     sport_label: str            # Full label, e.g., "NCAA Football"
     home: str                   # team name
     away: str
@@ -35,9 +35,9 @@ class GameRow:
     # 1.0 = pick'em (both teams equally likely to win); 0.0 = blowout.
     # Soccer populates this from the h2h moneyline market (devigged
     # probabilities, then 2 * min(p_home, p_away)). NCAAF / NCAAM still
-    # populate `spread` instead — score_game normalizes either path into
+    # populate `spread` instead: score_game normalizes either path into
     # the same [0, 1] effective closeness, but ONE of these two fields
-    # is None on every GameRow. DO NOT set both — keeps the contract
+    # is None on every GameRow. DO NOT set both: keeps the contract
     # "closeness wins if present, fall back to spread otherwise" honest.
     closeness: Optional[float] = None
     is_rivalry: bool = False             # known rivalry
@@ -49,7 +49,7 @@ class MatchResult:
     """One sampled match outcome. Used by the Monte Carlo importance simulator.
 
     Integer goals/points; ties (draws) are encoded as home_goals == away_goals
-    (legal in soccer, vanishingly rare in NCAAF — sources that ban draws
+    (legal in soccer, vanishingly rare in NCAAF: sources that ban draws
     should never sample one). Sub-game state (penalty shootouts in cup
     knockouts, OT in CFB) is encoded in `extra` per source; the simulator
     core only reads the goal counts.
@@ -137,7 +137,7 @@ class SportSource(ABC):
         match: GameRow,
         result: MatchResult,
     ) -> Dict[str, Any]:
-        """Return a new state with `match`'s `result` applied. Pure — the
+        """Return a new state with `match`'s `result` applied. Pure: the
         simulator depends on apply_result NOT mutating the input so that one
         `initial_state()` can seed many sampled seasons."""
         raise NotImplementedError(f"{type(self).__name__} does not support importance simulation")

--- a/sources/bracket.py
+++ b/sources/bracket.py
@@ -218,7 +218,7 @@ class BracketSportSource(SportSource):
                 # Cross-check: when downstream resolved participants differ
                 # from the source-published draw, the simulated tie's key
                 # uses the simulated teams. tie_results may not yet have an
-                # entry for the simulated tie_key — _emit_remaining_games_for_tie
+                # entry for the simulated tie_key: _emit_remaining_games_for_tie
                 # is responsible for handling that gracefully (treat as fresh).
                 tie = tie_results.get(tk) or self._new_tie_record(tie_meta)
                 games = self._emit_remaining_games_for_tie(
@@ -426,10 +426,10 @@ class BracketSportSource(SportSource):
 
         Two cases where the published names diverge from the simulated
         ones:
-          1. UCL-style counterfactual — an upstream sim flipped a feeder,
+          1. UCL-style counterfactual: an upstream sim flipped a feeder,
              putting a different team into this tie than FD.org's draw
              published.
-          2. WC chain seed (#53) — the entry tie's participants come from
+          2. WC chain seed (#53): the entry tie's participants come from
              the group-stage chain rather than FD.org; downstream-round
              tie_metas carry placeholder names ("L32_W1" etc.) that have
              to be resolved at lookup time, not at synthesis time.
@@ -452,7 +452,7 @@ class BracketSportSource(SportSource):
 
 
 # =====================================================================
-# AggregateLegSource — two-leg knockout (UEFA cup soccer)
+# AggregateLegSource: two-leg knockout (UEFA cup soccer)
 # =====================================================================
 
 class AggregateLegSource(BracketSportSource):
@@ -480,7 +480,7 @@ class AggregateLegSource(BracketSportSource):
         # ties run 2 legs except the FINAL (1 leg). International tournaments
         # (WC, EURO) run 1 leg per round including non-finals. Single source
         # of truth: count the games FD.org publishes for the tie. DO NOT
-        # branch on `stage == KO_STAGES[-1]` — that misclassifies single-leg
+        # branch on `stage == KO_STAGES[-1]`: that misclassifies single-leg
         # non-finals (WC LAST_16, EURO QF, etc.) as incomplete forever and
         # the round_reached cascade never fires.
         games_in_tie = len(tie_meta.get("games") or [])
@@ -584,7 +584,7 @@ class AggregateLegSource(BracketSportSource):
 
 
 # =====================================================================
-# BestOfNSeriesSource — best-of-N playoff series (NHL / NBA / MLB)
+# BestOfNSeriesSource: best-of-N playoff series (NHL / NBA / MLB)
 # =====================================================================
 
 class BestOfNSeriesSource(BracketSportSource):
@@ -604,7 +604,7 @@ class BestOfNSeriesSource(BracketSportSource):
     Subclasses set `SERIES_LENGTH` (e.g., 7 for NHL/NBA, varies for MLB).
     Game emission walks games in matchday order: a series at 2-1 emits
     the game-4 record (if applied=false), then game-5 / game-6 / game-7
-    conditional on the series staying alive — but only games actually
+    conditional on the series staying alive: but only games actually
     listed in the tie_meta's games[] are emitted. Subclasses generate
     those records (with home/away pattern) in `_fetch_bracket_games`.
     """
@@ -679,7 +679,7 @@ class BestOfNSeriesSource(BracketSportSource):
     def _is_decisive_game(self, tie, game_index, games_in_tie) -> bool:
         # Every series game can be a clincher (OT triggers per game, not
         # per series). For series sports this is "is this game a regular
-        # match that could go to OT" — always True; the actual OT decision
+        # match that could go to OT": always True; the actual OT decision
         # lives in the subclass `sample_result`.
         del tie, game_index, games_in_tie
         return True
@@ -764,7 +764,7 @@ class BestOfNSeriesSource(BracketSportSource):
 
 
 # =====================================================================
-# DoubleEliminationSource — N-team double-elimination bracket
+# DoubleEliminationSource: N-team double-elimination bracket
 # =====================================================================
 
 class DoubleEliminationSource(BracketSportSource):
@@ -793,20 +793,20 @@ class DoubleEliminationSource(BracketSportSource):
         of teams through one shared loss-tracking state, rather than a
         pair through a shared series-wins state.
       - `_build_bracket` groups games by `_tie_grouping_key(game)` (a
-        subclass-provided string from the source headline — e.g.,
+        subclass-provided string from the source headline: e.g.,
         "Auburn Regional" or "MCWS_sub1"), not by team-pair set.
       - `apply_result` looks up the tie via the game's `grouping_key`
         (carried in the GameRow `extra`), with a defensive fallback to
         membership-superset search.
       - `_advance_round_reached` is called once per eliminated team, not
         once per tie. The base method's `(winner, loser)` signature is
-        idempotent under multiple calls with the same winner — each
+        idempotent under multiple calls with the same winner: each
         loser still caps at `stage_depth`, the winner is still set to
         `winner_depth` via `max()`.
       - Source-driven only: `_emit_remaining_games_for_tie` emits the
         source-published games (in chronological order) that haven't
         been applied yet. It does NOT synthesize speculative future
-        games from the double-elim game tree — that's a #43 follow-up
+        games from the double-elim game tree: that's a #43 follow-up
         once live source data is wired in.
 
     Subclass contract: implement `_fetch_bracket_games` (inherited) AND
@@ -889,7 +889,7 @@ class DoubleEliminationSource(BracketSportSource):
         # Every game in a double-elim CAN be a tie-ending game (the one
         # that puts the last 1-loss team at 2 losses), so always True.
         # The base class contract uses this for ET / extra-innings hooks
-        # in subclass sample_result — baseball / softball use no shootout
+        # in subclass sample_result: baseball / softball use no shootout
         # so it doesn't matter, but stay consistent with BestOfNSeries.
         del tie, game_index, games_in_tie
         return True
@@ -901,7 +901,7 @@ class DoubleEliminationSource(BracketSportSource):
         records carrying the full participant set. feeds_from wiring is
         intentionally empty for double-elim: each sub-bracket tie is an
         entry tie at its stage (this class doesn't connect Regional →
-        Super Regional structurally — that handoff lives in the
+        Super Regional structurally: that handoff lives in the
         regular-season-strength sharing already on the playoff sources).
         """
         by_stage: Dict[str, Dict[str, Dict[str, Any]]] = {

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -1,4 +1,4 @@
-"""Field-event source — racing and golf.
+"""Field-event source: racing and golf.
 
 Racing and golf don't fit the team-based GameRow model because they're
 field events: one race or tournament with 20+ competitors and a
@@ -14,7 +14,7 @@ Design:
     as MAJOR). The scoring layer's `tournament` signal handles the
     rest; both labels map to non-zero stage_score so field events
     always surface in the guide when toggled on.
-  - No importance simulation, no closeness, no rank — the rarity of
+  - No importance simulation, no closeness, no rank: the rarity of
     these events (~1/week) means just-show-it-up is the right product.
     The matcher fuzzy-matches the event name against EPG titles.
 
@@ -83,7 +83,7 @@ class FieldEventSource(SportSource):
         """Pull events scheduled in the next N days via the ESPN
         scoreboard range endpoint. Field-event sports have low enough
         volume that range queries (which silently cap at 25 for team
-        sports) work fine — ESPN returns the whole window unfiltered.
+        sports) work fine: ESPN returns the whole window unfiltered.
         """
         today = datetime.now(timezone.utc).date()
         end = today + timedelta(days=days_ahead)
@@ -153,7 +153,7 @@ def _http_get(url: str, timeout: float = 15.0) -> Optional[Any]:
 
 
 class F1Source(FieldEventSource):
-    """Formula 1 — ~24 Grands Prix per year. Each weekend covers
+    """Formula 1: ~24 Grands Prix per year. Each weekend covers
     practice + qualifying + race; ESPN's scoreboard usually returns
     one event per GP date with the race itself."""
 
@@ -167,7 +167,7 @@ class F1Source(FieldEventSource):
 
 
 class NascarSource(FieldEventSource):
-    """NASCAR Cup Series — ~36 races per year, including the Daytona
+    """NASCAR Cup Series: ~36 races per year, including the Daytona
     500 (season opener) and the Coca-Cola 600. Both are 'crown jewels'
     but currently every race is EVENT-tier (no MAJOR_REGEX set)."""
 
@@ -192,7 +192,7 @@ _GOLF_MAJOR_RE: Pattern[str] = re.compile(
 
 
 class GolfSource(FieldEventSource):
-    """PGA Tour — ~45 tournaments per year. Four majors get the
+    """PGA Tour: ~45 tournaments per year. Four majors get the
     MAJOR tier; everything else is EVENT-tier. The MAJOR_REGEX
     intentionally catches both "The Open" and "British Open"
     framings; ESPN has inconsistently used both."""
@@ -213,7 +213,7 @@ _UFC_PPV_RE: Pattern[str] = re.compile(r"^\s*UFC\s+\d+\b", re.IGNORECASE)
 
 
 class UfcSource(FieldEventSource):
-    """UFC — one EPG entry per fight night card. The card itself is
+    """UFC: one EPG entry per fight night card. The card itself is
     the broadcast unit; ESPN's `event.name` carries the headliner
     framing ("UFC 309: Jones vs. Miocic", "UFC Fight Night:
     Sandhagen vs. Figueiredo").
@@ -232,7 +232,7 @@ class UfcSource(FieldEventSource):
 
 # Tennis Grand Slams + marquee year-end events. ESPN's tennis
 # scoreboard returns whole tournaments (each entry spans 1-2 weeks),
-# not individual matches — so tennis fits the FieldEventSource model
+# not individual matches: so tennis fits the FieldEventSource model
 # the same way racing and golf do. The four Slams plus the year-end
 # Finals get the MAJOR tier; regular tour events stay EVENT.
 _TENNIS_MAJOR_RE: Pattern[str] = re.compile(
@@ -243,7 +243,7 @@ _TENNIS_MAJOR_RE: Pattern[str] = re.compile(
 
 
 class AtpSource(FieldEventSource):
-    """ATP Tour — men's professional tennis. One entry per active
+    """ATP Tour: men's professional tennis. One entry per active
     tournament. Grand Slams (Wimbledon / Australian Open / French
     Open / US Open) and ATP Finals get MAJOR; regular tour stops
     stay EVENT."""
@@ -256,7 +256,7 @@ class AtpSource(FieldEventSource):
 
 
 class WtaSource(FieldEventSource):
-    """WTA Tour — women's professional tennis. Same shape and same
+    """WTA Tour: women's professional tennis. Same shape and same
     Grand Slam roster as ATP (the Slams are shared events). MAJOR
     detection is identical."""
 

--- a/sources/liga_mx.py
+++ b/sources/liga_mx.py
@@ -1,4 +1,4 @@
-"""Liga MX source — ESPN unofficial + Odds API closeness.
+"""Liga MX source: ESPN unofficial + Odds API closeness.
 
 Same minimal pattern as MlsSource: schedule + closeness only. No
 standings-based importance or Liguilla playoff bracket (#30).
@@ -6,9 +6,9 @@ standings-based importance or Liguilla playoff bracket (#30).
 Liga MX runs two seasons per calendar year (Apertura ≈ Jul-Dec,
 Clausura ≈ Jan-May), each followed by a 12-team Liguilla playoff.
 Season slug values surface as `extra.season_slug`:
-  - "torneo-apertura"  — fall season
-  - "torneo-clausura"  — spring season
-  - "liguilla"         — playoff round (single-leg + two-leg ties)
+  - "torneo-apertura" : fall season
+  - "torneo-clausura" : spring season
+  - "liguilla"        : playoff round (single-leg + two-leg ties)
 
 Liga MX Odds API key: `soccer_mexico_ligamx`. ESPN slug: `soccer/mex.1`.
 Relevant for US viewers via Univision / Telemundo EPG entries.

--- a/sources/mlb.py
+++ b/sources/mlb.py
@@ -1,37 +1,37 @@
-"""MLB source — official `statsapi.mlb.com` for both regular-season schedule
+"""MLB source: official `statsapi.mlb.com` for both regular-season schedule
 and the postseason bracket. No API key required.
 
 Two source classes:
   - `MlbRegularSource(PointsBasedSportSource)`: regular season. Uses raw win
-    count (no OT/SO bonus like NHL — MLB extra-innings winners get a normal
+    count (no OT/SO bonus like NHL: MLB extra-innings winners get a normal
     +1 W); LEAGUE_CONTEXTS["MLB"] has format="win_count" with thresholds at
     85 (wildcard bubble) / 90 (division lead) / 95 (elite) / 100 (historic).
   - `MlbPlayoffSource(BestOfNSeriesSource)`: full postseason. Mixed series
     lengths per round (Wild Card best-of-3, Division Series best-of-5,
-    LCS / World Series best-of-7) — model leans on the BestOfNSeriesSource
+    LCS / World Series best-of-7): model leans on the BestOfNSeriesSource
     per-stage series-length hook (`_series_length_for_stage`).
 
 API quirks captured here:
   - `/api/v1/schedule?sportId=1&season=YYYY&gameType=R` returns the entire
     regular season in a single response (≈2430 games). No per-day or
-    per-team iteration needed — unlike ESPN unofficial endpoints where
+    per-team iteration needed: unlike ESPN unofficial endpoints where
     multi-day ranges silently cap at 25 events.
   - `/api/v1/schedule/postseason?season=YYYY` returns every postseason
     game with `seriesDescription` ("AL Wild Card Series", "NL Division
     Series", "World Series", etc.) and `seriesGameNumber` (1..N) per game.
     Future-round games are not emitted until participants are decided;
     e.g., during LCS week the World Series ties don't exist in the
-    response. That tracks issue #17's NHL CUP_FINAL story — filed as a
+    response. That tracks issue #17's NHL CUP_FINAL story: filed as a
     follow-up for MLB World Series leverage during LCS.
   - `gameType` values: R=regular, F=Wild Card, D=Division Series,
     L=League Championship Series, W=World Series. (Plus S=spring,
-    P=preseason, A=allstar, I=intersquad — all filtered out.)
+    P=preseason, A=allstar, I=intersquad: all filtered out.)
   - `status.abstractGameState` is "Final" for FINISHED, "Preview" or
     "Live" otherwise. We treat anything not Final as SCHEDULED for
     importance purposes.
   - Team names come from `teams.home.team.name` (e.g., "Cleveland
     Guardians"). The `team.abbreviation` field is empty in the schedule
-    endpoint — use full name as the canonical key.
+    endpoint: use full name as the canonical key.
 
 The plugin opts into MLB via the `enable_mlb` boolean in `plugin.json`.
 Off by default.
@@ -63,7 +63,7 @@ _DEFAULT_RUNS_AGAINST = 4.5
 
 
 # seriesDescription → KO_STAGES label. Both leagues feed into the same
-# stage entry (AL and NL Wild Card both go to "WC") — the bracket
+# stage entry (AL and NL Wild Card both go to "WC"): the bracket
 # inference in BracketSportSource groups by (stage, team-pair), so AL/NL
 # bracket halves stay independent because they involve different teams.
 _SERIES_DESC_TO_STAGE: Dict[str, str] = {
@@ -86,18 +86,18 @@ _MLB_SERIES_LENGTHS: Dict[str, int] = {
 
 # MLB World Series 2-3-2 home pattern: top seed (AL/NL winner with the
 # better regular-season record) hosts games 1, 2, 6, 7; the other side
-# hosts games 3, 4, 5. NHL uses 2-2-1-1-1 — different sport, different
+# hosts games 3, 4, 5. NHL uses 2-2-1-1-1: different sport, different
 # home rotation, same shape of pattern array (True = top-seed home).
 MLB_WS_HOME_PATTERN: Tuple[bool, ...] = (True, True, False, False, False, True, True)
 
 # Sentinel team names for the synthesized WS placeholder tie. Same
 # pattern as nhl.py's CUP_FINAL sentinels (#17). The mlb postseason
 # endpoint omits the WS series from its response until both LCS series
-# resolve — so during LCS week the WS cascade reads 0 leverage even on
+# resolve: so during LCS week the WS cascade reads 0 leverage even on
 # an LCS Game-7. The placeholder lets the importance simulator
 # propagate counterfactual LCS winners into WS → WS_WINNER. DO NOT
 # change these strings without also updating _build_bracket's
-# placeholder-detection branch — the names are the join key. See #27.
+# placeholder-detection branch: the names are the join key. See #27.
 _WS_TOP_SENTINEL = "LCS_AL_WINNER"
 _WS_BOT_SENTINEL = "LCS_NL_WINNER"
 
@@ -139,9 +139,9 @@ class MlbRegularSource(PointsBasedSportSource):
 
     Uses raw `wins` as the threshold field (LEAGUE_CONTEXTS["MLB"] is
     format="win_count"). Unlike NHL, MLB has no OT-loss consolation
-    point — a 10-inning loss is still just a loss. Extra innings start
+    point: a 10-inning loss is still just a loss. Extra innings start
     with a runner on second base since 2020, but for our importance
-    sample_result the tie-breaker is a simple coin-flip — the resulting
+    sample_result the tie-breaker is a simple coin-flip: the resulting
     +1 boost gets attributed as a normal regulation win/loss.
 
     Goal-sampling: Poisson(λ) per side with the standard
@@ -172,7 +172,7 @@ class MlbRegularSource(PointsBasedSportSource):
         """Pull the next-N-day regular-season schedule via the single
         `/schedule` endpoint with a startDate/endDate filter. MLB's
         schedule endpoint reliably honors date ranges (no silent cap
-        like ESPN's). Closeness signal is left None — there is no Odds
+        like ESPN's). Closeness signal is left None: there is no Odds
         API integration for MLB in V1; structural importance carries.
         """
         today = datetime.now(timezone.utc).date()
@@ -216,7 +216,7 @@ class MlbRegularSource(PointsBasedSportSource):
     def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
         """Fetch the entire regular-season schedule in one shot. MLB's
         schedule endpoint returns the full season (~2430 games) reliably
-        as a single response — no per-team iteration needed.
+        as a single response: no per-team iteration needed.
         """
         url = (
             f"{MLB_API_BASE}/schedule?sportId=1&gameType=R&season={self.season}"
@@ -276,7 +276,7 @@ class MlbPlayoffSource(BestOfNSeriesSource):
 
     Per-game sampling: Poisson runs per side; tied regulation gets a
     coin-flip +1 (extra innings, treated as a normal W/L for the
-    importance signal). Unlike NHL, there's no shootout — but the
+    importance signal). Unlike NHL, there's no shootout: but the
     distinction doesn't matter because MLB doesn't have a consolation
     point: `wins`-based count_field for the regular season, but
     BestOfNSeriesSource doesn't read either count field at all (series
@@ -479,7 +479,7 @@ class MlbPlayoffSource(BestOfNSeriesSource):
         # series have published games (= participants are known) but the
         # endpoint hasn't yet populated the World Series. statsapi.mlb.com
         # only emits the WS series after both LCS resolve, which leaves
-        # the ws_winner band reading 0 leverage during LCS week — exactly
+        # the ws_winner band reading 0 leverage during LCS week: exactly
         # when LCS-Game-7 leverage should be maxing out. Mirrors the NHL
         # CUP_FINAL fix in #17.
         lcs_pair_set: set = set()
@@ -503,7 +503,7 @@ class MlbPlayoffSource(BestOfNSeriesSource):
         like 778411).
 
         The sentinels are stable across refreshes within one importance
-        run — they're matched by _build_bracket below to wire feeds_from
+        run: they're matched by _build_bracket below to wire feeds_from
         to the two LCS series.
         """
         games: List[Dict[str, Any]] = []
@@ -533,7 +533,7 @@ class MlbPlayoffSource(BestOfNSeriesSource):
         WS placeholder tie (whose participants are sentinel names, which
         the participant-set inference in the base class can't match
         against the actual LCS participants). Same shape as
-        NhlPlayoffSource._build_bracket — see #17 and #27.
+        NhlPlayoffSource._build_bracket: see #17 and #27.
         """
         bracket = super()._build_bracket(games)
         lcs_ties = bracket.get("LCS", [])
@@ -552,7 +552,7 @@ class MlbPlayoffSource(BestOfNSeriesSource):
         # corresponding LCS series. Bracket order from _build_bracket is
         # deterministic per frozenset insertion order; we treat LCS[0] as
         # the "top" feeder and LCS[1] as the "bottom" feeder. Without
-        # league-affiliation data this assignment is arbitrary — what
+        # league-affiliation data this assignment is arbitrary: what
         # matters for importance computation is that BOTH sentinels are
         # cascaded into the WS_WINNER depth, not which league each one
         # came from.

--- a/sources/mls.py
+++ b/sources/mls.py
@@ -1,4 +1,4 @@
-"""MLS source — ESPN's unofficial `site.api.espn.com` for the schedule
+"""MLS source: ESPN's unofficial `site.api.espn.com` for the schedule
 + The Odds API for closeness. MLS games surface with `favorite +
 closeness` scoring only; standings-based importance is filed as #30.
 
@@ -10,7 +10,7 @@ Scope:
     The Odds API.
   - **No** `supports_importance` flag. MLS Cup playoff bracket is
     structurally awkward (best-of-3 first round, single-leg subsequent
-    rounds — neither BestOfNSeriesSource nor AggregateLegSource fits
+    rounds: neither BestOfNSeriesSource nor AggregateLegSource fits
     cleanly); conference-standings importance needs its own bands.
     Both are tracked in #30.
   - The Odds API sport key is `soccer_usa_mls`. The Odds API team
@@ -40,7 +40,7 @@ ODDS_BASE = "https://api.the-odds-api.com/v4"
 ODDS_SPORT_KEY = "soccer_usa_mls"
 
 # Reuse the canonical TEAM_SUFFIX_TOKENS from _util.py: ("afc","fc","cf","sc").
-# DO NOT add "united" here — it's a substantive body word for several MLS
+# DO NOT add "united" here: it's a substantive body word for several MLS
 # franchises (Atlanta United, D.C. United, Minnesota United, New York
 # Red Bulls' historical "Metrostars United" naming), and stripping it
 # collapses different teams together. Same constraint as the soccer.py
@@ -50,7 +50,7 @@ ODDS_SPORT_KEY = "soccer_usa_mls"
 def _http_get(url: str, timeout: float = 15.0, **params: Any) -> Optional[Any]:
     """HTTP GET wrapper that logs on non-2xx and returns parsed JSON or
     None on any failure. Used for both ESPN (returns dict) and Odds API
-    (returns list of dicts) calls — return type is union, caller does
+    (returns list of dicts) calls: return type is union, caller does
     its own shape check."""
     try:
         r = requests.get(url, timeout=timeout, params=params or None)
@@ -65,7 +65,7 @@ def _http_get(url: str, timeout: float = 15.0, **params: Any) -> Optional[Any]:
 
 def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
     """ESPN soccer returns `team.displayName` ("Atlanta United FC",
-    "LA Galaxy"). Use that as the canonical join key — it matches
+    "LA Galaxy"). Use that as the canonical join key: it matches
     most EPG provider titles. Fall back to nickname / abbreviation
     only if displayName is missing."""
     name = (team_obj.get("displayName") or "").strip()
@@ -95,7 +95,7 @@ def _h2h_to_closeness(
       divide by total_implied -> normalized P_home, P_away
       closeness = 2 * min(P_home, P_away)
 
-    A 3-way market (home / draw / away) excludes the draw — closeness
+    A 3-way market (home / draw / away) excludes the draw: closeness
     measures the "either of the two teams could win" intuition, which
     isn't affected by draw probability. Pre-game blowouts (80/15/5)
     -> closeness 0.10; pickem 45/10/45 -> closeness 0.90.
@@ -121,7 +121,7 @@ def _h2h_to_closeness(
             implied["home"] = 1.0 / price
         elif nrm == _normalize_for_fuzzy(away_lc) or _normalize_for_fuzzy(away_lc) in nrm:
             implied["away"] = 1.0 / price
-        # Skip "draw" — closeness uses only home + away.
+        # Skip "draw": closeness uses only home + away.
     if "home" not in implied or "away" not in implied:
         return None
     # Devig over home + away only (the draw probability would lower
@@ -141,7 +141,7 @@ class MlsSource(SportSource):
 
     Class attrs `_ESPN_SLUG`, `_ODDS_SPORT_KEY`, `_FD_CODE`,
     `_SPORT_PREFIX`, `_SPORT_LABEL` parameterize the league. NwslSource
-    and LigaMxSource subclass this and override these five attrs — the
+    and LigaMxSource subclass this and override these five attrs: the
     rest of the fetch/closeness machinery is shared.
     """
 

--- a/sources/mls_cup.py
+++ b/sources/mls_cup.py
@@ -1,4 +1,4 @@
-"""MLS Cup playoff bracket — issue #30 part B.
+"""MLS Cup playoff bracket: issue #30 part B.
 
 Mixed-format postseason that neither AggregateLegSource nor a uniform
 best-of-N source handles cleanly:
@@ -13,7 +13,7 @@ best-of-N source handles cleanly:
     higher seed
   - Champion (`MLS_CUP_WINNER`): synthetic depth, the cup winner
 
-Per-stage series-length routing via `_series_length_for_stage` —
+Per-stage series-length routing via `_series_length_for_stage`:
 inherited from PR #51 (Phase F's BestOfNSeriesSource extension that
 NCAA Baseball uses for the mixed Super Regional / MCWS Final bracket).
 The same hook handles MLS's mix of best-of-3 R1 and single-leg
@@ -36,7 +36,7 @@ playoff goal-scoring rates from `MlsEastSource` / `MlsWestSource`
 1.4/1.4 league-average prior.
 
 Best-of-3 matchday inference: ESPN doesn't tag MLS R1 events with a
-game number on the event object — the `competition.notes[0].headline`
+game number on the event object: the `competition.notes[0].headline`
 carries series state ("LA leads series 1-0") but not the specific
 game index. Matchday is inferred from chronological ordering within
 each (stage, frozenset(participants)) tuple in `_fetch_bracket_games`,
@@ -134,7 +134,7 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
 
 def _default_season_year() -> int:
     """MLS season is named by the calendar year. Pre-October reads as
-    the prior season's playoffs (which wrap in early December — January
+    the prior season's playoffs (which wrap in early December to January
     onward is offseason). Post-October reads as the current calendar
     year's playoffs in progress.
     """
@@ -151,7 +151,7 @@ class MlsCupSource(BestOfNSeriesSource):
 
     Wild Card is the entry stage in modern MLS playoffs (since the 2024
     14-9 format expanded the field). Teams with a R1 bye (top 7 seeds
-    of each conference) skip the WC tier — their `round_reached` enters
+    of each conference) skip the WC tier: their `round_reached` enters
     at MLS_R1 depth.
     """
 
@@ -220,7 +220,7 @@ class MlsCupSource(BestOfNSeriesSource):
             "pa_per_game": _DEFAULT_GOALS_AGAINST,
         }
 
-    # ---------- sample_result (force a winner — bracket games) ----------
+    # ---------- sample_result (force a winner: bracket games) ----------
 
     def sample_result(
         self,
@@ -229,7 +229,7 @@ class MlsCupSource(BestOfNSeriesSource):
         strengths: Dict[str, Dict[str, float]],
         rng: random.Random,
     ) -> MatchResult:
-        """Bracket games CANNOT end in draws — MLS postseason goes to
+        """Bracket games CANNOT end in draws: MLS postseason goes to
         OT then PKs if needed. Same shape as NcaaSoccerCupSource's
         sample_result and distinct from the regular-season
         MlsStandingsSourceBase sample_result which allows draws (1
@@ -244,7 +244,7 @@ class MlsCupSource(BestOfNSeriesSource):
         home_goals = _poisson(lam_home, rng)
         away_goals = _poisson(lam_away, rng)
         if home_goals == away_goals:
-            # PK shootouts are roughly coin-flips at the MLS level —
+            # PK shootouts are roughly coin-flips at the MLS level:
             # no additional bias beyond the Poisson means.
             if rng.random() < 0.5:
                 home_goals += 1
@@ -256,7 +256,7 @@ class MlsCupSource(BestOfNSeriesSource):
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
         """Emit upcoming playoff bracket games. Per-day sweep with the
-        same slug filter that `_fetch_bracket_games` uses — only events
+        same slug filter that `_fetch_bracket_games` uses: only events
         whose `season.slug` is in `SLUG_TO_STAGE` surface here, so
         regular-season games (filtered out earlier in `MlsEastSource` /
         `MlsWestSource`) don't reappear via this source.
@@ -304,19 +304,19 @@ class MlsCupSource(BestOfNSeriesSource):
         """Pull the playoff window (Oct 1 - Dec 15 of season_year) and
         emit one canonical record per bracket game. Matchday inference
         for best-of-3 series: walk dates ascending and count games per
-        (stage, frozenset(participants)) tuple — first chronological
+        (stage, frozenset(participants)) tuple: first chronological
         appearance is game 1, second is game 2, third is game 3.
         Single-leg stages always emit matchday=1.
 
         Single-game-elim stages (MLS_WC, MLS_CSF, MLS_CF, MLS_CUP) also
         need PK dedup. ESPN sometimes publishes two events when a game
         goes to PKs (one with the regulation tie, one with the PK
-        result) — see `_dedupe_pk_shootout_pairs` in
+        result): see `_dedupe_pk_shootout_pairs` in
         `ncaa_soccer_cup.py` for the same shape. We import that helper
         rather than re-implementing; the dedup criterion is sport-
         agnostic for single-game-elim brackets.
 
-        Best-of-3 stages are NOT deduped on (stage, participants) —
+        Best-of-3 stages are NOT deduped on (stage, participants):
         the same teams legitimately play 2-3 games in a series, so
         collapsing them would lose the matchday cascade. PK dedup is
         applied per-matchday inside the best-of-3 grouping.
@@ -342,7 +342,7 @@ class MlsCupSource(BestOfNSeriesSource):
             )
             if isinstance(data, dict):
                 for event in data.get("events") or []:
-                    # Pass matchday=None — the inference loop below
+                    # Pass matchday=None: the inference loop below
                     # assigns it per (stage, participants) tuple.
                     rec = self._extract_bracket_record(event, matchday=None)
                     if rec is None or rec["game_id"] is None:
@@ -399,7 +399,7 @@ class MlsCupSource(BestOfNSeriesSource):
         completed = bool(status_type.get("completed"))
         state = (status_type.get("state") or "").lower()
         # ESPN publishes phantom placeholder games for best-of-3
-        # series that clinch in 2 games — the unnecessary game-3
+        # series that clinch in 2 games: the unnecessary game-3
         # has state="post" + completed=False + score=0-0. Skip
         # these entirely; emitting them (even as SCHEDULED) would
         # inject a never-going-to-happen game into the simulator's
@@ -431,7 +431,7 @@ class MlsCupSource(BestOfNSeriesSource):
         return {
             "game_id": event.get("id"),
             "stage": stage,
-            "matchday": matchday,  # may be None — inference assigns later
+            "matchday": matchday,  # may be None: inference assigns later
             "home": home_team,
             "away": away_team,
             "home_goals": hg,
@@ -454,7 +454,7 @@ def _dedupe_pk_shootout_pairs(
     NOTE: this is duplicated from `sources/ncaa_soccer_cup.py` while
     issues #24 and #30 part B land as independent PRs. Once both
     merge, the helper will be extracted to a shared module and both
-    call sites updated — DO NOT diverge the two implementations in
+    call sites updated: DO NOT diverge the two implementations in
     the meantime. Tracked in #69.
 
     Preference order when multiple records collide on (stage,

--- a/sources/mls_standings.py
+++ b/sources/mls_standings.py
@@ -1,4 +1,4 @@
-"""MLS conference-standings importance source — closes the gap left by
+"""MLS conference-standings importance source: closes the gap left by
 the Phase J V1 MlsSource (which surfaced schedule + closeness only).
 
 Issue #30 (part A): MLS playoff seeding is per-conference (top 9 from
@@ -19,7 +19,7 @@ uses a single league-wide source). Cross-conference games:
     outcome cascade.
   - `fetch_upcoming` emits games where the HOME team is in this
     conference. Cross-conf away games surface via the home team's
-    source — they still get importance computed (against the home
+    source: they still get importance computed (against the home
     team's conference bands), they just don't double-emit.
 
 Note: this module does NOT touch the existing MlsSource (which remains
@@ -32,18 +32,18 @@ Closeness via The Odds API is preserved (the V1 MlsSource computed
 it and we don't regress that signal): each conference source pulls
 the league-wide odds feed and attaches devigged h2h closeness to the
 games it emits. Helpers `_h2h_to_closeness` and `ODDS_BASE` are
-imported from mls.py to keep the calibration line consistent — the
+imported from mls.py to keep the calibration line consistent: the
 two sources MUST produce the same closeness for any given matchup as
 the legacy MlsSource would have.
 
 ESPN endpoints used:
-  - `/apis/v2/sports/soccer/usa.1/standings` — conference rosters +
+  - `/apis/v2/sports/soccer/usa.1/standings`: conference rosters +
     current standings points (3 W / 1 D / 0 L). Fetched once per
     refresh; the team→conference map is cached on the source instance.
-  - `/apis/site/v2/sports/soccer/usa.1/scoreboard?dates=YYYYMMDD` —
+  - `/apis/site/v2/sports/soccer/usa.1/scoreboard?dates=YYYYMMDD`:
     per-day schedule sweep across the Feb-Nov regular season.
 
-Known limitation — ESPN MLS future-fixtures coverage. The day-by-day
+Known limitation: ESPN MLS future-fixtures coverage. The day-by-day
 scoreboard sweep finds the season's FINISHED games but very few
 SCHEDULED ones: ESPN's MLS scoreboard endpoint publishes only ~1-2
 weeks of future fixtures, while pro leagues like MLB / NCAA Baseball
@@ -113,7 +113,7 @@ def _http_get(url: str, timeout: float = 15.0, **params: Any) -> Optional[Any]:
         return None
 
 
-# `_team_canonical_name` is imported from mls.py — both modules need
+# `_team_canonical_name` is imported from mls.py: both modules need
 # the same ESPN displayName join key across /standings and /scoreboard
 # endpoints. DO NOT define a parallel canonicalizer here; divergence
 # between the two would break the cross-endpoint team lookup.
@@ -127,7 +127,7 @@ REGULAR_SEASON_SLUG = "regular-season"
 
 # ESPN exposes MLS conference rosters under /standings → children[].abbreviation
 # as either "East" or "West". DO NOT use `children[].name` ("Eastern
-# Conference" / "Western Conference") — match the short token to keep
+# Conference" / "Western Conference"): match the short token to keep
 # `MlsEastSource._conference` / `MlsWestSource._conference` concise.
 CONFERENCE_ABBREVIATIONS = ("East", "West")
 
@@ -135,7 +135,7 @@ CONFERENCE_ABBREVIATIONS = ("East", "West")
 def _fetch_conference_map() -> Dict[str, str]:
     """Pull the current MLS conference assignments from ESPN's /standings
     endpoint. Returns {team_displayName: "East" | "West"}. Empty dict
-    on any failure — the source falls back to emitting zero games for
+    on any failure: the source falls back to emitting zero games for
     that conference (no spurious importance signal).
 
     The conference roster changes year over year (expansion teams). The
@@ -163,7 +163,7 @@ def _fetch_conference_map() -> Dict[str, str]:
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert one ESPN MLS scoreboard event into the canonical
     PointsBasedSportSource game record. Soccer-specific: a tied score
-    in a finished regulation game IS a draw (1 point each) — DO NOT
+    in a finished regulation game IS a draw (1 point each): DO NOT
     coin-flip it into a win the way NCAAF / NCAAM do. Same shape as
     `ncaa_soccer._extract_game_record`.
 
@@ -226,9 +226,9 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 class MlsStandingsSourceBase(PointsBasedSportSource):
     """Shared logic for MlsEastSource / MlsWestSource. Subclasses set
     `_conference` ("East" | "West") and the matching
-    `league_context_code` ("MLS_EAST" | "MLS_WEST"). Everything else —
+    `league_context_code` ("MLS_EAST" | "MLS_WEST"). Everything else:
     the standings fetch, the per-day scoreboard sweep, the 3 / 1 / 0
-    `_record_result_into_state` override — is shared here.
+    `_record_result_into_state` override: is shared here.
     """
 
     _count_field = "standings_points"
@@ -249,7 +249,7 @@ class MlsStandingsSourceBase(PointsBasedSportSource):
         # MLS season is named by calendar year (the 2025 season runs Feb-Nov
         # 2025). Default to current calendar year; pre-February in early
         # winter reads as the prior season (MLS Cup wraps in early Dec, so
-        # January is firmly between seasons — default to prior year so
+        # January is firmly between seasons: default to prior year so
         # offseason refreshes still pick up the last-finished season's data).
         self.season_year = (
             season_year if season_year is not None
@@ -386,7 +386,7 @@ class MlsStandingsSourceBase(PointsBasedSportSource):
                     continue
                 # Skip non-regular-season games for V1. MLS Cup playoff
                 # bracket is filed under issue #30 part B; until it lands,
-                # postseason MLS games should not be emitted here — they
+                # postseason MLS games should not be emitted here: they
                 # would get importance computed against regular-season
                 # bands, inflating their score.
                 if rec.get("season_slug") != REGULAR_SEASON_SLUG:
@@ -418,7 +418,7 @@ class MlsStandingsSourceBase(PointsBasedSportSource):
 
     def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
         """Day-by-day sweep across Feb 1 - Nov 30 of `season_year`.
-        Filters to INTRA-CONFERENCE regular-season games only — the
+        Filters to INTRA-CONFERENCE regular-season games only: the
         simulator's `_teams` dict then never picks up out-of-conference
         teams (which would get the wrong threshold bands applied in
         terminal_outcomes).
@@ -467,11 +467,11 @@ class MlsStandingsSourceBase(PointsBasedSportSource):
             day += timedelta(days=1)
         return list(seen.values())
 
-    # ---------- sample_result (allows draws — soccer rules) ----------
+    # ---------- sample_result (allows draws: soccer rules) ----------
 
     def sample_result(self, state, match, strengths, rng):
         """Sample Poisson goals per side. Soccer regulation results
-        include draws — DO NOT coin-flip a tied score into a win the
+        include draws: DO NOT coin-flip a tied score into a win the
         way the base PointsBasedSportSource does for NCAAF / NCAAM /
         NHL. MLS regular-season games CAN end in regulation draws
         (MLS dropped the shootout tiebreaker in 2000). A draw banks 1
@@ -500,11 +500,11 @@ class MlsStandingsSourceBase(PointsBasedSportSource):
     ) -> None:
         """MLS standings scheme mirrors college soccer's 3 / 1 / 0:
         win = 3 standings points, draw = 1 each, loss = 0. Subclass
-        of `ncaa_soccer._record_result_into_state` structurally —
+        of `ncaa_soccer._record_result_into_state` structurally:
         same pattern, no shared inheritance because the rest of the
         ESPN endpoint shape differs.
         """
-        del result_extra  # not used — MLS regular-season ties bank 1 pt each
+        del result_extra  # not used: MLS regular-season ties bank 1 pt each
         h = teams[home]
         a = teams[away]
         h.setdefault("draws", 0)

--- a/sources/nba.py
+++ b/sources/nba.py
@@ -1,4 +1,4 @@
-"""NBA source — ESPN's unofficial `site.api.espn.com` API. No key required.
+"""NBA source: ESPN's unofficial `site.api.espn.com` API. No key required.
 
 stats.nba.com would be the official source for NBA data, but it's behind
 a WAF that blocks most homelab egress (including pocket-dev's). ESPN's
@@ -6,12 +6,12 @@ unofficial scoreboard endpoint is the practical fallback: same shape as
 NCAA Baseball / NCAA Soccer in this codebase, and stable enough for a
 TV-guide curator. If ESPN ever changes its endpoint, `fetch_upcoming`
 and the importance interfaces return [] and NBA silently drops out of
-the guide for that refresh — graceful-degrade is already the contract.
+the guide for that refresh: graceful-degrade is already the contract.
 
 Two source classes:
   - `NbaRegularSource(PointsBasedSportSource)`: 82-game regular season,
     raw win count as the threshold field (LEAGUE_CONTEXTS["NBA"] is
-    format="win_count"). No OT bonus point — NBA OT wins count as
+    format="win_count"). No OT bonus point: NBA OT wins count as
     normal wins. Thresholds at 40 (play-in bubble) / 50 (comfortable
     in) / 55 (top-3 seed pace) / 65 (historic).
   - `NbaPlayoffSource(BestOfNSeriesSource)`: best-of-7 each round, 4
@@ -163,11 +163,11 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     (cancellations, postponements with no competitors) AND for
     non-bracket exhibition games like the All-Star Tournament
     (which ESPN labels season.type==2 alongside real regular-season
-    games — see competition.type.abbreviation == "ALLSTAR").
+    games: see competition.type.abbreviation == "ALLSTAR").
 
     Returned `competition.type.abbreviation` values:
       - "STD"     -> regular-season game
-      - "FINAL"   -> playoff game (ESPN's confusing label — applies
+      - "FINAL"   -> playoff game (ESPN's confusing label: applies
                      to every playoff round, not just the Finals)
       - "ALLSTAR" -> All-Star Tournament (rejected here)
     """
@@ -217,7 +217,7 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         ap = None
 
     if status == "FINISHED" and (hp is None or ap is None):
-        # Status says FINISHED but a score is missing — demote so the
+        # Status says FINISHED but a score is missing: demote so the
         # simulator doesn't seed a phantom 0-0 result.
         status = "SCHEDULED"
         hp = None
@@ -355,7 +355,7 @@ class NbaRegularSource(PointsBasedSportSource):
                     if rec["id"] in seen:
                         continue
                     # The base PointsBasedSportSource doesn't read the
-                    # season_type or notes fields — strip them so the
+                    # season_type or notes fields: strip them so the
                     # downstream contract stays tight.
                     seen[rec["id"]] = {
                         k: v for k, v in rec.items()
@@ -378,7 +378,7 @@ class NbaPlayoffSource(BestOfNSeriesSource):
     conference series.
 
     Stage routing comes from parsing the `competition.notes[0].headline`
-    field on each ESPN scoreboard event — there's no structured stage
+    field on each ESPN scoreboard event: there's no structured stage
     field on the API.
     """
 
@@ -388,7 +388,7 @@ class NbaPlayoffSource(BestOfNSeriesSource):
 
     def __init__(self, season_end_year: Optional[int] = None) -> None:
         self.season_end_year = season_end_year or _default_season_end_year()
-        # Caches for the importance interface — same pattern as NhlPlayoffSource.
+        # Caches for the importance interface: same pattern as NhlPlayoffSource.
         self._initial_state_cache: Optional[Dict[str, Any]] = None
         self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
         self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
@@ -484,13 +484,13 @@ class NbaPlayoffSource(BestOfNSeriesSource):
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
         """Pull the entire postseason schedule and normalize each game
         to the bracket per-game record shape. Stage comes from parsing
-        the ESPN headline ("East 1st Round - Game 3", etc.) — that's
+        the ESPN headline ("East 1st Round - Game 3", etc.): that's
         the only place ESPN exposes round information.
 
         Iteration window: April 1 (early play-in) through July 1 (latest
         possible Game-7 NBA Finals tail) of the season-end calendar year.
         That's a small enough window (~90 days) that the per-day cost
-        is bounded — playoff days have at most 4 games (R1) and often
+        is bounded: playoff days have at most 4 games (R1) and often
         just 1 (Finals), so the dedupe map stays small.
         """
         if self._bracket_games_cache is not None:

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -1,9 +1,9 @@
-"""NCAA Baseball source — ESPN's unofficial `site.api.espn.com` API.
+"""NCAA Baseball source: ESPN's unofficial `site.api.espn.com` API.
 
 No API key required. ESPN's API is undocumented but stable enough for
 a homelab TV-guide curator. If it ever 404s, `fetch_upcoming` and
 `_fetch_full_season_games` return [] and the affected sport silently
-drops out of the guide for that refresh cycle — graceful-degrade is
+drops out of the guide for that refresh cycle: graceful-degrade is
 already the contract.
 
 Two source classes ship under the `enable_ncaa_baseball` toggle:
@@ -11,8 +11,8 @@ Two source classes ship under the `enable_ncaa_baseball` toggle:
     win-count importance. Tournament-bubble through national-seed bands
     (see LEAGUE_CONTEXTS["BSB"]).
   - `NcaaBaseballPlayoffSource(BestOfNSeriesSource)`: postseason.
-    Currently models the best-of-3 stages — Super Regional and MCWS
-    Championship Final — both of which carry clean ESPN game-number
+    Currently models the best-of-3 stages: Super Regional and MCWS
+    Championship Final: both of which carry clean ESPN game-number
     metadata. Regional (4-team double-elim per site) and the 8-team
     MCWS bracket in Omaha are tracked in #43: ESPN headlines on those
     stages carry no game-number or bracket-position metadata, requiring
@@ -106,7 +106,7 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
 
 def _is_postseason_event(event: Dict[str, Any]) -> bool:
     """ESPN tags NCAA Baseball / Softball postseason events with
-    `season.type` in the 3-6 range — each stage gets its own type
+    `season.type` in the 3-6 range: each stage gets its own type
     value (verified against live 2026 data):
       - 2: Regular season (NOT postseason).
       - 3: Regional round (4-team double-elim per site).
@@ -121,11 +121,11 @@ def _is_postseason_event(event: Dict[str, Any]) -> bool:
     MCWS bracket stages are headline-metadata-poor and tracked in #43.
 
     DO NOT use the `notes[].headline` "Championship" substring as a
-    postseason discriminator — D1 conference tournaments in May use
+    postseason discriminator: D1 conference tournaments in May use
     that same word and are NOT postseason. season.type is the
     authoritative tag from ESPN.
 
-    DO NOT narrow to `type == 3` only — that was the original (wrong)
+    DO NOT narrow to `type == 3` only: that was the original (wrong)
     assumption from the issue body and would mute Super Regional and
     Finals coverage entirely (those are types 4 and 6).
     """
@@ -175,7 +175,7 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     except (TypeError, ValueError):
         ap = None
 
-    # If "FINISHED" but scores are missing, demote to SCHEDULED — the
+    # If "FINISHED" but scores are missing, demote to SCHEDULED: the
     # importance simulator must not seed a 0-0 result.
     if status == "FINISHED" and (hp is None or ap is None):
         status = "SCHEDULED"
@@ -204,7 +204,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
     contention.
 
     Postseason games (season.type=3 in ESPN's tags) are filtered out
-    of both fetch_upcoming and _fetch_full_season_games — NcaaBaseball
+    of both fetch_upcoming and _fetch_full_season_games: NcaaBaseball
     PlayoffSource owns those. Otherwise the regular-season win count
     would inflate by postseason wins, breaking the threshold bands.
     """
@@ -292,7 +292,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
         endpoint. Dedupe by event id. Returns the canonical shape
         PointsBasedSportSource expects.
 
-        DO NOT use the `dates=YYYYMMDD-YYYYMMDD` range syntax — empirically
+        DO NOT use the `dates=YYYYMMDD-YYYYMMDD` range syntax: empirically
         ESPN's scoreboard endpoint silently caps range responses at 25
         events regardless of the `limit` parameter. Single-day queries
         (`dates=YYYYMMDD`) return ALL games for that day (~70-100 during
@@ -309,7 +309,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
         season_end = (season_end_first + timedelta(days=31)).replace(day=1) - timedelta(days=1)
         end = min(now + timedelta(days=7), season_end)
         if end < season_start:
-            # Off-season / pre-season — no games yet.
+            # Off-season / pre-season: no games yet.
             return []
         day = season_start
         while day <= end:
@@ -318,7 +318,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
                 for event in data.get("events") or []:
                     if _is_postseason_event(event):
                         # Postseason win/loss counts must NOT flow into
-                        # the regular-season Monte Carlo — would corrupt
+                        # the regular-season Monte Carlo: would corrupt
                         # the win-count threshold bands. See class
                         # docstring.
                         continue
@@ -362,7 +362,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
 
 
 # =====================================================================
-# NcaaBaseballPlayoffSource — best-of-3 stages (Super Regional + MCWS Final)
+# NcaaBaseballPlayoffSource: best-of-3 stages (Super Regional + MCWS Final)
 # =====================================================================
 
 
@@ -372,7 +372,7 @@ class NcaaBaseballRegularSource(PointsBasedSportSource):
 # if ESPN ever drops the " - Game " separator (or pluralizes "Final"
 # on baseball the way they do for "Finals" on softball) the parser
 # returns (None, None) and the events fall through to the favorite +
-# rank-pair signals only — same graceful-degrade contract as the
+# rank-pair signals only: same graceful-degrade contract as the
 # rest of the source.
 _SUPER_REGIONAL_MARKER = "Super Regional - Game "
 _FINALS_MARKER = "Championship Final - Game "
@@ -382,7 +382,7 @@ def _parse_baseball_playoff_headline(headline: str) -> Tuple[Optional[str], Opti
     """Map an ESPN postseason headline to (stage, game_index). Returns
     (None, None) for Regional games (no game number, no bracket position)
     and MCWS 8-team bracket games ("Men's College World Series - Double
-    Elimination Round" / "Elimination Game") — those stages are tracked
+    Elimination Round" / "Elimination Game"): those stages are tracked
     in #43.
 
     Patterns observed in 2025-2026 ESPN data:
@@ -449,7 +449,7 @@ class _BaseballPlayoffStrengthsMixin:
         lam_away = max(0.1, (a["pf_per_game"] + h["pa_per_game"]) / 2.0)
         home_runs = _poisson(lam_home, rng)
         away_runs = _poisson(lam_away, rng)
-        # NCAA postseason has no draws — coin-flip the +1 to break the tie.
+        # NCAA postseason has no draws: coin-flip the +1 to break the tie.
         if home_runs == away_runs:
             if rng.random() < 0.5:
                 home_runs += 1
@@ -475,7 +475,7 @@ class NcaaBaseballPlayoffSource(_BaseballPlayoffStrengthsMixin, BestOfNSeriesSou
     Strength sharing: pre-postseason, the plugin pulls regular-season
     strength estimates from NcaaBaseballRegularSource and seeds them
     via `set_regular_season_strengths`. Without this hook, postseason
-    sampling falls back to the 6-runs-per-team default — workable but
+    sampling falls back to the 6-runs-per-team default: workable but
     less informative than per-team Poisson rates from the 55-game
     regular season.
     """
@@ -526,7 +526,7 @@ class NcaaBaseballPlayoffSource(_BaseballPlayoffStrengthsMixin, BestOfNSeriesSou
         sweep as the regular-season source but with `_is_postseason_event`
         flipped (filter IN postseason). Headlines are then parsed via
         `_parse_baseball_playoff_headline`; only the modeled stages
-        (Super Regional + MCWS Finals) survive — Regional and 8-team
+        (Super Regional + MCWS Finals) survive: Regional and 8-team
         MCWS bracket games are silently dropped here AND from the
         regular-season source's sibling fetch. Those stages are tracked
         in #43.
@@ -582,7 +582,7 @@ class NcaaBaseballPlayoffSource(_BaseballPlayoffStrengthsMixin, BestOfNSeriesSou
         away_team = _team_canonical_name(away.get("team") or {})
         # TBD-vs-TBD games appear in ESPN's data before participants are
         # determined (e.g., Finals before the MCWS bracket resolves).
-        # Skip them — the bracket source can't track a placeholder team
+        # Skip them: the bracket source can't track a placeholder team
         # and the EPG client doesn't surface a "TBD" matchup usefully.
         if not home_team or not away_team:
             return None
@@ -707,12 +707,12 @@ class NcaaBaseballPlayoffSource(_BaseballPlayoffStrengthsMixin, BestOfNSeriesSou
 
 
 # =====================================================================
-# NcaaBaseballPlayoffBracketSource — Regional + 8-team MCWS double-elim
+# NcaaBaseballPlayoffBracketSource: Regional + 8-team MCWS double-elim
 # =====================================================================
 
 
 # Site name is everything between "NCAA Baseball Championship - " and
-# " Regional" — e.g., "Auburn Regional" from
+# " Regional": e.g., "Auburn Regional" from
 # "NCAA Baseball Championship - Auburn Regional - Game 1".
 _REGIONAL_SITE_REGEX = re.compile(
     r"NCAA Baseball Championship - (?P<site>[^-]+? Regional)\b"
@@ -743,10 +743,10 @@ _MCWS_BRACKET_MARKERS = (
 def _parse_baseball_bracket_headline(headline: str) -> Tuple[Optional[str], Optional[str]]:
     """Map an ESPN postseason headline to (stage, partial_grouping_key).
 
-    For Regional games, returns ("BSB_REG", "<site> Regional") — the
+    For Regional games, returns ("BSB_REG", "<site> Regional"): the
     grouping_key is the site label parsed from the headline.
 
-    For 8-team MCWS bracket games, returns ("MCWS", None) — the
+    For 8-team MCWS bracket games, returns ("MCWS", None): the
     sub-bracket assignment can't be determined from one headline alone;
     `_classify_mcws_sub_brackets` does the chronological grouping later
     in `_fetch_bracket_games` once all MCWS events are collected.
@@ -756,13 +756,13 @@ def _parse_baseball_bracket_headline(headline: str) -> Tuple[Optional[str], Opti
     non-postseason / unclassifiable.
 
     DO NOT collapse the Regional / MCWS branches into a single regex
-    — Regional headlines carry the site name in a structured position
+   : Regional headlines carry the site name in a structured position
     that we can extract; MCWS bracket headlines don't have any
     sub-bracket hint, so the partition is purely chronological.
     """
     if not headline:
         return None, None
-    # Best-of-3 stages are owned by the sibling playoff source — explicitly
+    # Best-of-3 stages are owned by the sibling playoff source: explicitly
     # skip them here so the bracket source doesn't try to claim them.
     if _SUPER_REGIONAL_MARKER in headline or _FINALS_MARKER in headline:
         return None, None
@@ -799,7 +799,7 @@ def _classify_mcws_sub_brackets(
 
     Returns a dict {team_name: "MCWS_sub1" | "MCWS_sub2"}.
 
-    DO NOT partition by UTC date — MCWS evening games in Omaha
+    DO NOT partition by UTC date: MCWS evening games in Omaha
     (CT) routinely cross UTC midnight (a 7:30 PM CT game is 12:30 AM
     UTC the next day), which would split a single MCWS broadcast day
     across two UTC dates and put opening-day pairings into different
@@ -888,11 +888,11 @@ class NcaaBaseballPlayoffBracketSource(_BaseballPlayoffStrengthsMixin, DoubleEli
       - MCWS: "MCWS_sub1" / "MCWS_sub2" assigned by the day-partition
         heuristic in `_classify_mcws_sub_brackets`.
 
-    The bracket source emits records for BSB_REG and MCWS only — the
+    The bracket source emits records for BSB_REG and MCWS only: the
     best-of-3 BSB_SR and MCWS_F headlines are explicitly skipped so the
     sibling source owns them without duplication.
 
-    Strength sharing: same hook as the sibling — the plugin seeds
+    Strength sharing: same hook as the sibling: the plugin seeds
     per-team strengths via `set_regular_season_strengths` from the
     regular-season source. Without seeding, the 6-runs-per-team
     Poisson default applies.
@@ -945,7 +945,7 @@ class NcaaBaseballPlayoffBracketSource(_BaseballPlayoffStrengthsMixin, DoubleEli
         today = datetime.now(timezone.utc).date()
         out: List[GameRow] = []
         seen_ids: set = set()
-        # First sweep — collect ALL upcoming bracket events so MCWS
+        # First sweep: collect ALL upcoming bracket events so MCWS
         # sub-bracket grouping can use the full chronological context.
         raw_events: List[Tuple[Dict[str, Any], str, Optional[str]]] = []
         for offset in range(days_ahead + 1):

--- a/sources/ncaa_soccer.py
+++ b/sources/ncaa_soccer.py
@@ -1,7 +1,7 @@
-"""NCAA Soccer source — ESPN's unofficial API.
+"""NCAA Soccer source: ESPN's unofficial API.
 
 One source class, parametrized on `gender` ("m" or "w"). The same
-structure / endpoints / threshold semantics apply to both — only the
+structure / endpoints / threshold semantics apply to both: only the
 URL slug (`usa.ncaa.m.1` vs `usa.ncaa.w.1`) and the LEAGUE_CONTEXTS
 code (`NCAA_MSOC` vs `NCAA_WSOC`) differ. Both seasons run roughly
 August - early December, with the College Cup (NCAA Tournament) in
@@ -11,11 +11,11 @@ Key difference from NCAA Baseball: SOCCER HAS DRAWS. The standings-
 points scheme is 3 / 1 / 0 (win / draw / loss). `_count_field` is
 "standings_points" so the LEAGUE_CONTEXTS bands threshold against
 that field instead of raw wins. A team going 13-3-8 (Saint Louis
-men's, 2025) has only 13 wins but 47 standings points — without the
+men's, 2025) has only 13 wins but 47 standings points: without the
 draws credit the win-count thresholds would misclassify them as
 bubble when they're a national seed contender.
 
-College Cup postseason bracket is NOT modeled — same shape as the
+College Cup postseason bracket is NOT modeled: same shape as the
 WC / EURO knockout (single-leg elimination), so the existing
 KnockoutSoccerSource machinery can absorb it when wired up.
 fetch_upcoming still surfaces postseason games via rank + favorite
@@ -178,7 +178,7 @@ class NcaaSoccerSource(PointsBasedSportSource):
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
         """Per-day scoreboard sweep (ESPN's date-range syntax silently
-        caps at 25 events — see ncaa_baseball.py)."""
+        caps at 25 events: see ncaa_baseball.py)."""
         rankings = self._fetch_rankings()
         today = datetime.now(timezone.utc).date()
         out: List[GameRow] = []
@@ -270,11 +270,11 @@ class NcaaSoccerSource(PointsBasedSportSource):
                 ranks[name] = rank
         return ranks
 
-    # ---------- sample_result (allows ties — draws are legitimate) ----------
+    # ---------- sample_result (allows ties: draws are legitimate) ----------
 
     def sample_result(self, state, match, strengths, rng):
         """Sample Poisson goals per side. Soccer regulation outcomes
-        include draws — DO NOT coin-flip a tied score into a win.
+        include draws: DO NOT coin-flip a tied score into a win.
         The base PointsBasedSportSource.sample_result forces a non-tie
         outcome for NCAAF / NCAAM / NHL where regulation ties resolve
         into overtime; for college soccer the regulation tie IS the
@@ -282,7 +282,7 @@ class NcaaSoccerSource(PointsBasedSportSource):
         into_state).
 
         NCAA regular-season soccer DOES play one 10-minute overtime if
-        regulation ends tied, but it's GOLDEN GOAL — meaning a regulation
+        regulation ends tied, but it's GOLDEN GOAL: meaning a regulation
         tie that survives OT is still a draw in the standings. We model
         that by just sampling regulation; the small chance of OT-broken
         ties is folded into the Poisson noise.
@@ -314,7 +314,7 @@ class NcaaSoccerSource(PointsBasedSportSource):
         standings_points credit and a 'draws' counter (used by the
         threshold cascade and the cache.json display).
         """
-        del result_extra  # not used — soccer ties are part of regulation
+        del result_extra  # not used: soccer ties are part of regulation
         h = teams[home]
         a = teams[away]
         h.setdefault("draws", 0)
@@ -336,7 +336,7 @@ class NcaaSoccerSource(PointsBasedSportSource):
             h["losses"] += 1
             a["standings_points"] += 3
         else:
-            # Draw — 1 standings point each, no W/L update.
+            # Draw: 1 standings point each, no W/L update.
             h["draws"] += 1
             a["draws"] += 1
             h["standings_points"] += 1

--- a/sources/ncaa_soccer_cup.py
+++ b/sources/ncaa_soccer_cup.py
@@ -1,10 +1,10 @@
-"""NCAA College Cup source — single-game-elim bracket via ESPN.
+"""NCAA College Cup source: single-game-elim bracket via ESPN.
 
 Issue #24: NCAA Men's + Women's D1 Soccer Tournament. Both genders use
 the same structural shape (single-leg elimination across multiple
 rounds); only ESPN's URL slug, the LEAGUE_CONTEXTS code, and the
 gender-specific round labels differ. One source class parametrized on
-gender, mirroring NcaaSoccerSource (regular season) — same pattern.
+gender, mirroring NcaaSoccerSource (regular season): same pattern.
 
 Bracket shape (6 rounds, both genders):
 
@@ -24,20 +24,20 @@ cup---semifinal" / "college-cup---championship"; W's uses "semifinals" /
 "college-cup"). Both map to the same canonical R64/R32/S16/E8/F4/NCG
 stage labels, which match `KNOCKOUT_ROUND_DEPTH` entries already in use
 by NCAA Women's Basketball March Madness (also a 6-round single-game
-elim bracket — the depth dict is shared and the cascade is identical).
+elim bracket: the depth dict is shared and the cascade is identical).
 
 Field size note: Men's NCAA Soccer Tournament uses a 48-team field with
 16 byes (top 16 seeds play their first match in the second round), so
 "first-round" has only 16 games (32 of 48 teams), then "second-round"
 has 16 games (32 teams: 16 byes + 16 R1 winners). Treating the entry
-round as R64 is correct conceptually — the cascade only cares about
+round as R64 is correct conceptually: the cascade only cares about
 depth ordering, and a team that played and lost R1 has reached the
 "R64" entry tier even though the tier isn't full. Women's bracket is
 a full 64-team field with no byes.
 
 Strength sharing: `set_regular_season_strengths` lets the plugin seed
 playoff sampling with per-team Poisson rates from the regular-season
-NcaaSoccerSource — the College Cup samples then reflect actual scoring
+NcaaSoccerSource: the College Cup samples then reflect actual scoring
 skill from the 20-game regular season instead of the 1.5/1.5 league-
 average prior. Without the seed the source falls back to the prior.
 
@@ -83,17 +83,17 @@ _DEFAULT_GOALS_AGAINST = 1.5
 # Stage labels are reused from NCAAW Basketball (R64/R32/S16/E8/F4/NCG)
 # because the depth ordering in KNOCKOUT_ROUND_DEPTH already supports
 # them and the cascade behaves identically for single-game elim brackets.
-# Gender-specific keys for the last two rounds — both M's and W's map
+# Gender-specific keys for the last two rounds: both M's and W's map
 # to the same canonical labels via slug aliases.
 SLUG_TO_STAGE: Dict[str, str] = {
     "first-round":                  "R64",
     "second-round":                 "R32",
     "third-round":                  "S16",
     "quarterfinals":                "E8",
-    # College Cup Semifinals — gender split:
+    # College Cup Semifinals: gender split:
     "college-cup---semifinal":      "F4",  # M's slug
     "semifinals":                   "F4",  # W's slug
-    # National Championship Game — gender split:
+    # National Championship Game: gender split:
     "college-cup---championship":   "NCG", # M's slug
     "college-cup":                  "NCG", # W's slug (the final, not the full event)
 }
@@ -162,7 +162,7 @@ def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     finished = [r for r in bucket if r.get("status") == "FINISHED"]
     if not finished:
-        # All scheduled — keep the latest by start_time (most recent
+        # All scheduled: keep the latest by start_time (most recent
         # info is the canonical one).
         return max(bucket, key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc))
     non_tie = [
@@ -176,7 +176,7 @@ def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
-    """Prefer `team.location` (school) over `team.name` (mascot) — the
+    """Prefer `team.location` (school) over `team.name` (mascot): the
     EPG side of the matcher uses school names like "Washington at
     Stanford" rather than mascots like "Huskies at Cardinal". Same
     canonicalizer as NcaaSoccerSource so the cross-source team-name
@@ -192,12 +192,12 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
     """NCAA D1 soccer College Cup bracket, parametrized on gender.
 
     Six single-game elim rounds (R64 → R32 → S16 → E8 → F4 → NCG).
-    SERIES_LENGTH = 1 so each "series" clinches at ceil(1/2) = 1 win —
+    SERIES_LENGTH = 1 so each "series" clinches at ceil(1/2) = 1 win:
     the BestOfNSeriesSource state machine handles round_reached and
     terminal_outcomes for free at this length.
 
     Field-size asymmetry: M's has 48 teams (16 byes at entry), W's has
-    64 teams (no byes). The bracket source doesn't care — both genders
+    64 teams (no byes). The bracket source doesn't care: both genders
     surface the same 6 stage labels via slug aliases in `SLUG_TO_STAGE`.
     """
 
@@ -251,7 +251,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
 
     def _winner_advance_label(self, stage: str) -> Optional[str]:
         # Champion is the synthetic depth above NCG (final game). Mirror
-        # the NCAAW Basketball NCG → NCG_WINNER mapping — same depth
+        # the NCAAW Basketball NCG → NCG_WINNER mapping: same depth
         # entry in KNOCKOUT_ROUND_DEPTH (already at depth 6).
         if stage == "NCG":
             return "NCG_WINNER"
@@ -272,7 +272,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
     ) -> None:
         """Hook for the plugin to share regular-season strength
         estimates with the College Cup source. Without this, every
-        bracket team gets the league-average 1.5/1.5 prior — accurate
+        bracket team gets the league-average 1.5/1.5 prior: accurate
         enough for early-round importance but loses the team-skill
         signal that a 20-game regular season provides."""
         self._team_strengths_from_regular = strengths
@@ -287,7 +287,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
             "pa_per_game": _DEFAULT_GOALS_AGAINST,
         }
 
-    # ---------- sample_result (force a winner — bracket games) ----------
+    # ---------- sample_result (force a winner: bracket games) ----------
 
     def sample_result(
         self,
@@ -296,12 +296,12 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
         strengths: Dict[str, Dict[str, float]],
         rng: random.Random,
     ) -> MatchResult:
-        """Bracket games CANNOT end in a draw — NCAA postseason soccer
+        """Bracket games CANNOT end in a draw: NCAA postseason soccer
         goes to OT then PKs if needed. Sample Poisson goals; on a tied
         regulation result, coin-flip the +1 boost so the bracket
         cascade gets a clean winner. Distinct from NcaaSoccerSource
         regular-season sample_result which allows draws (1 standings
-        point each) — bracket scenarios have no draw outcome at all.
+        point each): bracket scenarios have no draw outcome at all.
         """
         del state  # interface-required, per-game classification only
         h = self._strength_for(strengths, match.home)
@@ -312,7 +312,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
         away_goals = _poisson(lam_away, rng)
         if home_goals == away_goals:
             # OT / PKs in real life; coin-flip the +1 here. Strength
-            # asymmetry already biased the Poisson means — no further
+            # asymmetry already biased the Poisson means: no further
             # bias added (PK shootouts are roughly coin-flips empirically
             # at the NCAA level).
             if rng.random() < 0.5:
@@ -324,7 +324,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
     # ---------- fetch_upcoming (EPG display side) ----------
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
-        """Emit upcoming tournament games (any stage). Per-day sweep —
+        """Emit upcoming tournament games (any stage). Per-day sweep:
         ESPN's date-range syntax silently caps at 25 events, same trap
         as ncaa_baseball.py / ncaa_soccer.py. Postseason games carry
         a `season.slug` of one of the SLUG_TO_STAGE keys; non-tournament
@@ -373,7 +373,7 @@ class NcaaSoccerCupSource(BestOfNSeriesSource):
     def _fetch_bracket_games(self) -> List[Dict[str, Any]]:
         """Pull the November-December tournament window and emit one
         canonical record per bracket game. Filters out non-tournament
-        events via SLUG_TO_STAGE membership — regular-season games
+        events via SLUG_TO_STAGE membership: regular-season games
         won't carry a slug like 'quarterfinals', so they fall out
         naturally.
 

--- a/sources/ncaa_softball.py
+++ b/sources/ncaa_softball.py
@@ -1,12 +1,12 @@
-"""NCAA Softball source — ESPN's unofficial site.api.espn.com.
+"""NCAA Softball source: ESPN's unofficial site.api.espn.com.
 No API key required.
 
 Two source classes ship under the `enable_ncaa_softball` toggle:
   - `NcaaSoftballRegularSource(PointsBasedSportSource)`: regular-season
     win-count importance (LEAGUE_CONTEXTS["SBL"]).
   - `NcaaSoftballPlayoffSource(BestOfNSeriesSource)`: postseason.
-    Currently models the best-of-3 stages — Super Regional and WCWS
-    Championship Finals — both with clean ESPN game-number metadata.
+    Currently models the best-of-3 stages: Super Regional and WCWS
+    Championship Finals: both with clean ESPN game-number metadata.
     Regional (4-team double-elim per site) and the 8-team WCWS bracket
     in OKC are tracked in #43: ESPN headlines on those stages are
     "Women's College World Series - Double Elimination Round" with no
@@ -26,7 +26,7 @@ Rankings poll: ESPN exposes the ESPN.com/USA Softball Collegiate
 Top 25 (the canonical D1 softball poll). Used for the rank-pair
 signal on upcoming matchups.
 
-Per-day iteration is required — ESPN's range syntax silently caps
+Per-day iteration is required: ESPN's range syntax silently caps
 at 25 events. D1 softball can produce 60+ games on a Saturday
 during peak season; per-day single-date queries return all of
 them.
@@ -164,12 +164,12 @@ class NcaaSoftballRegularSource(PointsBasedSportSource):
     """D1 NCAA Softball regular-season importance.
 
     Win-count threshold bands tuned against historical NCAA Tournament
-    selection criteria (64-team field — same field size as baseball).
+    selection criteria (64-team field: same field size as baseball).
     The selection committee weights RPI + strength-of-schedule + wins,
     but win-count alone is a strong proxy for tournament status.
 
     Postseason games (season.type=3) are filtered out of both
-    fetch_upcoming and _fetch_full_season_games — NcaaSoftballPlayoff
+    fetch_upcoming and _fetch_full_season_games: NcaaSoftballPlayoff
     Source owns those. Otherwise the regular-season win count would
     inflate by postseason wins, breaking the threshold bands.
     """
@@ -300,7 +300,7 @@ class NcaaSoftballRegularSource(PointsBasedSportSource):
 
 
 # =====================================================================
-# NcaaSoftballPlayoffSource — best-of-3 stages (Super Regional + WCWS Finals)
+# NcaaSoftballPlayoffSource: best-of-3 stages (Super Regional + WCWS Finals)
 # =====================================================================
 
 
@@ -314,7 +314,7 @@ _FINALS_MARKER = "Championship Finals - Game "
 def _parse_softball_playoff_headline(headline: str) -> Tuple[Optional[str], Optional[int]]:
     """Map an ESPN softball postseason headline to (stage, game_index).
     Returns (None, None) for unmodeled stages (Regional, 8-team WCWS
-    bracket — both lack headline game metadata in ESPN's data; see #43).
+    bracket: both lack headline game metadata in ESPN's data; see #43).
 
     Patterns observed in 2025-2026 ESPN data:
       - "NCAA Softball Championship - Lincoln Super Regional - Game 1"
@@ -598,7 +598,7 @@ class NcaaSoftballPlayoffSource(_SoftballPlayoffStrengthsMixin, BestOfNSeriesSou
 
 
 # =====================================================================
-# NcaaSoftballPlayoffBracketSource — Regional + 8-team WCWS double-elim
+# NcaaSoftballPlayoffBracketSource: Regional + 8-team WCWS double-elim
 # =====================================================================
 
 
@@ -632,7 +632,7 @@ def _parse_softball_bracket_headline(headline: str) -> Tuple[Optional[str], Opti
     """Map an ESPN softball postseason headline to (stage, partial_grouping_key).
 
     For Regional games, returns ("SB_REG", "<site> Regional"). For 8-team
-    WCWS bracket games, returns ("WCWS", None) — the sub-bracket
+    WCWS bracket games, returns ("WCWS", None): the sub-bracket
     assignment is resolved chronologically by `_classify_wcws_sub_brackets`.
 
     Returns (None, None) for best-of-3 SB_SR / WCWS_F headlines (owned by

--- a/sources/ncaaf.py
+++ b/sources/ncaaf.py
@@ -1,9 +1,9 @@
 """NCAA Football source via CollegeFootballData.com.
 
 Free tier: 1k req/day. We make 3 calls per refresh:
-  1) /rankings — current AP Top-25 (nested polls→ranks shape)
-  2) /games   — schedule for the upcoming window (param: ?year=)
-  3) /lines   — betting lines per week
+  1) /rankings: current AP Top-25 (nested polls→ranks shape)
+  2) /games  : schedule for the upcoming window (param: ?year=)
+  3) /lines  : betting lines per week
 
 Offseason (Feb-Aug) /games returns no upcoming results; fetch_upcoming
 returns []. CFBD identifies a season by its START year (?year=2024 means
@@ -202,7 +202,7 @@ class NcaafSource(PointsBasedSportSource):
         /games call covers the whole season; cached per source instance
         in the base class.
 
-        Filters to games where at least one side is FBS-classified — keeps
+        Filters to games where at least one side is FBS-classified: keeps
         FBS vs FCS cupcake matchups (they count toward FBS wins) but
         drops pure FCS-vs-FCS scheduling. CFBD's typical /games?year=
         response is ~3700 rows; after FBS filter, ~750-900 remain. That

--- a/sources/ncaam.py
+++ b/sources/ncaam.py
@@ -8,12 +8,12 @@ live API on 2026-04-27):
     not nested under polls[].ranks[]. Field names: `team` not `school`,
     `ranking` not `rank`, `pollType` not `poll`. Filter by season.
   - /games is paginated at 3000 results without offset support. Use
-    startDateRange / endDateRange query params instead — they accept any
+    startDateRange / endDateRange query params instead: they accept any
     YYYY-MM-DD range and return only games in that window. Games have no
     `week` field. Excitement is `excitement` not `excitementIndex`.
   - /lines accepts the same date-range params and is keyed by `gameId`.
 
-These shape differences make sharing code with NcaafSource brittle — each
+These shape differences make sharing code with NcaafSource brittle: each
 source implements SportSource directly.
 
 Free tier: same as CFBD (1k req/day, free key from collegebasketballdata.com).
@@ -118,7 +118,7 @@ class NcaamSource(PointsBasedSportSource):
     def _current_season_year() -> int:
         # CBB's ?season= is the END year of the season (?season=2025 means
         # 2024-25). Pivot at November (when the season opens). In May-Oct we
-        # return last season's end-year — /games for that season is in the
+        # return last season's end-year: /games for that season is in the
         # past so fetch_upcoming filters everything out and returns [].
         now = datetime.now(timezone.utc)
         return now.year + 1 if now.month >= 11 else now.year
@@ -141,7 +141,7 @@ class NcaamSource(PointsBasedSportSource):
             return None
         if not data:
             return None
-        # Flat list — filter by pollType, then take the latest week.
+        # Flat list: filter by pollType, then take the latest week.
         relevant = [r for r in data if r.get("pollType") == self.poll_name]
         if not relevant:
             return None
@@ -156,7 +156,7 @@ class NcaamSource(PointsBasedSportSource):
         return out or None
 
     def _fetch_games(self, start: datetime, end: datetime) -> List[Dict]:
-        """Use startDateRange/endDateRange — /games is hard-capped at 3000
+        """Use startDateRange/endDateRange: /games is hard-capped at 3000
         without offset support, so a season-wide call would silently miss
         late-season games.
         """
@@ -201,7 +201,7 @@ class NcaamSource(PointsBasedSportSource):
             if gid is None:
                 continue
             line_list = entry.get("lines") or []
-            # CBB returns per-bookmaker lines without a "consensus" entry —
+            # CBB returns per-bookmaker lines without a "consensus" entry:
             # take the first non-null spread we see (mirrors what the user
             # would see at the top of any sportsbook).
             for line in line_list:
@@ -220,7 +220,7 @@ class NcaamSource(PointsBasedSportSource):
     def _fetch_full_season_games(self) -> List[Dict[str, Any]]:
         """Return the current regular-season game list filtered to games
         involving an AP-ranked team. The full D1 schedule is ~7500 games
-        — too many for the Monte Carlo simulator to iterate every refresh
+       : too many for the Monte Carlo simulator to iterate every refresh
         at acceptable latency. Filtering to AP-relevant games drops it to
         ~700-1000 (each of ~25 AP teams plays ~30 games, with overlap),
         which keeps per-refresh importance cost in the seconds, not
@@ -238,7 +238,7 @@ class NcaamSource(PointsBasedSportSource):
         ranked = self._fetch_rankings(season)
         if not ranked:
             # No AP poll yet (preseason). Importance signal returns 0
-            # via terminal_outcomes' empty dict — graceful no-op.
+            # via terminal_outcomes' empty dict: graceful no-op.
             return []
         ap_teams = set(ranked.keys())
 
@@ -284,7 +284,7 @@ class NcaamSource(PointsBasedSportSource):
             ap_pts = g.get("awayPoints")
             # CBBD encodes completion via the homeWinner/awayWinner booleans
             # being non-null AND the *Points fields being numeric. Use the
-            # joint check — `status` field doesn't always reflect completion.
+            # joint check: `status` field doesn't always reflect completion.
             completed = (hp is not None and ap_pts is not None
                          and (g.get("homeWinner") is not None
                               or g.get("awayWinner") is not None))

--- a/sources/ncaaw_basketball.py
+++ b/sources/ncaaw_basketball.py
@@ -1,4 +1,4 @@
-"""NCAA Women's Basketball source — ESPN's unofficial site.api.espn.com.
+"""NCAA Women's Basketball source: ESPN's unofficial site.api.espn.com.
 No API key required.
 
 Two source classes:
@@ -79,7 +79,7 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
 def _default_season_end_year() -> int:
     """Season runs Nov YYYY through April YYYY+1. The "season year" is
     the calendar year the tournament ends in (matching ESPN's convention
-    for tournaments — the 2024-25 season ends with the March 2025 NCG)."""
+    for tournaments: the 2024-25 season ends with the March 2025 NCG)."""
     now = datetime.now(timezone.utc)
     # Pre-November: still in previous season's offseason.
     return now.year + 1 if now.month >= SEASON_START_MONTH else now.year
@@ -129,7 +129,7 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not comps:
         return None
     comp = comps[0]
-    # No All-Star filter needed for NCAA — there's no All-Star Game in
+    # No All-Star filter needed for NCAA: there's no All-Star Game in
     # college basketball. competition.type.abbreviation is always STD
     # for regular season, and the tournament uses headline-based
     # stage routing.
@@ -225,7 +225,7 @@ class NcaawBasketballRegularSource(PointsBasedSportSource):
                 if rec is None:
                     continue
                 # Both regular-season AND tournament games surface here.
-                # Filtering by season.type isn't strictly necessary — we
+                # Filtering by season.type isn't strictly necessary: we
                 # surface postseason games in fetch_upcoming so the user's
                 # guide picks them up; the playoff source covers the
                 # importance-cascade side separately.
@@ -255,7 +255,7 @@ class NcaawBasketballRegularSource(PointsBasedSportSource):
 
     def _fetch_rankings(self) -> Dict[str, int]:
         """Return {team_location: rank} from ESPN's AP poll. Empty
-        dict if missing — rank-pair signal sits out the cycle."""
+        dict if missing: rank-pair signal sits out the cycle."""
         data = _http_get(f"{ESPN_BASE}/rankings")
         if not data:
             return {}
@@ -283,7 +283,7 @@ class NcaawBasketballRegularSource(PointsBasedSportSource):
         """Walk every day from season start through min(today + 7d,
         regular season end). Filter to regular-season games only
         (season.type == 2) so the tournament doesn't pollute the
-        win-count importance signal — the playoff source has its own
+        win-count importance signal: the playoff source has its own
         bracket-based importance."""
         seen: Dict[Any, Dict[str, Any]] = {}
         # Season starts early-November of (end_year - 1).

--- a/sources/nfl.py
+++ b/sources/nfl.py
@@ -1,4 +1,4 @@
-"""NFL source — ESPN's unofficial site.api.espn.com. No API key required.
+"""NFL source: ESPN's unofficial site.api.espn.com. No API key required.
 
 Two source classes:
   - `NflRegularSource(PointsBasedSportSource)`: 17-game season since
@@ -50,7 +50,7 @@ _DEFAULT_POINTS_AGAINST = 22.0
 
 # NFL regular season runs early-September through early-January; playoffs
 # January through early-February. ESPN tags `season.year` by the FINAL
-# calendar year of the season (e.g., "2025" for the 2024 season — the
+# calendar year of the season (e.g., "2025" for the 2024 season: the
 # Super Bowl was in February 2025).
 SEASON_START_MONTH = 9   # September
 PLAYOFF_END_MONTH = 2    # February (Super Bowl)
@@ -125,7 +125,7 @@ def _parse_stage_from_headline(headline: Optional[str]) -> Optional[Dict[str, An
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert one ESPN scoreboard event into the canonical record.
     Filters out the Pro Bowl (tagged competition.type.abbreviation
-    == "ALLSTAR" — same NBA/WNBA trap)."""
+    == "ALLSTAR": same NBA/WNBA trap)."""
     comps = event.get("competitions") or []
     if not comps:
         return None
@@ -191,7 +191,7 @@ class NflRegularSource(PointsBasedSportSource):
     """NFL regular-season importance via PointsBasedSportSource.
 
     Uses raw `wins` (LEAGUE_CONTEXTS["NFL"] is format="win_count"). NFL
-    has 17 games per team since 2021 — the 7th playoff seed cutoff has
+    has 17 games per team since 2021: the 7th playoff seed cutoff has
     settled around 9-10 wins. Bands tuned to the modern 17-game era;
     pre-2021 seasons would have lower cutoffs but the curator only
     surfaces current games anyway.
@@ -255,7 +255,7 @@ class NflRegularSource(PointsBasedSportSource):
         """Walk every day of the regular season (early-September through
         early-January of the next calendar year). Filter to
         season.type == 2 so playoffs don't leak into the win-count
-        importance signal — the playoff source covers that separately.
+        importance signal: the playoff source covers that separately.
         """
         seen: Dict[Any, Dict[str, Any]] = {}
         # NFL season starts early-September of (end_year - 1).
@@ -299,7 +299,7 @@ class NflPlayoffSource(BestOfNSeriesSource):
     as March Madness, just with 4 rounds instead of 6).
 
     Stages: WC -> DIV -> CONF -> SB. Each "series" is one game;
-    clinching wins == 1. Cross-conference until the Super Bowl —
+    clinching wins == 1. Cross-conference until the Super Bowl:
     AFC and NFC ladders feed independently until the SB pairs the
     two conference winners.
     """

--- a/sources/nhl.py
+++ b/sources/nhl.py
@@ -1,4 +1,4 @@
-"""NHL source — official `api-web.nhle.com` for both regular-season standings
+"""NHL source: official `api-web.nhle.com` for both regular-season standings
 and Stanley Cup playoffs. No API key required.
 
 Two source classes:
@@ -14,7 +14,7 @@ Two source classes:
 API quirks captured here:
   - `/v1/standings/now` returns HTTP 307 to `/v1/standings/{date}`.
     `requests.get` with `allow_redirects=True` (the default) handles it,
-    but the request must be made WITHOUT `compressed=False` — Cloudflare
+    but the request must be made WITHOUT `compressed=False`: Cloudflare
     in front of api-web.nhle.com returns gzip-encoded responses and
     `requests` only decodes them when `Accept-Encoding: gzip` is sent
     (which it does by default).
@@ -53,7 +53,7 @@ NHL_API_BASE = "https://api-web.nhle.com/v1"
 
 # All 32 active NHL franchises by their api-web abbreviation. Used by
 # NhlRegularSource to walk per-team season schedules and dedupe games
-# by ID — there's no league-wide season-fetch endpoint on api-web, but
+# by ID: there's no league-wide season-fetch endpoint on api-web, but
 # 32 sequential team-schedule calls complete in well under a minute and
 # the importance refresh runs at most every 6 hours.
 NHL_TEAM_ABBREVS: Tuple[str, ...] = (
@@ -154,7 +154,7 @@ class NhlRegularSource(PointsBasedSportSource):
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
         """Pull next-N-day schedule via `/v1/schedule/{date}` and emit
-        GameRows. Closeness is left None — there is no Odds API
+        GameRows. Closeness is left None: there is no Odds API
         integration for NHL in V1. The structural importance signal
         carries the score on its own.
         """
@@ -223,7 +223,7 @@ class NhlRegularSource(PointsBasedSportSource):
                 ag = (g.get("awayTeam") or {}).get("score")
                 # api-web marks finished games as "OFF" (final) or "FINAL"
                 # depending on the firmware version; both are terminal.
-                # Active live games have state == "LIVE" — we treat them
+                # Active live games have state == "LIVE": we treat them
                 # as SCHEDULED for the simulator (don't seed in-progress
                 # results because the score is still moving).
                 is_final = state in ("OFF", "FINAL") and hg is not None and ag is not None
@@ -350,7 +350,7 @@ NHL_HOME_PATTERN: Tuple[bool, ...] = (True, True, False, False, True, False, Tru
 # placeholder lets the importance simulator propagate counterfactual
 # CONF_FINAL winners into the CUP_FINAL → CUP_WINNER cascade. DO NOT
 # change these strings without also updating `_build_bracket`'s
-# placeholder-detection branch — the names are the join key. Bit me on
+# placeholder-detection branch: the names are the join key. Bit me on
 # the first round of #17 work before I made this constant.
 _CUP_FINAL_TOP_SENTINEL = "CF_A_WINNER"
 _CUP_FINAL_BOT_SENTINEL = "CF_B_WINNER"
@@ -365,7 +365,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
     series/{season}/{seriesLetter}`.
 
     Per-game sampling uses the same Poisson goal model as the regular
-    season, but each individual game gets its own OT/SO resolution —
+    season, but each individual game gets its own OT/SO resolution:
     a series can run 7 games with a mix of regulation, OT, and SO
     decisions. Series winners propagate through `_round_reached` to
     drive the terminal_outcomes label cascade (R1 → R2 → CONF_FINAL →
@@ -376,7 +376,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
     SERIES_LENGTH = 7
     supports_importance = True
 
-    # NHL playoffs don't have a "WINNER" depth above CUP_FINAL — that
+    # NHL playoffs don't have a "WINNER" depth above CUP_FINAL: that
     # synthetic label IS the cup winner. _winner_advance_label maps
     # CUP_FINAL → CUP_WINNER explicitly.
 
@@ -475,7 +475,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
     ) -> None:
         """Hook for the plugin to share regular-season strength estimates
         with the playoff source. Without this, every playoff team gets
-        the league-average prior — accurate enough for early-round
+        the league-average prior: accurate enough for early-round
         importance but loses the team-skill signal a 60-game baseline
         provides."""
         self._team_strengths_from_regular = strengths
@@ -505,7 +505,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         home_goals = _poisson(lam_home, rng)
         away_goals = _poisson(lam_away, rng)
         # Playoff OT is sudden-death continuous (no SO), so a tied
-        # regulation always resolves in OT. We still need a winner —
+        # regulation always resolves in OT. We still need a winner:
         # add +1 to a coin-flipped side (slight bias by strength? skip
         # for V1; pen-shootout variance dominates the calibration).
         if home_goals == away_goals:
@@ -553,7 +553,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
 
             # Per-series schedule for the actual game records. URL is
             # `/v1/schedule/playoff-series/{full_season}/{lower_letter}`
-            # — empirically confirmed against the live host. NB: this
+            #: empirically confirmed against the live host. NB: this
             # uses the full 8-digit season, not the end-year used by
             # the bracket endpoint above.
             series_url = (
@@ -596,7 +596,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         # CONF_FINAL series have known participants but the bracket
         # endpoint hasn't yet populated the SCF series with teams. The
         # endpoint emits a Round-4 stub with topSeedTeam/bottomSeedTeam
-        # = None during the conference-finals week — the loop above
+        # = None during the conference-finals week: the loop above
         # silently skips that stub (because _team_canonical_name returns
         # "" for the None teams). Without this placeholder, the cup_winner
         # leverage signal reads 0 during the very week when it matters
@@ -609,7 +609,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         # cf_emitted > 0 (data exists) rather than ==14 (all games published)
         # because the schedule endpoint emits games as they're scheduled,
         # not all up-front. The 2-series count comes from grouping inside
-        # _build_bracket — easier to check via the actual game emission.
+        # _build_bracket: easier to check via the actual game emission.
         cf_series_with_teams = sum(
             1 for s in bracket_data.get("series", []) or []
             if _NHL_ROUND_TO_STAGE.get(s.get("playoffRound") or 0) == "CONF_FINAL"
@@ -632,7 +632,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         (which are positive 8-digit numbers like 2025030323).
 
         The sentinels are stable across refreshes within one importance
-        run — they're matched by _build_bracket below to wire feeds_from
+        run: they're matched by _build_bracket below to wire feeds_from
         to the two CONF_FINAL series.
         """
         games: List[Dict[str, Any]] = []
@@ -663,7 +663,7 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         names, which the participant-set inference in the base class
         can't match against the actual CONF_FINAL participants).
 
-        Called by BracketSportSource.initial_state — we call super for
+        Called by BracketSportSource.initial_state: we call super for
         the standard structural pass, then post-process the placeholder
         if it's present.
         """
@@ -681,11 +681,11 @@ class NhlPlayoffSource(BestOfNSeriesSource):
             return bracket  # not a placeholder, leave alone
 
         # Wire feeds_from explicitly: each sentinel resolves to the winner
-        # of its corresponding CONF_FINAL series. Order matters — sentinel
+        # of its corresponding CONF_FINAL series. Order matters: sentinel
         # _CUP_FINAL_TOP_SENTINEL maps to CONF_FINAL[0]'s winner; bottom
         # to CONF_FINAL[1]. Order within the bracket comes from
         # _build_bracket's grouping pass which is deterministic per
-        # frozenset insertion order — stable enough for a 2-series
+        # frozenset insertion order: stable enough for a 2-series
         # check. For home-ice priority in the placeholder, we assume
         # CONF_FINAL[0]'s winner gets games 1/2/5/7 at home (the higher
         # regular-season seed normally would; without seeding data, the

--- a/sources/nwsl.py
+++ b/sources/nwsl.py
@@ -1,8 +1,8 @@
-"""NWSL source — ESPN unofficial + Odds API closeness.
+"""NWSL source: ESPN unofficial + Odds API closeness.
 
 Same minimal pattern as MlsSource: schedule from ESPN + closeness
 from The Odds API. No standings-based importance and no playoff
-bracket — NWSL playoff format mirrors MLS Cup (mixed best-of-3 and
+bracket: NWSL playoff format mirrors MLS Cup (mixed best-of-3 and
 single-leg rounds), tracked under #30.
 
 NWSL Odds API key: `soccer_usa_nwsl`. ESPN slug: `soccer/usa.nwsl`.

--- a/sources/points_based.py
+++ b/sources/points_based.py
@@ -4,7 +4,7 @@ sports (NCAAF, NCAAM, future NHL/NBA/MLB regular seasons).
 The model: each team has a per-game points-scored and points-allowed average
 derived from FINISHED games. `sample_result` draws Poisson(lam_home),
 Poisson(lam_away) where lam_home blends home-team's offense + away-team's
-defense, and lam_away mirrors. OT/overtime/extra-innings are abstracted —
+defense, and lam_away mirrors. OT/overtime/extra-innings are abstracted:
 draws are post-resolved by giving +1 to a random side so `_classify_target_
 result` produces W/L rather than D (NCAA games never end in regulation ties
 that affect win-count outcomes; the simulator's tau-c just needs a binary
@@ -13,7 +13,7 @@ W/L).
 Terminal outcomes are win-count bands (e.g., "11+ wins" for elite CFB
 seasons, "bowl_eligible" at 6+, "25+ wins" for NCAAM elite). The
 LEAGUE_CONTEXTS entry's thresholds list is `(min_wins, label, weight)`
-tuples — `cutoff` is interpreted as a win-count threshold rather than a
+tuples: `cutoff` is interpreted as a win-count threshold rather than a
 position cutoff (the SoccerSource interpretation).
 
 The base assumes `_fetch_full_season_games()` returns a flat list of
@@ -306,7 +306,7 @@ class PointsBasedSportSource(SportSource):
         `last_period_type` from sample_result, used to compute standings
         points). Default ignores it; NHL subclasses override the method
         to bake in the OT-loss-point logic. DO NOT use a @staticmethod
-        decorator — subclasses need `self` for overriding.
+        decorator: subclasses need `self` for overriding.
         """
         del result_extra  # base ignores; NHL subclass reads
         h = teams[home]
@@ -323,7 +323,7 @@ class PointsBasedSportSource(SportSource):
         elif home_pts < away_pts:
             a["wins"] += 1
             h["losses"] += 1
-        # Tie: no W/L update (shouldn't happen — sample_result enforces a
+        # Tie: no W/L update (shouldn't happen: sample_result enforces a
         # winner via coin-flip, and FD.org doesn't publish tied finals for
         # NCAA football/basketball).
 
@@ -332,7 +332,7 @@ class PointsBasedSportSource(SportSource):
 
         For format="win_count" sports (CFB, CBB, NBA, MLB): _count_field
         defaults to "wins". 11 wins satisfies "11+ wins" AND "10+ wins"
-        AND "8+ wins" AND "bowl_eligible" — the caller sums leverage ×
+        AND "8+ wins" AND "bowl_eligible": the caller sums leverage ×
         consequence over the band set per the cross-sport calibration.
 
         For format="points_count" sports (NHL): _count_field is

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -1,11 +1,11 @@
-"""European football (soccer) source — Football-Data.org for fixtures + standings,
+"""European football (soccer) source: Football-Data.org for fixtures + standings,
 The Odds API for spreads.
 
 Free tier coverage on Football-Data.org includes:
   - PL  (Premier League)
-  - ELC (English Football League Championship — i.e., the second tier)
+  - ELC (English Football League Championship: i.e., the second tier)
   - CL  (UEFA Champions League)
-  + Bundesliga, La Liga, Serie A, Ligue 1, etc. — easy to add later.
+  + Bundesliga, La Liga, Serie A, Ligue 1, etc.: easy to add later.
 
 Soccer rank: there's no AP poll, so we use **league position** as the rank.
 Wrexham 6th, Hull 7th → "6v7" matchup, both fighting for the playoff spot.
@@ -49,12 +49,12 @@ ODDS_BASE = "https://api.the-odds-api.com/v4"
 #
 # Two caches replace the per-source-instance fetch pattern:
 #
-#   _TIER_FIXTURES_CACHE  — one /v4/matches call returns fixtures for
+#   _TIER_FIXTURES_CACHE : one /v4/matches call returns fixtures for
 #                           every competition on the tier in a single
 #                           date window. SoccerSource._fetch_fixtures
 #                           filters this by self.config.fd_code instead
 #                           of calling /v4/competitions/<code>/matches.
-#   _SEASON_MATCHES_CACHE — full-season matches per competition (used
+#   _SEASON_MATCHES_CACHE: full-season matches per competition (used
 #                           by the Monte Carlo importance simulator).
 #                           Keyed by fd_code so sibling sources
 #                           (wc_groups + wc_knockout) share one fetch
@@ -175,7 +175,7 @@ def _fetch_season_matches_for_code(fd_api_key: str, fd_code: str) -> List[Dict]:
     the same competition's schedule.
 
     NOTE: there's no /v4/matches-equivalent that returns full-season
-    history per competition in one shot — /v4/matches is date-bounded.
+    history per competition in one shot: /v4/matches is date-bounded.
     So this remains a per-competition call, but at most ONE call per
     distinct fd_code per refresh, regardless of how many sources
     consume it.
@@ -206,7 +206,7 @@ def _fetch_season_matches_for_code(fd_api_key: str, fd_code: str) -> List[Dict]:
 # a "position prior." Without the seed, MD1-3 produces tied scores (no
 # rank_pair signal, no stakes signal) and the algorithm has nothing but
 # favorites + spread to work with. See TUNING_REPORT.md finding #2.
-# DO NOT raise this above ~5 — by MD5 enough matches have played that
+# DO NOT raise this above ~5: by MD5 enough matches have played that
 # the current-season position is a stronger signal than the prior year's.
 # Public (no underscore) because the sim harness imports it to mirror
 # this exact cutoff in its standings_as_of replay; a divergence would
@@ -228,7 +228,7 @@ def _h2h_to_closeness(
       closeness     = 2 * min(p_home, p_away)
 
     The draw probability is intentionally not part of the closeness
-    formula — "either team could win" is what we care about, and the
+    formula: "either team could win" is what we care about, and the
     draw outcome is its own state. A 33/34/33 split → closeness 0.66,
     not 1.0; that's correct (a draw-heavy market isn't a coinflip).
     """
@@ -308,7 +308,7 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         sport_label="UEFA Champions League",
         odds_sport_key="soccer_uefa_champs_league",
         use_position_as_rank=False,  # group/knockout standings don't map cleanly
-        # total_matchdays=0 — knockout, not a fixed-length season
+        # total_matchdays=0: knockout, not a fixed-length season
     ),
     # Top-flight European league competitions. All available on
     # Football-Data.org's free tier (verified 2026-05-25). Each is a
@@ -367,7 +367,7 @@ COMPETITIONS: Dict[str, SoccerCompetitionConfig] = {
         use_position_as_rank=False,
     ),
     # Additional Football-Data.org free-tier leagues. Same config
-    # shape as the top-flight European leagues above — pure data
+    # shape as the top-flight European leagues above: pure data
     # additions, no source code changes. UEFA Europa League and
     # Conference League are NOT on the FD.org free tier (only Champions
     # League is), so they're not included here.
@@ -495,7 +495,7 @@ class SoccerSource(SportSource):
                     "raw_position_home": rh,
                     "raw_position_away": ra,
                     "fd_competition_code": self.config.fd_code,
-                    # Standings is position-based (not poll-based) — the WHY
+                    # Standings is position-based (not poll-based): the WHY
                     # renderer uses this to skip "both top-N" framing that's
                     # meaningless when every team in the league is already
                     # "ranked" (e.g. all 20 EPL teams are top-25).
@@ -568,7 +568,7 @@ class SoccerSource(SportSource):
 
         Trade-off: teams promoted INTO this league won't appear in the
         seed (they were in a different competition last year) and stay
-        unranked through the seed window. That's correct — they have no
+        unranked through the seed window. That's correct: they have no
         positional signal anyway. The 17 carry-over teams get realistic
         ranks; the 3 promoted teams fall back to the existing
         one-ranked-one-unranked rank-pair path.
@@ -582,7 +582,7 @@ class SoccerSource(SportSource):
         seed_by_team, seed_table = self._fetch_standings(season=prev_year)
         if not seed_table:
             return current_by_team, current_table
-        # Reset playedGames to 0 — the seed represents a fresh season's
+        # Reset playedGames to 0: the seed represents a fresh season's
         # prior, not last year's residual. Downstream consumers
         # (build_impact_narratives, the matcher's rank cap) read these
         # numbers; the importance simulator builds its own standings from
@@ -688,8 +688,8 @@ class SoccerSource(SportSource):
                      home: str, away: str) -> Optional[float]:
         """Match Football-Data.org team names to The Odds API team names with
         a fuzzy fallback. Football-Data uses 'Wrexham AFC', Odds API uses
-        'Wrexham' — strip common suffixes and try lowercase substring.
-        Generic over whatever value the odds_map carries — pre-B.3 was
+        'Wrexham': strip common suffixes and try lowercase substring.
+        Generic over whatever value the odds_map carries: pre-B.3 was
         spread floats, post-B.3 is closeness floats."""
         h_lc = home.lower()
         a_lc = away.lower()
@@ -834,7 +834,7 @@ class SoccerSource(SportSource):
     def initial_state(self) -> Dict[str, Any]:
         """Standings snapshot as of the moment importance is computed. Built
         from finished matches in the season (NOT from the FD.org standings
-        endpoint — that endpoint can include in-progress results that
+        endpoint: that endpoint can include in-progress results that
         de-sync from the fixture list, and the simulator needs the two to
         agree).
 
@@ -887,7 +887,7 @@ class SoccerSource(SportSource):
     @staticmethod
     def _mutate_apply(state: Dict[str, Any], home: str, away: str, hg: int, ag: int) -> None:
         """Apply one finished result to a state dict in place. Used by
-        `initial_state` (where mutation is fine — we own the new state) and
+        `initial_state` (where mutation is fine: we own the new state) and
         `apply_result` (which copies first to preserve immutability)."""
         h = state[home]
         a = state[away]
@@ -946,7 +946,7 @@ class SoccerSource(SportSource):
         rate; mirror for away goals.
 
         `state` is part of the SportSource ABC signature but unused by the
-        league-shape Poisson model — team strengths fully determine the
+        league-shape Poisson model: team strengths fully determine the
         rates. KnockoutSoccerSource overrides this and DOES read state
         (to look up leg 1's result when sampling leg 2). Reference the
         param explicitly to silence "unused parameter" hints.
@@ -967,7 +967,7 @@ class SoccerSource(SportSource):
         match: GameRow,
         result: MatchResult,
     ) -> Dict[str, Any]:
-        """Return a NEW state with `match`'s `result` applied. Pure — the
+        """Return a NEW state with `match`'s `result` applied. Pure: the
         simulator depends on this NOT mutating `state` so one initial_state
         can seed many sampled seasons.
         """
@@ -986,7 +986,7 @@ class SoccerSource(SportSource):
 
     def terminal_outcomes(self, state: Dict[str, Any]) -> Dict[str, List[str]]:
         """{team: [outcome_labels]} at the final standings encoded in
-        `state`. Sorts by (points desc, goal_diff desc, gf desc) — the
+        `state`. Sorts by (points desc, goal_diff desc, gf desc): the
         standard soccer tiebreak. Assigns labels based on
         `LEAGUE_CONTEXTS[fd_code].thresholds`.
 
@@ -1000,7 +1000,7 @@ class SoccerSource(SportSource):
             return {team: [] for team in state if team != "_applied"}
         # DO NOT use this method for knockout-format contexts (UCL, etc.).
         # The cutoff in knockout thresholds is a stage string ("LAST_16"),
-        # not an int position — the `pos > cutoff` comparison below would
+        # not an int position: the `pos > cutoff` comparison below would
         # TypeError. The factory in plugin.py routes knockout configs to
         # KnockoutSoccerSource; falling here means a misroute. Return empty
         # so importance silently produces 0 (consistent with "no league
@@ -1008,7 +1008,7 @@ class SoccerSource(SportSource):
         if ctx.format != "league":
             logger.warning(
                 "[soccer:%s] SoccerSource.terminal_outcomes called on a non-league "
-                "context (format=%s); returning empty. This is a wiring bug — the "
+                "context (format=%s); returning empty. This is a wiring bug: the "
                 "factory should route this competition to KnockoutSoccerSource.",
                 self.config.fd_code, ctx.format,
             )
@@ -1058,13 +1058,13 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
     """
 
     # Stage tuple ordered by depth (earlier rounds first). PLAYOFFS and
-    # LAST_32 are both at depth 0 — UEFA cup competitions use PLAYOFFS as
+    # LAST_32 are both at depth 0: UEFA cup competitions use PLAYOFFS as
     # the entry round (pos 9-24 face the league phase's top 8); the new
     # 48-team FIFA World Cup uses LAST_32. The ordering matters only for
     # feeds_from inference (each tie looks back through earlier stages);
     # since no single competition uses both PLAYOFFS and LAST_32, they
     # don't collide. EURO and FIFA pre-2026 tournaments simply have
-    # neither stage populated — _build_bracket skips empty stages.
+    # neither stage populated: _build_bracket skips empty stages.
     KO_STAGES = (
         "PLAYOFFS",
         "LAST_32",
@@ -1089,10 +1089,10 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
         sibling GroupStageSoccerSource. Knockout fixtures (PLAYOFFS,
         LAST_32 / LAST_16 / QF / SF / FINAL / THIRD_PLACE) pass through.
 
-        Safe for non-tournament competitions (UCL, UEL, UECL) — their
+        Safe for non-tournament competitions (UCL, UEL, UECL): their
         FD.org fixtures never carry stage="GROUP_STAGE" so the filter
         is a no-op there. The filter is keyed off `extra.stage` set by
-        SoccerSource.fetch_upcoming, NOT off `self.KO_STAGES` — that
+        SoccerSource.fetch_upcoming, NOT off `self.KO_STAGES`: that
         keeps the filter robust even if FD.org introduces a knockout
         stage label we haven't seen yet (better to over-emit a new
         knockout stage than to under-emit a known one).
@@ -1110,18 +1110,18 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
         shape. Bakes the penalty-shootout +1 boost into home_goals/away_goals
         so the aggregate sum reflects the actual tie winner (FD.org stores
         `fullTime` as the score that decided the leg, and the shootout
-        outcome lives in `score.penalties` — we apply the +1 here so the
+        outcome lives in `score.penalties`: we apply the +1 here so the
         downstream aggregate computation in AggregateLegSource doesn't
         need to know about shootout semantics).
 
         Matchday normalization: FD.org's `matchday` is competition-relative.
         For UEFA cup two-leg ties it doubles as the leg index (1 = leg 1,
-        2 = leg 2 — works directly). For international tournaments (WC,
+        2 = leg 2: works directly). For international tournaments (WC,
         EURO) it's the overall tournament-day counter (e.g., matchday=7
         for the EURO 2024 final), which DOES NOT map to a leg index. We
         normalize per-tie here: matchday becomes the 1-indexed leg position
         within the tie, ordered chronologically. DO NOT pass FD's matchday
-        through unchanged for single-leg-per-round competitions — the
+        through unchanged for single-leg-per-round competitions: the
         AggregateLegSource records the score into `leg2` instead of
         `leg1` and the tie never marks itself complete.
         """
@@ -1219,7 +1219,7 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
         Returns a state dict in the shape `BracketSportSource.
         initial_state` produces: keys `_applied`, `_tie_results`,
         `_bracket`, `_round_reached`. Compatible with `remaining_matches`,
-        `sample_result`, `apply_result`, `terminal_outcomes` as-is —
+        `sample_result`, `apply_result`, `terminal_outcomes` as-is:
         seed_from_chain is the entry point INSTEAD of `initial_state`,
         not in addition to it.
         """
@@ -1295,7 +1295,7 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
         Aggregate-tie detection uses leg 1's score from `state["_tie_results"]`
         for 2-leg decisive legs; for 1-leg FINAL it's the regulation score
         directly. Non-decisive legs (leg 1 of a 2-leg tie) return regulation
-        goals only — the simulator will re-enter via sample_result for leg 2
+        goals only: the simulator will re-enter via sample_result for leg 2
         which carries the decisive logic.
         """
         h = self._strength_for(strengths, match.home)
@@ -1348,7 +1348,7 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
             return MatchResult(home_goals=home_goals, away_goals=away_goals, extra=result_extra)
 
         # Penalty shootout: +1 to winner. Encodes a non-draw outcome for
-        # tau-c classification. Symmetric 70% per-shot model — pen shootouts
+        # tau-c classification. Symmetric 70% per-shot model: pen shootouts
         # are dominated by variance; per-team skill barely shifts results
         # at the calibration precision used.
         pen_winner = self._sample_penalty_shootout(rng)
@@ -1373,7 +1373,7 @@ class KnockoutSoccerSource(AggregateLegSource, SoccerSource):
 
 
 # =====================================================================
-# GroupStageSoccerSource — international-tournament group importance
+# GroupStageSoccerSource: international-tournament group importance
 # =====================================================================
 
 
@@ -1397,9 +1397,9 @@ class GroupStandings(NamedTuple):
 # WC 2026 LAST_32 bracket pairings, source: FIFA published schedule
 # (matches M73-M88). Each entry: (home_slot, away_slot).
 # Slot kinds:
-#   ("group_winner", "<letter>")     — 1st place in that group
-#   ("group_runner_up", "<letter>")  — 2nd place in that group
-#   ("best_third", frozenset(...))   — best-3rd-placer from any of the
+#   ("group_winner", "<letter>")    : 1st place in that group
+#   ("group_runner_up", "<letter>") : 2nd place in that group
+#   ("best_third", frozenset(...))  : best-3rd-placer from any of the
 #                                      listed groups (FIFA Annex C
 #                                      constraint preventing same-group
 #                                      LAST_32 rematches)
@@ -1460,7 +1460,7 @@ class GroupStageSoccerSource(SoccerSource):
     Each tournament has N parallel groups of 4 teams, each playing 6
     games (each team plays 3 games). `terminal_outcomes` classifies
     each team as `"advance"` (top 2 in its group) or `"eliminated"`.
-    Outcome labels are intentionally hardcoded — the group-stage
+    Outcome labels are intentionally hardcoded: the group-stage
     classification ("did I finish top-2 in MY group") doesn't fit the
     flat-position-threshold shape that league sources use, so we bypass
     LEAGUE_CONTEXTS.thresholds' cutoff field and provide our own
@@ -1468,7 +1468,7 @@ class GroupStageSoccerSource(SoccerSource):
 
     Cross-source `feeds_from` to KnockoutSoccerSource (a group winner
     structurally faces a different LAST_16 opponent than a runner-up)
-    is NOT modeled — the simulator doesn't currently support cross-
+    is NOT modeled: the simulator doesn't currently support cross-
     source advancement chains. The two sources run independently, so
     group-stage leverage covers the advance/eliminate decision only,
     not the downstream knockout-path differential. Tracked in #53.
@@ -1485,7 +1485,7 @@ class GroupStageSoccerSource(SoccerSource):
     # ---------- fetch_upcoming: filter to GROUP_STAGE ----------
 
     def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
-        """Only emit group-stage fixtures — knockout fixtures are owned
+        """Only emit group-stage fixtures: knockout fixtures are owned
         by the sibling KnockoutSoccerSource for the same competition.
 
         Remaps `extra.fd_competition_code` from the base "WC" / "EC"
@@ -1575,7 +1575,7 @@ class GroupStageSoccerSource(SoccerSource):
             if not home or not away or fd_id is None:
                 continue
             if home not in state or away not in state:
-                continue  # defensive — team_group_map should have covered them
+                continue  # defensive: team_group_map should have covered them
             applied.append(fd_id)
             self._mutate_apply(state, home, away, int(hg), int(ag))
         state["_applied"] = frozenset(applied)
@@ -1723,7 +1723,7 @@ class GroupStageSoccerSource(SoccerSource):
 
         Two cases where None is returned:
           1. No paired knockout source was registered (not a tournament
-             with a follow-on bracket — most competitions).
+             with a follow-on bracket: most competitions).
           2. The knockout source's `_fetch_bracket_games()` returned
              non-empty, meaning FD.org has populated the bracket with
              real team names (the group stage has ended and FIFA's
@@ -1820,7 +1820,7 @@ class GroupStageSoccerSource(SoccerSource):
         # reserved slots. Greedy fails on cases where the strongest-
         # first pick locks out a later slot (e.g., the {ABCDEFGH}
         # qualification set has only 3 candidates for M82's {A,E,H,I,J}
-        # slot — if A, E, and H are all consumed by earlier slots,
+        # slot: if A, E, and H are all consumed by earlier slots,
         # M82 stalls). Backtracking DFS tries each slot in canonical
         # order, attempts each unassigned 3rd-placer whose group is
         # allowed (strongest-first to preserve the FIFA tiebreaker

--- a/sources/wnba.py
+++ b/sources/wnba.py
@@ -1,14 +1,14 @@
-"""WNBA source — ESPN's unofficial `site.api.espn.com` API. No key required.
+"""WNBA source: ESPN's unofficial `site.api.espn.com` API. No key required.
 
 Two source classes mirroring the NBA pattern, with WNBA-specific
 adjustments:
 
   - `WnbaRegularSource(PointsBasedSportSource)`: 40-game regular season,
     raw wins as the threshold field. LEAGUE_CONTEXTS["WNBA"] thresholds
-    at 20 (playoff bubble — 8 of 13 teams make playoffs) / 25
+    at 20 (playoff bubble: 8 of 13 teams make playoffs) / 25
     (comfortable) / 30 (top-seed pace) / 35 (elite).
   - `WnbaPlayoffSource(BestOfNSeriesSource)`: variable series lengths
-    via `_series_length_for_stage` — R1 best-of-3, Semifinals best-of-5,
+    via `_series_length_for_stage`: R1 best-of-3, Semifinals best-of-5,
     Finals best-of-5 (≤2024) or best-of-7 (≥2025 when the WNBA expanded
     the championship series). The stage labels are R1 / SF / FINALS;
     cross-conference seeding (no East/West split in the playoffs since
@@ -103,7 +103,7 @@ def _default_season_year() -> int:
 
 
 # Headline parser. WNBA exposes playoff stage in `competition.notes[0].
-# headline`. Unlike NBA, there's no East/West prefix — the league
+# headline`. Unlike NBA, there's no East/West prefix: the league
 # uses cross-conference reseeding since 2022.
 _HEADLINE_RE = re.compile(
     r"^(?:(?P<round>First\s+Round)|WNBA\s+(?P<wnba>Semifinals|Finals))\s*-\s*Game\s+(?P<game>\d+)",

--- a/tests/test_llm_descriptions.py
+++ b/tests/test_llm_descriptions.py
@@ -90,7 +90,7 @@ class TestBuildLlmContext:
         assert "Tottenham Hotspur FC" in ctx
         assert "Everton FC" in ctx
         assert "Today 11:00 AM EDT" in ctx
-        # Away listed first, "at" home — broadcast convention.
+        # Away listed first, "at" home: broadcast convention.
         assert "Everton FC at Tottenham Hotspur FC" in ctx
 
     def test_includes_competition_and_matchday(self):

--- a/tests/test_logos.py
+++ b/tests/test_logos.py
@@ -1,6 +1,6 @@
 """Tests for the SportsDB matchup-thumbnail resolver (logos.py).
 
-Network-dependent paths are exercised via monkey-patched urlopen — no live
+Network-dependent paths are exercised via monkey-patched urlopen: no live
 HTTP. The cache-file and stale-sweep paths use tmp_path fixtures.
 """
 from __future__ import annotations
@@ -136,7 +136,7 @@ class TestHintMatches:
 
     def test_mismatch_rejected(self):
         ev = {"strLeague": "NCAA Division I Basketball Mens", "strSport": "Basketball"}
-        # CFB hint requires "NCAA" in league — basketball league DOES contain
+        # CFB hint requires "NCAA" in league: basketball league DOES contain
         # "NCAA", so it would pass. The date filter is the real discriminator.
         # Use a non-NCAA league to confirm rejection.
         ev2 = {"strLeague": "MLB", "strSport": "Baseball"}
@@ -211,7 +211,7 @@ class TestResolveThumbUrl:
         assert url == "https://r2.thesportsdb.com/images/media/event/thumb/foo.jpg"
 
     def test_date_mismatch_rejected(self, monkeypatch):
-        # SportsDB returns a match for a different date — the date filter
+        # SportsDB returns a match for a different date: the date filter
         # rejects it so we don't grab the wrong leg of a season series.
         payload = {"event": [{
             "dateEvent": "2024-12-15",  # 17 months off

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,4 +1,4 @@
-"""Tests for matcher.py — pure-logic helpers (no Anthropic, no Django)."""
+"""Tests for matcher.py: pure-logic helpers (no Anthropic, no Django)."""
 
 from datetime import datetime, timezone
 
@@ -27,7 +27,7 @@ class TestTeamKeywords:
 
     def test_state_suffix_skipped(self):
         kws = _team_keywords("Penn State")
-        # "State" is too generic — must be excluded so we don't false-match
+        # "State" is too generic: must be excluded so we don't false-match
         # any other "Foo State" team.
         assert "State" not in kws
         assert "Penn State" in kws
@@ -53,7 +53,7 @@ class TestTeamKeywords:
         kws = _team_keywords("Manchester United FC")
         assert "Manchester United" in kws
         assert "Manchester United FC" in kws
-        # 'United' alone is suppressed as a generic — see
+        # 'United' alone is suppressed as a generic: see
         # test_generic_soccer_suffix_not_a_keyword.
 
     def test_afc_suffix_stripped(self):
@@ -149,7 +149,7 @@ class TestRegexFilterChannelName:
         )
 
     def test_team_channel_rejected(self):
-        # 'Manchester United' channel does NOT contain 'Brentford' — reject.
+        # 'Manchester United' channel does NOT contain 'Brentford': reject.
         cands = [self._cand("Manchester United")]
         out = _regex_filter_channel_name(cands, "Manchester United FC", "Brentford FC")
         assert out == []
@@ -160,7 +160,7 @@ class TestRegexFilterChannelName:
         assert len(out) == 1
 
     def test_returns_all_provider_variants(self):
-        # Same fixture across multiple provider channels — all returned for
+        # Same fixture across multiple provider channels: all returned for
         # the caller to stack as fallback streams.
         cands = [
             self._cand("EPL01: Manchester United 20:00 Brentford 27/04", 100),
@@ -247,7 +247,7 @@ class TestTeamAliases:
         assert "united" not in kws_lower
 
     def test_manchester_united_fc_form_also_aliased(self):
-        # FD.org returns 'Manchester United FC' — alias key is the
+        # FD.org returns 'Manchester United FC': alias key is the
         # FC-stripped form, but lookup tries both.
         from dispatcharr_ranked_matchups.matcher import _team_keywords
         kws = _team_keywords("Manchester United FC")

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -17,7 +17,7 @@ PKG_NAME = os.path.basename(REPO_ROOT)
 
 def _load_plugin_module():
     """Load `plugin.py` as a submodule of the (already-stub-registered)
-    package. Need to stub the Django imports it does at top-level too — but
+    package. Need to stub the Django imports it does at top-level too: but
     actually plugin.py only does Django imports lazily inside functions, so
     top-level load is safe."""
     if f"{PKG_NAME}.plugin" in sys.modules:
@@ -48,7 +48,7 @@ class TestActionRefreshClearsFdCaches:
     """The FD.org batching refactor pins module-level caches into
     `sources/soccer.py` and relies on `_action_refresh` to wipe them at
     the top of every refresh. Without the wipe, a long-running plugin
-    instance serves stale fixtures on the second and later refreshes —
+    instance serves stale fixtures on the second and later refreshes:
     silent staleness, no error.
 
     This integration test asserts the contract directly: pre-populate
@@ -81,12 +81,12 @@ class TestActionRefreshClearsFdCaches:
 
         # Both caches must be wiped.
         assert soccer._TIER_FIXTURES_CACHE is None, (
-            "_action_refresh did not call _clear_fd_caches() — tier "
+            "_action_refresh did not call _clear_fd_caches(): tier "
             "fixtures cache survived the refresh boundary, which would "
             "cause stale FD.org data on every refresh after the first."
         )
         assert "SENTINEL" not in soccer._SEASON_MATCHES_CACHE, (
-            "_action_refresh did not call _clear_fd_caches() — season "
+            "_action_refresh did not call _clear_fd_caches(): season "
             "matches cache survived the refresh boundary."
         )
 
@@ -112,7 +112,7 @@ class TestActionRefreshClearsFdCaches:
 
         plugin._action_refresh({"lookahead_days": 7})
         assert order == ["clear", "build_sources"], (
-            f"unexpected order: {order} — cache clear must fire BEFORE "
+            f"unexpected order: {order}: cache clear must fire BEFORE "
             "source building so the first source's fetch sees fresh data"
         )
 
@@ -208,7 +208,7 @@ class TestBuildWeights:
         # [0, 1] coinflip-ness measure (devigged bookmaker probabilities
         # for soccer; spread normalized for NCAAF / NCAAM). Default
         # bumped 0.1 → 3.0 because the underlying range shrank from
-        # [0, 7] to [0, 1] — same per-game magnitude (~3 raw for a
+        # [0, 7] to [0, 1]: same per-game magnitude (~3 raw for a
         # pick'em) preserved across the formula change.
         assert w.spread == 3.0
         # favorite is bumped to 6.0 to push favorite-involved games up
@@ -237,7 +237,7 @@ class TestBuildWeights:
         # Phase A tuning: _build_weights had hardcoded fallback values
         # that drifted from scoring.Weights's dataclass defaults. When
         # the dataclass was bumped, runtime kept the old values until a
-        # test caught it. This test pins them together — any future
+        # test caught it. This test pins them together: any future
         # divergence here will fail loudly on every commit.
         from dispatcharr_ranked_matchups.scoring import Weights
         defaults = Weights()
@@ -262,7 +262,7 @@ class TestBuildWeights:
             "weight_rank": 1.0,
         })
         assert w.rank == 1.0
-        # Stale keys silently dropped — no AttributeError, no surprise
+        # Stale keys silently dropped: no AttributeError, no surprise
         # contribution.
         assert not hasattr(w, "stakes")
         assert not hasattr(w, "impact_favorite")
@@ -343,7 +343,7 @@ class TestResolveKey:
 class TestBuildSignalsScoreFromPayload:
     def test_legacy_payload_without_score_raw(self, plugin):
         # Old caches don't have score_raw; we fall back to summing the
-        # breakdown (same scale as raw) — NOT to `score` (which is 0-10 scale).
+        # breakdown (same scale as raw): NOT to `score` (which is 0-10 scale).
         g = {
             "score": 7.6,
             "score_breakdown": {"rank_pair": 5.0, "favorite": 4.0},
@@ -554,7 +554,7 @@ class TestStreamSortKey:
     failed probe (0x0 resolution) must sort last regardless of name."""
 
     def test_valid_probe_beats_name_keyword(self, plugin):
-        # Probed 720p vs name-only "Sport UHD" — probed wins.
+        # Probed 720p vs name-only "Sport UHD": probed wins.
         probed_720 = plugin._stream_sort_key(
             {"width": 1280, "height": 720, "resolution": "1280x720"},
             "ESPN",
@@ -631,7 +631,7 @@ class TestEpgSourceConfig:
     """Regression: source_type='dummy' triggers Dispatcharr's joke-filler EPG
     overlay (Rush Hour, What's For Dinner?, etc.) on top of our real
     ProgramData. The constants must NEVER drift back to dummy. See
-    EPGGridAPIView in apps/epg/api_views.py — it filters on
+    EPGGridAPIView in apps/epg/api_views.py: it filters on
     epg_data__epg_source__source_type='dummy' to decide which channels need
     on-the-fly placeholder text generation."""
 
@@ -643,7 +643,7 @@ class TestEpgSourceConfig:
         assert plugin.EPG_SOURCE_TYPE == "xmltv"
 
     def test_source_is_inactive(self, plugin):
-        # is_active=False so the EPG refresh task skips us — we have no URL
+        # is_active=False so the EPG refresh task skips us: we have no URL
         # to fetch, and we write ProgramData ourselves on apply.
         assert plugin.EPG_SOURCE_IS_ACTIVE is False
 
@@ -689,7 +689,7 @@ class TestPluginKey:
         #
         # This test reads plugin.py source directly and refuses the
         # exact failing pattern. Format-fragile by design: if the line
-        # is reflowed across lines, the assertion needs updating —
+        # is reflowed across lines, the assertion needs updating:
         # which is a feature, not a bug. Forces a re-think.
         src = open(plugin.__file__).read()
         assert "PLUGIN_KEY = __package__" not in src, (
@@ -705,7 +705,7 @@ class TestPluginKey:
         # right or wrong; it had to do with __package__ resolving to
         # Dispatcharr's wrapper namespace at runtime. In pytest's
         # importlib setup, __package__ is the conftest stub, which is
-        # already correct by accident — so the other PLUGIN_KEY tests
+        # already correct by accident: so the other PLUGIN_KEY tests
         # would have passed even on the broken `PLUGIN_KEY = __package__`
         # code. This test reproduces the loader-wrap scenario directly:
         # write a tiny plugin.py-equivalent into tmp_path with the
@@ -761,7 +761,7 @@ class TestOwnedTvgIdQ:
     orphan EPGSources visible in the UI with status='error'.
 
     The function builds Django Q objects with lazy import (do NOT
-    hoist `from django.db.models import Q` to module level — the test
+    hoist `from django.db.models import Q` to module level: the test
     suite relies on plugin.py keeping Django imports inside function
     bodies; see tests/conftest.py)."""
 
@@ -854,7 +854,7 @@ class TestBuildDescription:
 
     Six blocks, joined by blank lines:
       1. Placeholder note (when placeholder=True).
-      2. Headline: "A/An {tagline} — {spread_desc}." (each piece optional).
+      2. Headline: "A/An {tagline}: {spread_desc}." (each piece optional).
       3. Matchday + league boundary summary.
       4. Favorite-impact narratives.
       5. Favorite-is-playing line ("X is your favorite." / "Your favorites: ...").
@@ -877,7 +877,7 @@ class TestBuildDescription:
 
     def test_placeholder_note_appears_first(self, plugin):
         out = plugin._build_description(self._g(), "", placeholder=True)
-        # Leading underscore = markdown italic — the renderer relies on
+        # Leading underscore = markdown italic: the renderer relies on
         # the placeholder note being italic, not plain text.
         assert out.startswith("_Channel match pending")
         assert "next refresh" in out
@@ -912,7 +912,7 @@ class TestBuildDescription:
     def test_headline_with_closeness_toss_up(self, plugin):
         # closeness >= 0.7 → "toss-up". Em-dash separates the two parts.
         out = plugin._build_description(self._g(closeness=0.8), "title race", False)
-        assert "A title race — toss-up." in out
+        assert "A title race: toss-up." in out
 
     def test_headline_with_only_spread_no_tagline(self, plugin):
         # spread alone (no tagline) still produces a headline line
@@ -923,7 +923,7 @@ class TestBuildDescription:
 
     def test_headline_terminates_with_period(self, plugin):
         out = plugin._build_description(self._g(), "title race", False)
-        # The period is intentional — without it, EPG clients sometimes
+        # The period is intentional: without it, EPG clients sometimes
         # run the headline into the following block.
         assert out.split("\n\n", 1)[0].endswith(".")
 
@@ -1053,7 +1053,7 @@ class TestBuildDescription:
             channel_name_current="ESPN",
         )
         out = plugin._build_description(g, "title race", placeholder=True)
-        # Use .find() to pin order — earlier marker must have lower index.
+        # Use .find() to pin order: earlier marker must have lower index.
         pos_placeholder = out.find("Channel match pending")
         pos_headline = out.find("A title race")
         pos_matchday = out.find("Matchday 5")
@@ -1077,7 +1077,7 @@ class TestFormatMatchup:
 
     def test_no_star_prefix(self, plugin):
         # The matchup string explicitly omits the ★ score prefix that the
-        # channel name carries — the EPG title should read like a real
+        # channel name carries: the EPG title should read like a real
         # program guide entry, not a debug breadcrumb.
         result = plugin._format_matchup("Auburn", "Vanderbilt")
         assert "★" not in result
@@ -1092,7 +1092,7 @@ class TestBuildProgramTitle:
         assert title == "Upcoming: Auburn vs Vanderbilt, Fri 7:30 PM EDT"
 
     def test_upcoming_without_kickoff_omits_separator(self, plugin):
-        # Empty kickoff_local string falls back to just the matchup —
+        # Empty kickoff_local string falls back to just the matchup:
         # no trailing comma.
         title = plugin._build_program_title("upcoming", "Auburn vs Vanderbilt", "")
         assert title == "Upcoming: Auburn vs Vanderbilt"
@@ -1114,7 +1114,7 @@ class TestBuildProgramTitle:
             plugin._build_program_title("inplay", "Auburn vs Vanderbilt", "")
 
     def test_truncation_at_255_chars(self, plugin):
-        # ProgramData.title is varchar(255) — anything longer gets
+        # ProgramData.title is varchar(255): anything longer gets
         # truncated with ellipsis. The Upcoming prefix + matchup + a
         # very long team name combo must not blow the column.
         long_team = "A" * 300
@@ -1256,7 +1256,7 @@ class TestCurationPresets:
         assert w.favorite == 4.0
 
     def test_balanced_preset_matches_default_weights(self, plugin):
-        # Balanced preset == scoring.Weights() defaults — DRY check that
+        # Balanced preset == scoring.Weights() defaults: DRY check that
         # prevents the preset drifting silently as defaults change.
         from dispatcharr_ranked_matchups.scoring import Weights
         d = Weights()
@@ -1294,7 +1294,7 @@ class TestCurationPresets:
         }) == 7
 
     def test_resolve_max_games_preset_wins(self, plugin):
-        # User set max_games=999 but picked high_curation — preset wins.
+        # User set max_games=999 but picked high_curation: preset wins.
         assert plugin._resolve_max_games({
             "curation_preset": "high_curation", "max_games": 999,
         }) == 10
@@ -1326,17 +1326,17 @@ class TestIsCatchupMatchday:
         assert plugin._is_catchup_matchday(g) is False
 
     def test_current_matchday_is_not_catchup(self, plugin):
-        # League at MD46, fixture at MD46 — normal final round.
+        # League at MD46, fixture at MD46: normal final round.
         g = {"extra": {"matchday": 46, "standings_table": self._table(46)}}
         assert plugin._is_catchup_matchday(g) is False
 
     def test_one_behind_is_not_catchup(self, plugin):
-        # League at MD46, fixture at MD45 — normal weekly lag (midweek game).
+        # League at MD46, fixture at MD45: normal weekly lag (midweek game).
         g = {"extra": {"matchday": 45, "standings_table": self._table(46)}}
         assert plugin._is_catchup_matchday(g) is False
 
     def test_two_behind_is_catchup(self, plugin):
-        # League at MD46, fixture at MD44 — postponed by 2 weeks.
+        # League at MD46, fixture at MD44: postponed by 2 weeks.
         g = {"extra": {"matchday": 44, "standings_table": self._table(46)}}
         assert plugin._is_catchup_matchday(g) is True
 
@@ -1356,7 +1356,7 @@ class TestIsCatchupMatchday:
         assert plugin._is_catchup_matchday(g) is False
 
     def test_partial_played_uses_what_we_have(self, plugin):
-        # Some entries have 'played', some don't — use the ones that do.
+        # Some entries have 'played', some don't: use the ones that do.
         table = [
             {"name": "A", "position": 1, "points": 70, "played": 46},
             {"name": "B", "position": 2, "points": 69},  # missing
@@ -1431,7 +1431,7 @@ class TestOrdinal:
 
 class TestBuildStandingsPostureLine:
     def _table(self):
-        # Minimal EPL-shaped table — 3 teams enough to exercise the path.
+        # Minimal EPL-shaped table: 3 teams enough to exercise the path.
         return [
             {"name": "Manchester City FC", "position": 2, "points": 70, "played": 35},
             {"name": "Manchester United FC", "position": 3, "points": 69, "played": 35},
@@ -1457,7 +1457,7 @@ class TestBuildStandingsPostureLine:
             "extra": {"standings_table": self._table()},
         }
         line = plugin._build_standings_posture_line(g)
-        assert line == "Manchester City FC 2nd, 70 pts. Manchester United FC 3rd, 69 pts — 1 pt behind."
+        assert line == "Manchester City FC 2nd, 70 pts. Manchester United FC 3rd, 69 pts: 1 pt behind."
 
     def test_both_teams_wide_gap(self, plugin):
         g = {
@@ -1466,7 +1466,7 @@ class TestBuildStandingsPostureLine:
             "extra": {"standings_table": self._table()},
         }
         line = plugin._build_standings_posture_line(g)
-        assert line == "Manchester City FC 2nd, 70 pts. Bournemouth FC 14th, 41 pts — 29 pts behind."
+        assert line == "Manchester City FC 2nd, 70 pts. Bournemouth FC 14th, 41 pts: 29 pts behind."
 
     def test_away_team_ahead(self, plugin):
         # When home team is lower-ranked, away team's gap reads "ahead".
@@ -1476,7 +1476,7 @@ class TestBuildStandingsPostureLine:
             "extra": {"standings_table": self._table()},
         }
         line = plugin._build_standings_posture_line(g)
-        assert line == "Bournemouth FC 14th, 41 pts. Manchester City FC 2nd, 70 pts — 29 pts ahead."
+        assert line == "Bournemouth FC 14th, 41 pts. Manchester City FC 2nd, 70 pts: 29 pts ahead."
 
     def test_tied_on_points_no_gd_cached(self, plugin):
         # Older caches (pre-#10) won't have goal_difference; fall back to
@@ -1487,27 +1487,27 @@ class TestBuildStandingsPostureLine:
         ]
         g = {"home": "A FC", "away": "B FC", "extra": {"standings_table": table}}
         line = plugin._build_standings_posture_line(g)
-        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts — level on points."
+        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts: level on points."
 
     def test_tied_on_points_away_gd_better(self, plugin):
-        # B has the better GD — reads "... GD ahead" for the away team.
+        # B has the better GD: reads "... GD ahead" for the away team.
         table = [
             {"name": "A FC", "position": 1, "points": 70, "played": 35, "goal_difference": 15},
             {"name": "B FC", "position": 2, "points": 70, "played": 35, "goal_difference": 22},
         ]
         g = {"home": "A FC", "away": "B FC", "extra": {"standings_table": table}}
         line = plugin._build_standings_posture_line(g)
-        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts — level on points, 7 GD ahead."
+        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts: level on points, 7 GD ahead."
 
     def test_tied_on_points_home_gd_better(self, plugin):
-        # A (home) has better GD — away reads "behind on GD".
+        # A (home) has better GD: away reads "behind on GD".
         table = [
             {"name": "A FC", "position": 1, "points": 70, "played": 35, "goal_difference": 22},
             {"name": "B FC", "position": 2, "points": 70, "played": 35, "goal_difference": 15},
         ]
         g = {"home": "A FC", "away": "B FC", "extra": {"standings_table": table}}
         line = plugin._build_standings_posture_line(g)
-        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts — level on points, 7 GD behind."
+        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts: level on points, 7 GD behind."
 
     def test_tied_on_everything(self, plugin):
         table = [
@@ -1516,7 +1516,7 @@ class TestBuildStandingsPostureLine:
         ]
         g = {"home": "A FC", "away": "B FC", "extra": {"standings_table": table}}
         line = plugin._build_standings_posture_line(g)
-        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts — level on points and goal difference."
+        assert line == "A FC 1st, 70 pts. B FC 2nd, 70 pts: level on points and goal difference."
 
     def test_one_pt_uses_singular(self, plugin):
         # 1 → "1 pt", not "1 pts".
@@ -1694,7 +1694,7 @@ class TestPluginStopTeardown:
                 spawned.append(kw.get("name") or "<unnamed>")
                 super().__init__(*a, **kw)
             def start(self):
-                # Don't actually start — we don't want a live thread
+                # Don't actually start: we don't want a live thread
                 # touching DB / FD in tests.
                 pass
 
@@ -1712,7 +1712,7 @@ class TestPluginStopTeardown:
             inst1.stop()
             inst2 = plugin.Plugin()
 
-            # Second spawn happened — no skipped instantiation.
+            # Second spawn happened: no skipped instantiation.
             assert len(spawned) == 2
         finally:
             plugin._scheduler_thread = saved_thread
@@ -1723,14 +1723,14 @@ class TestDedupSeriesGames:
     """Best-of-N playoff series sources (NHL / NBA / MLB / NCAA tournaments)
     return every scheduled series game from fetch_upcoming. Without
     dedup, a Carolina vs Montreal best-of-7 becomes 4-7 redundant
-    virtual channels — same matchup, different dates. The user-facing
+    virtual channels: same matchup, different dates. The user-facing
     fix Jake hit live on 2026-05-26: keep ONLY the chronologically
     earliest game per (sport_prefix, team-pair) key; let the next
     refresh after the game finishes promote the subsequent series
     game.
 
     The dedup MUST key on `frozenset({home, away})` not `(home, away)`
-    — NHL playoff games 2 and 4 swap home-ice (the lower-seed gets
+   : NHL playoff games 2 and 4 swap home-ice (the lower-seed gets
     "Carolina at Montreal" alternating with "Montreal at Carolina"),
     and a strict ordered key would treat them as distinct.
     """
@@ -1777,7 +1777,7 @@ class TestDedupSeriesGames:
         assert len(out_g) == 1
         # The earliest survives.
         assert out_g[0].start_time.day == 27
-        # The corresponding source survives too — parallel index preserved.
+        # The corresponding source survives too: parallel index preserved.
         assert out_s == ["s1"]
 
     def test_home_ice_swap_treated_as_same_series(self, plugin):
@@ -1792,7 +1792,7 @@ class TestDedupSeriesGames:
         out_g, out_s, n = plugin._dedup_series_games(games, ["a", "b"])
         assert n == 1
         assert len(out_g) == 1
-        # The May 28 game (with Montreal at Carolina) survives — earlier.
+        # The May 28 game (with Montreal at Carolina) survives: earlier.
         assert out_g[0].home == "Montreal"
         assert out_g[0].away == "Carolina"
 

--- a/tests/test_rivalries.py
+++ b/tests/test_rivalries.py
@@ -43,7 +43,7 @@ class TestIsRivalry:
         assert rivalries.is_rivalry("Liverpool FC", "Manchester United FC", "EPL")
 
     def test_order_independent(self):
-        # Same pair, swapped — should still match.
+        # Same pair, swapped: should still match.
         assert rivalries.is_rivalry("Manchester United FC", "Liverpool FC", "EPL")
 
     def test_case_insensitive(self):
@@ -79,13 +79,13 @@ class TestIsRivalry:
         assert rivalries.is_rivalry("New York Yankees", "Boston Red Sox", "MLB")
 
     def test_la_classico_either_name(self):
-        # Real Madrid vs Barcelona — full names + abbreviations.
+        # Real Madrid vs Barcelona: full names + abbreviations.
         assert rivalries.is_rivalry("Real Madrid", "Barcelona", "LaLiga")
         assert rivalries.is_rivalry("Real Madrid CF", "FC Barcelona", "LaLiga")
 
     def test_paris_sg_abbreviation(self):
         # SportsDB returns "Paris SG"; FD.org returns "Paris Saint-Germain FC".
-        # JSON has both forms — both should match Marseille.
+        # JSON has both forms: both should match Marseille.
         assert rivalries.is_rivalry("Paris SG", "Olympique de Marseille", "Ligue1")
         assert rivalries.is_rivalry("Paris Saint-Germain FC", "Marseille", "Ligue1")
 
@@ -94,7 +94,7 @@ class TestIsRivalry:
         assert not rivalries.is_rivalry("Liverpool FC", "Manchester United FC", "MLS")
 
     def test_handles_one_word_team_name_substring(self):
-        # NCAA Football "Texas vs Oklahoma" — bare 1-word names. Both
+        # NCAA Football "Texas vs Oklahoma": bare 1-word names. Both
         # appear in many other team names ("UT-Austin Texas Longhorns"),
         # but the JSON entries are exact-bare so they only match teams
         # whose name actually contains "Texas".

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -20,7 +20,7 @@ from dispatcharr_ranked_matchups.scoring import (
 
 
 class TestCompressTo10:
-    """Anchor values from the docstring — if these drift, the score everyone
+    """Anchor values from the docstring: if these drift, the score everyone
     sees in the UI shifts. Pin them."""
 
     def test_zero_or_negative(self):
@@ -40,7 +40,7 @@ class TestCompressTo10:
         assert round(_compress_to_10(32), 2) == 9.64
 
     def test_asymptotes_at_10_for_large_input(self):
-        # tanh saturates to 1.0 in float64 well before raw=1000 — that's
+        # tanh saturates to 1.0 in float64 well before raw=1000: that's
         # fine; the score is "10/10" in display either way.
         assert _compress_to_10(100) <= 10.0
         assert _compress_to_10(1000) <= 10.0
@@ -54,16 +54,16 @@ class TestMatchFavorites:
 
     def test_word_boundary_blocks_substring(self):
         # "Hull" must NOT match "Hull City" if we're searching for "Hull"
-        # actually it should — "Hull City" has "City" as a TEAM_QUALIFIER_TOKEN
+        # actually it should: "Hull City" has "City" as a TEAM_QUALIFIER_TOKEN
         assert match_favorites("Hull City AFC", "QPR", ["Hull"]) == ["Hull"]
 
     def test_qualifier_required_after_partial(self):
         # "UNC" should NOT match "UNC Pembroke" because Pembroke isn't a
-        # qualifier token — it's a different school.
+        # qualifier token: it's a different school.
         assert match_favorites("UNC Pembroke", "Wofford", ["UNC"]) == []
 
     def test_qualifier_required_for_compound_name(self):
-        # "North Carolina" inside "North Carolina A&T" — A&T is the second
+        # "North Carolina" inside "North Carolina A&T": A&T is the second
         # word, "&" is a qualifier token, so this matches A&T as the
         # trailing capitalized word's first char.
         # (Documenting actual behavior: "A&T" starts with "A", a single
@@ -193,7 +193,7 @@ class TestScoreGameCloseness:
         assert s.breakdown["close_game"] == 1.5
 
     def test_closeness_note_distinguishes_from_spread_path(self):
-        # The note format reveals which path fired — closeness path says
+        # The note format reveals which path fired: closeness path says
         # "implied coinflip-ness", spread path says "betting spread".
         sig = GameSignals(closeness=0.8)
         s = score_game(sig, Weights())
@@ -277,7 +277,7 @@ class TestStripTeamSuffix:
 
     def test_keeps_compound_when_not_suffix(self):
         # "City" is a qualifier (Hull City is its own team), not a strippable
-        # club-tag — must NOT be stripped.
+        # club-tag: must NOT be stripped.
         assert strip_team_suffix("Hull City") == "Hull City"
 
     def test_strips_only_trailing(self):
@@ -381,7 +381,7 @@ class TestBuildImpactNarratives:
             ],
         )
         assert len(narratives) == 1
-        # Man United is closer (1 spot away) — narrative should reference it
+        # Man United is closer (1 spot away): narrative should reference it
         assert "Manchester United" in narratives[0]
         assert "Brentford" not in narratives[0]
 
@@ -434,7 +434,7 @@ class TestPickTagline:
 
     def test_standings_rank_pair_dropped(self):
         # For league standings (every team is "ranked"), rank-pair tagline
-        # must be dropped — it's noise. Should fall through to other signals.
+        # must be dropped: it's noise. Should fall through to other signals.
         tag = pick_tagline(
             score_breakdown={"rank_pair": 5.0},
             favorites_matched=[],
@@ -521,7 +521,7 @@ class _FakeMatch:
 class _FakeImportanceSource:
     """A SportSource stand-in that returns deterministic per-(team, label)
     leverages. Lets compute_match_importance be tested without running the
-    actual Monte Carlo simulator — that's tested separately in
+    actual Monte Carlo simulator: that's tested separately in
     test_simulation.py.
     """
     def __init__(self, leverages):
@@ -531,7 +531,7 @@ class _FakeImportanceSource:
 
     def __getattr__(self, name):
         # Other SportSource methods are unused on the compute_match_importance
-        # path (which delegates straight to monte_carlo_importance_batch — we
+        # path (which delegates straight to monte_carlo_importance_batch: we
         # monkeypatch the simulator below for tests).
         raise AttributeError(name)
 
@@ -640,7 +640,7 @@ class TestComputeMatchImportance:
 
     def test_locked_outcomes_contribute_zero(self, monkeypatch):
         """When the simulator returns leverage=0 for every (team, outcome)
-        — i.e., locked seasons — the raw points are 0 and there are no notes.
+       : i.e., locked seasons: the raw points are 0 and there are no notes.
         This is the structural fix Phase C delivers: mathematically locked
         teams stop polluting the importance signal.
         """
@@ -717,7 +717,7 @@ class TestComputeMatchImportanceChainRouting:
     ):
         # Patch BOTH simulator entry points. Confirm the chain function
         # fires (not the regular batch) AND that the queries passed in
-        # include the downstream-cascade labels — otherwise WC_GS
+        # include the downstream-cascade labels: otherwise WC_GS
         # could silently drop the cascade labels and this routing test
         # would still pass while production produces 0 contribution
         # on R16+ bands.
@@ -876,7 +876,7 @@ class TestScoreGameImportanceBranch:
         s = GameSignals(rank_a=1, rank_b=2, importance_points=4.0,
                         importance_notes=["X: 0.50 leverage × 5.0 = 2.50"])
         score = score_game(s, Weights(importance=0.0))
-        # weight=0 → zero contribution AND no breakdown entry — same as
+        # weight=0 → zero contribution AND no breakdown entry: same as
         # importance_points=0. Other signals (rank_pair) still fire.
         assert "importance" not in score.breakdown
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -3,7 +3,7 @@
 The simulator (`simulation.monte_carlo_importance`) is tested against an
 in-memory FakeSource that implements the 7-method interface
 deterministically. SoccerSource's implementation is tested separately in
-test_sources.py — this file isolates the simulator from any source-specific
+test_sources.py: this file isolates the simulator from any source-specific
 fetching, so failures here are unambiguously bugs in the algorithm, not in
 HTTP plumbing or strength estimation.
 """
@@ -157,7 +157,7 @@ class FakeSource(SportSource):
 
 
 def _poisson(lam: float, rng: random.Random) -> int:
-    """Same as SoccerSource._poisson — duplicated here to keep the test file
+    """Same as SoccerSource._poisson: duplicated here to keep the test file
     independent of soccer.py's module-private helper."""
     L = math.exp(-lam)
     k = 0
@@ -179,7 +179,7 @@ def _make_round_robin() -> Tuple[FakeSource, GameRow]:
     Match #3 (Alpha vs Delta) is the target match used by most tests.
     For an Alpha-vs-Delta game, Alpha winning strongly increases the
     chance Alpha finishes champion AND that Delta finishes wooden spoon
-    — strong importance signal.
+   : strong importance signal.
     """
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
     teams = ["Alpha", "Beta", "Gamma", "Delta"]
@@ -271,7 +271,7 @@ class TestMonteCarloImportance:
         )
         # Not asserting a tight bound (depends on strength config), but
         # importance for a powerhouse playing the weakest team should be
-        # at least *some* signal — far from zero.
+        # at least *some* signal: far from zero.
         assert imp > 0.05
 
     def test_uninvolved_team_outcome_yields_low_importance(self):
@@ -451,7 +451,7 @@ class TestMonteCarloImportanceBatchChain:
 
     def test_chain_query_for_eliminated_team_returns_low_leverage(self):
         # Querying a downstream outcome that NEVER fires for the team
-        # (e.g., asking about Delta finishing `qualified` — Delta is
+        # (e.g., asking about Delta finishing `qualified`: Delta is
         # the dreadful team and never wins the group) should return
         # near-zero leverage.
         source, target = _make_round_robin()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,4 @@
-"""Sanity tests for the sport adapters. Network isn't called — we just check
+"""Sanity tests for the sport adapters. Network isn't called: we just check
 class-level constants and the shape-handling logic so a typo or refactor
 doesn't ship silently."""
 
@@ -158,13 +158,13 @@ class TestNcaamRankingsShape:
             def json(self):
                 return self._p
 
-        # Mix of week=1 and week=15 entries — we want only week 15.
+        # Mix of week=1 and week=15 entries: we want only week 15.
         payload = [
             {"week": 1,  "pollType": "AP Top 25", "team": "Old #1", "ranking": 1},
             {"week": 1,  "pollType": "AP Top 25", "team": "Old #2", "ranking": 2},
             {"week": 15, "pollType": "AP Top 25", "team": "Latest #1", "ranking": 1},
             {"week": 15, "pollType": "AP Top 25", "team": "Latest #2", "ranking": 2},
-            # Different poll type — should be ignored
+            # Different poll type: should be ignored
             {"week": 15, "pollType": "Coaches Poll", "team": "Other", "ranking": 1},
         ]
         monkeypatch.setattr(ncaam_mod.requests, "get", lambda *a, **kw: FakeResp(payload))
@@ -192,7 +192,7 @@ class TestNcaamRankingsShape:
                 return [{"week": 1, "pollType": "Coaches Poll", "team": "X", "ranking": 1}]
 
         monkeypatch.setattr(ncaam_mod.requests, "get", lambda *a, **kw: FakeResp())
-        # We default to AP Top 25 — Coaches Poll doesn't match.
+        # We default to AP Top 25: Coaches Poll doesn't match.
         assert NcaamSource(api_key="x")._fetch_rankings(2026) is None
 
 
@@ -322,7 +322,7 @@ class TestSoccerCompetitions:
         assert SOCCER_COMPETITIONS["ligue_1"].fd_code == "FL1"
 
     def test_top_flight_leagues_use_position_as_rank(self):
-        # All Big-Five leagues have a real points table — position-as-rank applies.
+        # All Big-Five leagues have a real points table: position-as-rank applies.
         for k in ("bundesliga", "la_liga", "serie_a", "ligue_1"):
             assert SOCCER_COMPETITIONS[k].use_position_as_rank is True
 
@@ -380,7 +380,7 @@ class TestSoccerCompetitions:
         from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
         assert LEAGUE_CONTEXTS["EC"].format == "knockout"
         ec_labels = {label for _cut, label, _w in LEAGUE_CONTEXTS["EC"].thresholds}
-        # EURO is 24-team, enters at LAST_16 — no LAST_32 band.
+        # EURO is 24-team, enters at LAST_16: no LAST_32 band.
         assert "last_32" not in ec_labels
         assert "round_of_16" in ec_labels
         assert "winner" in ec_labels
@@ -401,7 +401,7 @@ class TestSoccerCompetitions:
     def test_last_32_in_knockout_depth(self):
         from dispatcharr_ranked_matchups.scoring import KNOCKOUT_ROUND_DEPTH
         assert "LAST_32" in KNOCKOUT_ROUND_DEPTH
-        # Entry-level (same depth as PLAYOFFS — both are pre-LAST_16).
+        # Entry-level (same depth as PLAYOFFS: both are pre-LAST_16).
         assert KNOCKOUT_ROUND_DEPTH["LAST_32"] == 0
         # Strictly shallower than LAST_16.
         assert KNOCKOUT_ROUND_DEPTH["LAST_32"] < KNOCKOUT_ROUND_DEPTH["LAST_16"]
@@ -505,7 +505,7 @@ class TestH2HToCloseness:
 
     def test_missing_home_returns_none(self):
         # If the bookmaker doesn't list the home team's outcome, we
-        # can't compute closeness — return None instead of guessing.
+        # can't compute closeness: return None instead of guessing.
         outcomes = [
             {"name": "draw",      "price": 4.0},
             {"name": "away_team", "price": 2.0},
@@ -582,7 +582,7 @@ class TestSoccerSeedFromPreviousSeason:
         assert calls[1] is not None  # previous-season year passed
         # Returned table came from the seed, not the current sparse table.
         assert all(r["name"].startswith("Veteran") for r in table)
-        # playedGames reset to 0 — the seed represents a fresh-season prior,
+        # playedGames reset to 0: the seed represents a fresh-season prior,
         # not last year's residual (matches_remaining must be the full new season).
         assert all(r["playedGames"] == 0 for r in table)
         # Positions preserved from the seed table.
@@ -607,7 +607,7 @@ class TestSoccerSeedFromPreviousSeason:
         assert table == current_table
 
     def test_seed_skipped_when_current_table_empty(self):
-        # Empty current table (median computes to 0) — by the rules above,
+        # Empty current table (median computes to 0): by the rules above,
         # 0 < threshold → seed should fire. Verify it does.
         src = self._make_source()
         seed_table = [
@@ -642,37 +642,37 @@ class TestSoccerImportanceInterface:
         """
         base_date = "2026-05-01T12:00:00Z"
         return [
-            {  # FINISHED — A beats B 3-0 at home
+            {  # FINISHED: A beats B 3-0 at home
                 "id": 101, "status": "FINISHED",
                 "homeTeam": {"name": "Team A"}, "awayTeam": {"name": "Team B"},
                 "score": {"fullTime": {"home": 3, "away": 0}},
                 "utcDate": base_date, "matchday": 1,
             },
-            {  # FINISHED — C beats D 2-1 at home
+            {  # FINISHED: C beats D 2-1 at home
                 "id": 102, "status": "FINISHED",
                 "homeTeam": {"name": "Team C"}, "awayTeam": {"name": "Team D"},
                 "score": {"fullTime": {"home": 2, "away": 1}},
                 "utcDate": base_date, "matchday": 1,
             },
-            {  # FINISHED — A beats C 2-0 at home
+            {  # FINISHED: A beats C 2-0 at home
                 "id": 103, "status": "FINISHED",
                 "homeTeam": {"name": "Team A"}, "awayTeam": {"name": "Team C"},
                 "score": {"fullTime": {"home": 2, "away": 0}},
                 "utcDate": base_date, "matchday": 2,
             },
-            {  # SCHEDULED — B vs D
+            {  # SCHEDULED: B vs D
                 "id": 104, "status": "SCHEDULED",
                 "homeTeam": {"name": "Team B"}, "awayTeam": {"name": "Team D"},
                 "score": {"fullTime": {"home": None, "away": None}},
                 "utcDate": base_date, "matchday": 2,
             },
-            {  # SCHEDULED — A vs D (the target match for most tests)
+            {  # SCHEDULED: A vs D (the target match for most tests)
                 "id": 105, "status": "SCHEDULED",
                 "homeTeam": {"name": "Team A"}, "awayTeam": {"name": "Team D"},
                 "score": {"fullTime": {"home": None, "away": None}},
                 "utcDate": base_date, "matchday": 3,
             },
-            {  # SCHEDULED — B vs C
+            {  # SCHEDULED: B vs C
                 "id": 106, "status": "SCHEDULED",
                 "homeTeam": {"name": "Team B"}, "awayTeam": {"name": "Team C"},
                 "score": {"fullTime": {"home": None, "away": None}},
@@ -688,7 +688,7 @@ class TestSoccerImportanceInterface:
     # ---------- supports_importance ----------
 
     def test_soccer_source_supports_importance(self):
-        # Class attr — true for ALL SoccerSource instances, regardless of
+        # Class attr: true for ALL SoccerSource instances, regardless of
         # config (UCL etc. will fail at outcome_labels if their fd_code
         # has no LEAGUE_CONTEXTS entry; the caller handles that).
         src = SoccerSource("epl", fd_api_key="fake")
@@ -710,7 +710,7 @@ class TestSoccerImportanceInterface:
         # so we synthesize an unknown fd_code on an existing source to exercise
         # the "ctx is None" branch. The branch must survive so future
         # competitions added to COMPETITIONS without a matching context don't
-        # crash — they silently produce 0 importance.
+        # crash: they silently produce 0 importance.
         src = SoccerSource("epl", fd_api_key="fake")
         monkeypatch.setattr(src.config, "fd_code", "UNKNOWN_COMP")
         assert src.outcome_labels == []
@@ -723,7 +723,7 @@ class TestSoccerImportanceInterface:
         # alive on a no-op-importance fallback. Verifies the guard fires for CL.
         src = SoccerSource("ucl", fd_api_key="fake")  # ucl → fd_code="CL", knockout
         src._all_matches_cache = []  # avoid HTTP
-        # Hand-built minimal state — the guard short-circuits before reading it.
+        # Hand-built minimal state: the guard short-circuits before reading it.
         state = {"_applied": frozenset(), "Some Team": {"played": 0, "points": 0, "gf": 0, "ga": 0}}
         with caplog.at_level("WARNING"):
             out = src.terminal_outcomes(state)
@@ -752,7 +752,7 @@ class TestSoccerImportanceInterface:
         # Mutate the cache to verify the second call returns the cached object.
         src._strengths_cache["MARKER"] = {"sh": 9.9, "ch": 9.9, "sa": 9.9, "ca": 9.9}
         second = src.estimate_strengths()
-        assert "MARKER" in second  # same object — cache hit
+        assert "MARKER" in second  # same object: cache hit
 
     def test_strength_for_unknown_team_returns_defaults(self):
         src = self._make_source()
@@ -791,7 +791,7 @@ class TestSoccerImportanceInterface:
         # Mutate the underlying cache; second call should return same.
         first["MARKER"] = "set"
         second = src.initial_state()
-        assert "MARKER" in second  # same object — cache hit
+        assert "MARKER" in second  # same object: cache hit
 
     # ---------- remaining_matches ----------
 
@@ -908,7 +908,7 @@ class TestSoccerImportanceInterface:
         state["Tied A"] = {"played": 38, "points": 80, "gf": 70, "ga": 50}  # gd=20
         state["Tied B"] = {"played": 38, "points": 80, "gf": 60, "ga": 50}  # gd=10
         # Two stronger fillers (one above each tied team) plus weaker fillers
-        # so Tied A / Tied B land at positions 3 and 4 — straddling the UCL
+        # so Tied A / Tied B land at positions 3 and 4: straddling the UCL
         # cutoff so the GD tiebreak is observable.
         state["Strong 1"] = {"played": 38, "points": 90, "gf": 60, "ga": 30}
         state["Strong 2"] = {"played": 38, "points": 85, "gf": 60, "ga": 35}
@@ -924,7 +924,7 @@ class TestSoccerImportanceInterface:
         assert "title" not in outcomes["Tied B"]
         # GD tiebreak: Tied A should outrank Tied B. The test of that
         # ordering is "Tied B has more outcomes than Tied A only if A is
-        # behind B" — but here both have the same outcomes. Use a second
+        # behind B": but here both have the same outcomes. Use a second
         # state where the cutoff sits between them.
 
     def test_is_bottom_outcome_label_detection(self):
@@ -986,12 +986,12 @@ class TestKnockoutSoccerSource:
         SCHEDULED with no scores.
         """
         if sf_finished:
-            # Tie 1: A vs B — leg1 A 2-0, leg2 B 1-1 → A wins 3-1 aggregate
+            # Tie 1: A vs B: leg1 A 2-0, leg2 B 1-1 → A wins 3-1 aggregate
             sf_leg1_ab = {"home": "A", "away": "B", "home_g": 2, "away_g": 0,
                           "status": "FINISHED", "duration": "REGULAR"}
             sf_leg2_ab = {"home": "B", "away": "A", "home_g": 1, "away_g": 1,
                           "status": "FINISHED", "duration": "REGULAR"}
-            # Tie 2: C vs D — leg1 C 2-0, leg2 D 0-0 → C wins 2-0 aggregate
+            # Tie 2: C vs D: leg1 C 2-0, leg2 D 0-0 → C wins 2-0 aggregate
             sf_leg1_cd = {"home": "C", "away": "D", "home_g": 2, "away_g": 0,
                           "status": "FINISHED", "duration": "REGULAR"}
             sf_leg2_cd = {"home": "D", "away": "C", "home_g": 0, "away_g": 0,
@@ -1014,7 +1014,7 @@ class TestKnockoutSoccerSource:
 
     def _final_match(self, home: str = "A", away: str = "C") -> dict:
         """Final: single leg. By default A vs C (the SF winners in the
-        finished-SF setup). Always SCHEDULED for the test set — the final
+        finished-SF setup). Always SCHEDULED for the test set: the final
         is what the simulator should be predicting.
         """
         return self._fd_match(301, "FINAL", 1, {
@@ -1112,7 +1112,7 @@ class TestKnockoutSoccerSource:
             assert sf_tie["is_entry_tie"] is True
             assert sf_tie["feeds_from"] == {}
         # FINAL: feeds_from for A and C point to their SF ties even though
-        # those SFs are scheduled. is_entry_tie is False — the FINAL is a
+        # those SFs are scheduled. is_entry_tie is False: the FINAL is a
         # downstream tie that blocks until upstream resolves.
         final_tie = bracket["FINAL"][0]
         assert set(final_tie["feeds_from"].keys()) == {"A", "C"}
@@ -1258,7 +1258,7 @@ class TestKnockoutSoccerSource:
         assert {rem[0].home, rem[0].away} == {"A", "C"}
 
     def test_remaining_matches_blocks_downstream_when_feeders_pending(self):
-        """If SFs aren't FINISHED, the FINAL can't be played yet — its
+        """If SFs aren't FINISHED, the FINAL can't be played yet: its
         feeds_from upstreams haven't resolved. remaining = 4 SF legs only."""
         matches = self._semi_finals_matches(sf_finished=False)
         matches.append(self._final_match("A", "C"))
@@ -1273,7 +1273,7 @@ class TestKnockoutSoccerSource:
 
     def test_sample_result_no_et_on_leg_one(self):
         """Leg 1 of a 2-leg tie should never sample ET, even if regulation
-        is tied — the tie is decided over both legs."""
+        is tied: the tie is decided over both legs."""
         matches = self._semi_finals_matches(sf_finished=False)
         src = self._make_source(matches)
         state = src.initial_state()
@@ -1285,7 +1285,7 @@ class TestKnockoutSoccerSource:
                      for t in ("A", "B", "C", "D")}
         rng = random.Random(0)
         result = src.sample_result(state, leg1, strengths, rng)
-        # No ET marker in extra — sample_result returned early for non-decisive leg.
+        # No ET marker in extra: sample_result returned early for non-decisive leg.
         assert "et_goals" not in result.extra
         assert "pen_winner" not in result.extra
 
@@ -1339,7 +1339,7 @@ class TestKnockoutSoccerSource:
         assert state2["_round_reached"]["B"] == KNOCKOUT_ROUND_DEPTH["SEMI_FINALS"]
 
     def test_terminal_outcomes_label_cascade(self):
-        """A team that reached the FINAL should also be labeled SF/QF/R16 —
+        """A team that reached the FINAL should also be labeled SF/QF/R16:
         the deeper round implies all shallower bands."""
         matches = self._semi_finals_matches(sf_finished=True)
         matches.append(self._final_match("A", "C"))
@@ -1360,12 +1360,12 @@ class TestKnockoutSoccerSource:
 
     def test_monte_carlo_winner_importance_is_high_on_final(self, monkeypatch):
         """The FINAL is the only match between participants and the WINNER
-        outcome — tau-c should be near 1.0 (deterministic association).
+        outcome: tau-c should be near 1.0 (deterministic association).
         Sanity-checks the full simulator pipeline against a knockout source.
 
         Strengths are monkeypatched to identical symmetric values so the
         marginal W/L distribution is ~50/50 (tau-c is bounded by the
-        marginal balance — extreme W/L imbalance from a 4-finished-match
+        marginal balance: extreme W/L imbalance from a 4-finished-match
         strength estimate would cap tau-c at ~0.5 even with perfect
         outcome correlation). The algorithm is what's under test, not the
         strength estimator.
@@ -1388,7 +1388,7 @@ class TestKnockoutSoccerSource:
     def test_monte_carlo_already_locked_outcomes_have_zero_importance(self, monkeypatch):
         """A's 'semifinal' label is already true regardless of the FINAL
         result (A reached the final). Importance for that pair should be
-        ~0 — the FINAL doesn't change A's semifinal status."""
+        ~0: the FINAL doesn't change A's semifinal status."""
         from dispatcharr_ranked_matchups.simulation import monte_carlo_importance
         matches = self._semi_finals_matches(sf_finished=True)
         matches.append(self._final_match("A", "C"))
@@ -1408,7 +1408,7 @@ class TestKnockoutSoccerSource:
 
     def test_penalty_shootout_returns_decisive_winner(self):
         """20 shootouts at the same seed should produce both HOME and AWAY
-        winners — penalty resolution is variance-dominated, never the same
+        winners: penalty resolution is variance-dominated, never the same
         outcome every time."""
         outcomes = set()
         for seed in range(30):
@@ -1632,25 +1632,25 @@ class TestNcaafFullSeasonFilter:
                 return self._p
 
         payload = [
-            {  # FBS vs FBS — kept
+            {  # FBS vs FBS: kept
                 "id": 1, "homeClassification": "fbs", "awayClassification": "fbs",
                 "homeTeam": "Michigan", "awayTeam": "Ohio State",
                 "homePoints": 28, "awayPoints": 21, "completed": True,
                 "startDate": "2025-11-29T12:00:00.000Z",
             },
-            {  # FBS vs FCS — kept (cupcake counts toward FBS win total)
+            {  # FBS vs FCS: kept (cupcake counts toward FBS win total)
                 "id": 2, "homeClassification": "fbs", "awayClassification": "fcs",
                 "homeTeam": "Alabama", "awayTeam": "Chattanooga",
                 "homePoints": 56, "awayPoints": 7, "completed": True,
                 "startDate": "2025-09-15T16:00:00.000Z",
             },
-            {  # FCS vs FCS — dropped
+            {  # FCS vs FCS: dropped
                 "id": 3, "homeClassification": "fcs", "awayClassification": "fcs",
                 "homeTeam": "Furman", "awayTeam": "Wofford",
                 "homePoints": 24, "awayPoints": 21, "completed": True,
                 "startDate": "2025-10-01T16:00:00.000Z",
             },
-            {  # SCHEDULED FBS vs FBS — kept, no scores
+            {  # SCHEDULED FBS vs FBS: kept, no scores
                 "id": 4, "homeClassification": "fbs", "awayClassification": "fbs",
                 "homeTeam": "Georgia", "awayTeam": "Texas",
                 "homePoints": None, "awayPoints": None, "completed": False,
@@ -1703,19 +1703,19 @@ class TestNcaamFullSeasonFilter:
         monkeypatch.setattr(src, "_fetch_rankings",
                             lambda _season: {"Duke": 1, "UConn": 2})
         payload = [
-            {  # AP vs AP — kept
+            {  # AP vs AP: kept
                 "id": 101, "homeTeam": "Duke", "awayTeam": "UConn",
                 "homePoints": 78, "awayPoints": 72,
                 "homeWinner": True, "awayWinner": False,
                 "startDate": "2025-12-15T20:00:00.000Z",
             },
-            {  # AP vs non-AP — kept (Duke needs all their games tracked)
+            {  # AP vs non-AP: kept (Duke needs all their games tracked)
                 "id": 102, "homeTeam": "Duke", "awayTeam": "Some Mid-Major",
                 "homePoints": 95, "awayPoints": 60,
                 "homeWinner": True, "awayWinner": False,
                 "startDate": "2025-11-20T20:00:00.000Z",
             },
-            {  # Non-AP vs Non-AP — dropped
+            {  # Non-AP vs Non-AP: dropped
                 "id": 103, "homeTeam": "Random A", "awayTeam": "Random B",
                 "homePoints": 70, "awayPoints": 68,
                 "homeWinner": True, "awayWinner": False,
@@ -1764,7 +1764,7 @@ class TestNcaamFullSeasonFilter:
 
 
 # =====================================================================
-# Phase E: BestOfNSeriesSource — base bracket-state-machine tests
+# Phase E: BestOfNSeriesSource: base bracket-state-machine tests
 # =====================================================================
 
 class TestBestOfNSeriesSource:
@@ -1922,7 +1922,7 @@ class TestBestOfNSeriesSource:
                 (1, 4),  # G3 B-home: A wins  (A: 3, B: 0)
                 (3, 1),  # G4 B-home: B wins  (A: 3, B: 1)
                 (1, 3),  # G5 A-home: B wins  (A: 3, B: 2)
-                (1, 4),  # G6 B-home: A wins  (A: 4, B: 2) — A clinches
+                (1, 4),  # G6 B-home: A wins  (A: 4, B: 2): A clinches
             ],
             series_letter="a",
         )
@@ -2045,12 +2045,12 @@ class TestBestOfNSeriesSource:
         assert "round_2" in outcomes["A"]
         assert "conf_final" not in outcomes["A"]
         assert "cup_final" not in outcomes["A"]
-        # B at depth 0 (R1) — no bands fire (cutoffs all >= 1).
+        # B at depth 0 (R1): no bands fire (cutoffs all >= 1).
         assert outcomes["B"] == []
 
 
 # =====================================================================
-# Phase E: NhlRegularSource — standings_points + OT/SO classification
+# Phase E: NhlRegularSource: standings_points + OT/SO classification
 # =====================================================================
 
 class TestNhlRegularSource:
@@ -2157,7 +2157,7 @@ class TestNhlRegularSource:
 
 
 # =====================================================================
-# Phase E: NhlPlayoffSource — bracket inference + round_reached cascade
+# Phase E: NhlPlayoffSource: bracket inference + round_reached cascade
 # =====================================================================
 
 class TestNhlPlayoffSource:
@@ -2299,7 +2299,7 @@ class TestNcaaBaseballRegularSource:
         assert src.sport_label == "NCAA Baseball"
 
     def test_count_field_is_wins(self):
-        # Inherits the PointsBasedSportSource default — D1 baseball has
+        # Inherits the PointsBasedSportSource default: D1 baseball has
         # no OT/SO bonus point complication like NHL.
         from dispatcharr_ranked_matchups.sources.ncaa_baseball import NcaaBaseballRegularSource
         assert NcaaBaseballRegularSource._count_field == "wins"
@@ -2323,7 +2323,7 @@ class TestNcaaBaseballRegularSource:
         evt = self._event("1002", "2026-04-01T19:00Z", hp=4, ap=2,
                           completed=False, state="in")
         rec = _extract_game_record(evt)
-        # In-progress score is unstable — must not seed wins/losses.
+        # In-progress score is unstable: must not seed wins/losses.
         assert rec is not None
         assert rec["status"] == "SCHEDULED"
         assert rec["home_points"] is None
@@ -2372,7 +2372,7 @@ class TestNcaaBaseballRegularSource:
     def test_team_canonical_name_prefers_location_over_mascot(self):
         from dispatcharr_ranked_matchups.sources.ncaa_baseball import _team_canonical_name
         # EPG provider titles use the school name ("UCLA at Texas")
-        # not the mascot ("Bruins at Longhorns") — pick location.
+        # not the mascot ("Bruins at Longhorns"): pick location.
         assert _team_canonical_name({"location": "UCLA", "name": "Bruins"}) == "UCLA"
 
     def test_team_canonical_name_falls_back_to_nickname(self):
@@ -2411,7 +2411,7 @@ class TestNcaaBaseballRegularSource:
 class TestNcaaBaseballPlayoffSource:
     """NcaaBaseballPlayoffSource: BestOfNSeriesSource subclass that ships
     the cleanly-labeled best-of-3 stages (Super Regional + MCWS Finals).
-    Regional double-elim and 8-team MCWS bracket are Phase 2 — those
+    Regional double-elim and 8-team MCWS bracket are Phase 2: those
     headlines lack game-number metadata so chronological inference is
     needed and that's a separate design.
     """
@@ -2452,7 +2452,7 @@ class TestNcaaBaseballPlayoffSource:
         # MCWS Final winner → MCWS_W synthetic depth.
         assert src._winner_advance_label("MCWS_F") == "MCWS_W"
         # Super Regional advances via default stage_depth + 1 rule
-        # (which lands at MCWS depth — the unmodeled 8-team bracket).
+        # (which lands at MCWS depth: the unmodeled 8-team bracket).
         assert src._winner_advance_label("BSB_SR") is None
 
     def test_outcome_labels_uses_mcws_po_thresholds(self):
@@ -2544,7 +2544,7 @@ class TestBaseballPlayoffHeadlineParser:
         ) == ("BSB_SR", 1)
 
     def test_super_regional_game_3_if_necessary(self):
-        # The "(if necessary)" trailer must be stripped — ESPN attaches
+        # The "(if necessary)" trailer must be stripped: ESPN attaches
         # it to Game 3 placeholders that haven't been confirmed.
         assert self._parse(
             "NCAA Baseball Championship - Auburn Super Regional - Game 3 (if necessary)"
@@ -2571,7 +2571,7 @@ class TestBaseballPlayoffHeadlineParser:
         ) == (None, None)
 
     def test_mcws_elimination_game_returns_none(self):
-        # MCWS losers-bracket games ESPN tags as "Elimination Game" —
+        # MCWS losers-bracket games ESPN tags as "Elimination Game":
         # still Phase 2 (no game number).
         assert self._parse(
             "Men's College World Series - Elimination Game"
@@ -2657,7 +2657,7 @@ class TestBaseballBracketHeadlineParser:
             "Men's College World Series - Double Elimination Round"
         )
         assert stage == "MCWS"
-        # Partial key — sub-bracket resolution happens chronologically.
+        # Partial key: sub-bracket resolution happens chronologically.
         assert key is None
 
     def test_mcws_elimination_game(self):
@@ -2681,7 +2681,7 @@ class TestBaseballBracketHeadlineParser:
 
     def test_super_regional_headline_belongs_to_sibling_source(self):
         # SUPER_REGIONAL headlines are owned by NcaaBaseballPlayoffSource,
-        # NOT the bracket source — the bracket parser must return None.
+        # NOT the bracket source: the bracket parser must return None.
         from dispatcharr_ranked_matchups.sources.ncaa_baseball import (
             _parse_baseball_bracket_headline,
         )
@@ -2750,7 +2750,7 @@ class TestMcwsSubBracketClassification:
         assert out["LSU"] == "MCWS_sub2"
 
     def test_day3_game_inherits_from_opening_day(self):
-        # Day 3 game (Oregon State vs Coastal Carolina) — both teams
+        # Day 3 game (Oregon State vs Coastal Carolina): both teams
         # already classified to sub1 from Day 1, so the Day 3 game
         # MUST stay sub1.
         from datetime import datetime, timezone
@@ -2766,7 +2766,7 @@ class TestMcwsSubBracketClassification:
             # Day 2 establishes sub2
             self._g("UCLA", "Arkansas",
                     datetime(2025, 6, 14, 18, 0, tzinfo=timezone.utc)),
-            # Day 3 rematch — both teams classified already.
+            # Day 3 rematch: both teams classified already.
             self._g("Oregon State", "Coastal Carolina",
                     datetime(2025, 6, 15, 23, 0, tzinfo=timezone.utc)),
         ]
@@ -2894,7 +2894,7 @@ class TestNcaaBaseballPlayoffBracketSource:
 
 class TestNcaaBaseballPlayoffBracketSourceFiltering:
     """Make sure the bracket source DOES NOT step on the sibling
-    NcaaBaseballPlayoffSource's stages — best-of-3 BSB_SR + MCWS_F
+    NcaaBaseballPlayoffSource's stages: best-of-3 BSB_SR + MCWS_F
     headlines must be ignored by the bracket parser."""
 
     def test_super_regional_excluded(self):
@@ -2957,7 +2957,7 @@ class TestSoftballBracketHeadlineParser:
         assert key is None
 
     def test_wcws_elimination_game_if_necessary(self):
-        # Verbatim text from 2025 WCWS — "If Necessary" suffix is part
+        # Verbatim text from 2025 WCWS: "If Necessary" suffix is part
         # of the elimination-game pattern.
         from dispatcharr_ranked_matchups.sources.ncaa_softball import (
             _parse_softball_bracket_headline,
@@ -2989,7 +2989,7 @@ class TestSoftballBracketHeadlineParser:
 
 
 class TestWcwsSubBracketClassification:
-    """Same day-partition heuristic as MCWS — pinned by a representative
+    """Same day-partition heuristic as MCWS: pinned by a representative
     fixture using verbatim 2026 WCWS opening-day pairings."""
 
     @staticmethod
@@ -3035,7 +3035,7 @@ class TestWcwsSubBracketClassification:
             _classify_wcws_sub_brackets,
         )
         games = [
-            # Day 1 (May 29 CT) — first game stays in May 29 UTC.
+            # Day 1 (May 29 CT): first game stays in May 29 UTC.
             self._g("Texas Tech", "Oklahoma",
                     datetime(2026, 5, 29, 22, 0, tzinfo=timezone.utc)),
             # Day 1 second game crosses into May 30 UTC.
@@ -3227,7 +3227,7 @@ class TestNcaaSoccerSource:
         )
         # With lambda~1.0 and 200 samples, draws happen frequently
         # (Poisson(1) variance puts ~30%+ chance of identical scores).
-        # Confirm at least one tie sampled — base PointsBasedSportSource
+        # Confirm at least one tie sampled: base PointsBasedSportSource
         # would have force-coin-flipped it away.
         seen_tie = False
         for seed in range(200):
@@ -3290,7 +3290,7 @@ class TestNhlCupFinalPlaceholder:
         from dispatcharr_ranked_matchups.sources.nhl import NHL_HOME_PATTERN
         games = []
         # Two CONF_FINAL series, each at 0-0 (no games applied yet for
-        # the placeholder logic to fire — it's structural based on
+        # the placeholder logic to fire: it's structural based on
         # series existence, not on series progress).
         for series_idx, (top, bot) in enumerate([("Colorado", "Vegas"), ("Montreal", "Carolina")]):
             for matchday in range(1, len(NHL_HOME_PATTERN) + 1):
@@ -3721,7 +3721,7 @@ class TestMlbPlayoffSource:
 
     def test_mlb_po_thresholds_are_depth_ordered(self):
         """MLB_PO threshold stages must appear in KNOCKOUT_ROUND_DEPTH in
-        increasing depth order — otherwise the terminal_outcomes cascade
+        increasing depth order: otherwise the terminal_outcomes cascade
         would emit out-of-order bands."""
         from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH
         ctx = LEAGUE_CONTEXTS["MLB_PO"]
@@ -3781,7 +3781,7 @@ class TestNbaHeadlineParser:
         assert self._parse("") is None
 
     def test_unrecognized_returns_none(self):
-        # Defensive — preseason headlines or odd formats should not
+        # Defensive: preseason headlines or odd formats should not
         # accidentally match.
         assert self._parse("Preseason") is None
         assert self._parse("Game 5") is None
@@ -4049,7 +4049,7 @@ class TestNbaPlayoffSource:
 
 class TestMlsSourceIdentity:
     """MlsSource: V1 schedule+closeness adapter. No importance, no
-    standings — just confirm the basic contract holds."""
+    standings: just confirm the basic contract holds."""
 
     @staticmethod
     def _make():
@@ -4254,7 +4254,7 @@ class TestMlsFetchUpcomingShape:
 # =====================================================================
 
 class TestWnbaHeadlineParser:
-    """WNBA headline regex differs from NBA — no East/West prefix on R1
+    """WNBA headline regex differs from NBA: no East/West prefix on R1
     ("First Round"), WNBA name appears explicitly on Semifinals and
     Finals ("WNBA Semifinals", "WNBA Finals")."""
 
@@ -4294,7 +4294,7 @@ class TestWnbaHeadlineParser:
 
 
 class TestWnbaAllStarFilter:
-    """Same All-Star filter pattern as NBA — WNBA also runs an
+    """Same All-Star filter pattern as NBA: WNBA also runs an
     All-Star Game tagged competition.type.abbreviation=ALLSTAR."""
 
     @staticmethod
@@ -4600,7 +4600,7 @@ class TestNcaawBasketballPlayoffSource:
         assert self._make().KO_STAGES == ("R64", "R32", "S16", "E8", "F4", "NCG")
 
     def test_series_length_uniform_one(self):
-        """Single-game elim — every stage uses SERIES_LENGTH=1; the
+        """Single-game elim: every stage uses SERIES_LENGTH=1; the
         clinching-wins target is ceil(1/2)=1."""
         src = self._make()
         for stage in src.KO_STAGES:
@@ -4674,7 +4674,7 @@ class TestNcaawBasketballPlayoffSource:
 # =====================================================================
 
 class TestNcaaSoccerCupSource:
-    """One source class parametrized on gender — same shape / endpoints
+    """One source class parametrized on gender: same shape / endpoints
     / stage labels for both, only ESPN URL slug + league_context_code
     differ. Mirrors NcaaSoccerSource (regular season) parametrization."""
 
@@ -4724,7 +4724,7 @@ class TestNcaaSoccerCupSource:
         assert self._make().KO_STAGES == ("R64", "R32", "S16", "E8", "F4", "NCG")
 
     def test_series_length_uniform_one(self):
-        """Single-game elim — every stage uses SERIES_LENGTH=1; clinches
+        """Single-game elim: every stage uses SERIES_LENGTH=1; clinches
         at ceil(1/2)=1 win."""
         src = self._make()
         for stage in src.KO_STAGES:
@@ -4744,7 +4744,7 @@ class TestNcaaSoccerCupSource:
 
     def test_slug_to_stage_table_covers_both_genders(self):
         """Both M's and W's College Cup slugs map to the same canonical
-        stage labels — M's uses 'college-cup---semifinal' / 'college-
+        stage labels: M's uses 'college-cup---semifinal' / 'college-
         cup---championship', W's uses 'semifinals' / 'college-cup'. Pin
         both gender aliases so an ESPN slug rename surfaces here, not
         as silently-missing-stage in production."""
@@ -4785,7 +4785,7 @@ class TestNcaaSoccerCupSource:
         assert NcaaSoccerCupSource._extract_bracket_record(event) is None
 
     def test_extract_bracket_record_routes_third_round_to_s16(self):
-        """ESPN's 'third-round' slug is what humans call Sweet 16 —
+        """ESPN's 'third-round' slug is what humans call Sweet 16:
         confirm the routing so a label mismatch surfaces here, not via
         an importance-band silently misfiring on production data.
         """
@@ -4856,7 +4856,7 @@ class TestNcaaSoccerCupSource:
     def test_thresholds_are_depth_ordered(self):
         # Cross-sport calibration requires later stages to be ranked
         # deeper than earlier ones. Out-of-order depths would break the
-        # cascade — a team reaching SF wouldn't be credited with the
+        # cascade: a team reaching SF wouldn't be credited with the
         # E8 / S16 / R32 labels below it.
         from dispatcharr_ranked_matchups.scoring import (
             LEAGUE_CONTEXTS, KNOCKOUT_ROUND_DEPTH,
@@ -4884,7 +4884,7 @@ class TestNcaaSoccerCupSource:
 
     def test_champion_cascade(self):
         """A team that wins each of the 6 rounds reaches NCG_WINNER
-        depth and `terminal_outcomes` returns every band — pin the
+        depth and `terminal_outcomes` returns every band: pin the
         cascade end-to-end so a future refactor of bracket.py can't
         silently break the round_reached → terminal_outcomes path
         for soccer-style brackets.
@@ -4925,7 +4925,7 @@ class TestNcaaSoccerCupSource:
     # ---------- sample_result forces a winner (no draws in bracket) ----------
 
     def test_sample_result_never_produces_ties(self):
-        """Bracket games go to OT then PKs in real life — sample_result
+        """Bracket games go to OT then PKs in real life: sample_result
         must coin-flip a +1 to break a regulation tie. Distinct from the
         regular-season NcaaSoccerSource which allows draws (1 standings
         point each). Run a tight-Poisson sample 200x and confirm zero
@@ -4976,7 +4976,7 @@ class TestNcaaSoccerCupSource:
 
     def test_loser_round_reached_stops_at_lost_stage(self):
         """A team that wins R64 + R32 but loses S16 should have
-        round_reached at depth(S16) — they made it to Sweet 16, didn't
+        round_reached at depth(S16): they made it to Sweet 16, didn't
         advance to Elite 8. terminal_outcomes returns sweet_16 and
         round_of_32 but NOT elite_8.
         """
@@ -5077,7 +5077,7 @@ class TestNcaaSoccerCupSource:
 
     def test_dedupe_passes_through_unique_games(self):
         """A bracket with all distinct (stage, participants) tuples
-        passes through unchanged — no false collapsing of legitimate
+        passes through unchanged: no false collapsing of legitimate
         bracket games."""
         from dispatcharr_ranked_matchups.sources.ncaa_soccer_cup import (
             _dedupe_pk_shootout_pairs,
@@ -5103,7 +5103,7 @@ class TestNcaaSoccerCupSource:
 
     def test_fetch_upcoming_emits_only_bracket_games(self, monkeypatch):
         """fetch_upcoming must filter to events with a tournament slug
-        — a regular-season game that happens to fall in the same date
+       : a regular-season game that happens to fall in the same date
         window must not appear. Pin via stub so a slug-table regression
         surfaces here."""
         from dispatcharr_ranked_matchups.sources import ncaa_soccer_cup as mod
@@ -5155,7 +5155,7 @@ class TestNcaaSoccerCupSource:
 
 class TestNcaaSoftballRegularSource:
     """V1: regular-season importance only. WCWS bracket (double-elim)
-    is filed as a follow-up — same scope deferral as NCAA Baseball's CWS."""
+    is filed as a follow-up: same scope deferral as NCAA Baseball's CWS."""
 
     @staticmethod
     def _make():
@@ -5234,7 +5234,7 @@ class TestNcaaSoftballRegularSource:
 
 class TestNcaaSoftballPlayoffSource:
     """NcaaSoftballPlayoffSource: best-of-3 Super Regional + WCWS Finals.
-    Sibling of NcaaBaseballPlayoffSource with one twist — softball
+    Sibling of NcaaBaseballPlayoffSource with one twist: softball
     headlines use "Finals" (plural) where baseball uses "Final"
     (singular)."""
 
@@ -5325,7 +5325,7 @@ class TestSoftballPlayoffHeadlineParser:
         ) == ("SB_SR", 3)
 
     def test_wcws_finals_game_1(self):
-        # Plural "Finals" for softball — distinct from baseball's "Final".
+        # Plural "Finals" for softball: distinct from baseball's "Final".
         assert self._parse(
             "Women's College World Series Championship Finals - Game 1"
         ) == ("WCWS_F", 1)
@@ -5347,7 +5347,7 @@ class TestSoftballPlayoffHeadlineParser:
         ) == (None, None)
 
     def test_wcws_elimination_game_returns_none(self):
-        # WCWS losers-bracket games — observed in live 2026 data
+        # WCWS losers-bracket games: observed in live 2026 data
         # (May 30+). Must skip; no game number → Phase 2.
         assert self._parse(
             "Women's College World Series - Elimination Game"
@@ -5361,7 +5361,7 @@ class TestSoftballPlayoffHeadlineParser:
         ) == (None, None)
 
     def test_regional_elimination_game_returns_none(self):
-        # Regional losers-bracket games carry "Elimination Game" too —
+        # Regional losers-bracket games carry "Elimination Game" too:
         # also Phase 2 territory.
         assert self._parse(
             "NCAA Softball Championship - Athens Regional - Elimination Game"
@@ -5407,7 +5407,7 @@ class TestNflHeadlineParser:
         assert self._parse("Super Bowl LIX") == {"stage": "SB", "matchday": 1}
 
     def test_super_bowl_no_numeral(self):
-        # Defensive — if ESPN ever drops the Roman numeral.
+        # Defensive: if ESPN ever drops the Roman numeral.
         assert self._parse("Super Bowl") == {"stage": "SB", "matchday": 1}
 
     def test_no_headline_returns_none(self):
@@ -5424,7 +5424,7 @@ class TestNflHeadlineParser:
 
 
 class TestNflProBowlFilter:
-    """Pro Bowl is tagged competition.type.abbreviation=ALLSTAR — same
+    """Pro Bowl is tagged competition.type.abbreviation=ALLSTAR: same
     trap as NBA/WNBA. Filter must drop it from regular-season fetches."""
 
     @staticmethod
@@ -5724,7 +5724,7 @@ class TestMlsStandingsContexts:
 
 class TestMlsStandingsRecordResult:
     """The 3 / 1 / 0 standings-points credit. Mirrors ncaa_soccer's
-    record path because both apply the same soccer scheme — pin
+    record path because both apply the same soccer scheme: pin
     independently so regression in one doesn't drag the other."""
 
     @staticmethod
@@ -5832,7 +5832,7 @@ class TestMlsStandingsConferenceFilter:
             if calls["n"] != 1:
                 return {"events": []}
             return {"events": [
-                # (1) A vs B — intra-East, should appear
+                # (1) A vs B: intra-East, should appear
                 {"id": 1, "date": "2025-04-01T19:00:00Z",
                  "season": {"slug": "regular-season"},
                  "competitions": [{
@@ -5842,7 +5842,7 @@ class TestMlsStandingsConferenceFilter:
                          {"homeAway": "away", "team": {"displayName": "B"}, "score": "1"},
                      ],
                  }]},
-                # (2) A vs C — cross-conf, should be filtered out
+                # (2) A vs C: cross-conf, should be filtered out
                 {"id": 2, "date": "2025-04-01T19:00:00Z",
                  "season": {"slug": "regular-season"},
                  "competitions": [{
@@ -5852,7 +5852,7 @@ class TestMlsStandingsConferenceFilter:
                          {"homeAway": "away", "team": {"displayName": "C"}, "score": "1"},
                      ],
                  }]},
-                # (3) C vs D — intra-West, should be filtered out for East
+                # (3) C vs D: intra-West, should be filtered out for East
                 {"id": 3, "date": "2025-04-01T19:00:00Z",
                  "season": {"slug": "regular-season"},
                  "competitions": [{
@@ -5919,7 +5919,7 @@ class TestMlsStandingsConferenceFilter:
         remaining matches in the season produces nonzero playoff_bubble
         leverage. Uses a stub state to bypass ESPN's thin future-
         fixtures publishing (see module docstring's "Known limitation"
-        — live mid-season importance reads near 0 because ESPN MLS
+       : live mid-season importance reads near 0 because ESPN MLS
         publishes only ~1-2 weeks of future games, so the simulator
         can't propagate; this test pins the simulator pipeline
         independent of the data-availability quirk).
@@ -5939,7 +5939,7 @@ class TestMlsStandingsConferenceFilter:
                 # Nashville at 29 pts, one game from the 30 pt bubble.
                 # Inter Miami at 26, also within reach. A single match
                 # result genuinely moves Nashville above or below the
-                # threshold — leverage should be nonzero.
+                # threshold: leverage should be nonzero.
                 return {
                     "_applied": frozenset(),
                     "_teams": {
@@ -6069,7 +6069,7 @@ class TestMlsStandingsConferenceFilter:
     def test_conference_map_returns_empty_on_endpoint_failure(self, monkeypatch):
         """When _http_get returns None (ESPN down / network error /
         4xx), the conference map MUST be empty rather than partial.
-        An empty map cascades to 0 emitted games — graceful degradation
+        An empty map cascades to 0 emitted games: graceful degradation
         rather than misclassified teams getting the wrong conference's
         threshold bands.
         """
@@ -6144,7 +6144,7 @@ class TestMlsCupSourceIdentity:
 
     def test_series_lengths_match_mls_format(self):
         """Mixed format: WC, CSF, CF, MLS_CUP are single-leg; R1 is
-        best-of-3 (clinches at 2 wins). Pin all five — a regression
+        best-of-3 (clinches at 2 wins). Pin all five: a regression
         to uniform best-of-N would silently misclassify clinches."""
         src = self._make()
         assert src._series_length_for_stage("MLS_WC") == 1
@@ -6248,7 +6248,7 @@ class TestMlsCupSlugRouting:
     def test_extract_filters_phantom_best_of_3_game(self):
         """ESPN publishes a phantom game-3 (state=post, completed=False,
         score=0-0) for best-of-3 series that clinch in 2 games. These
-        MUST be filtered out — pinning against the live shape observed
+        MUST be filtered out: pinning against the live shape observed
         on event 722587 in the 2024 R1 (LA Galaxy / Colorado series
         clinched in 2 games; ESPN's game-3 slot was state=post +
         completed=False).
@@ -6393,7 +6393,7 @@ class TestMlsCupMatchdayInference:
 
     def test_best_of_3_does_not_dedupe_legitimate_repeats(self):
         """Same teams playing 2-3 games in a best-of-3 series must
-        NOT be collapsed by the PK dedup — pin so a future refactor
+        NOT be collapsed by the PK dedup: pin so a future refactor
         doesn't accidentally apply dedup to best-of-N stages."""
         from datetime import datetime, timezone
         from dispatcharr_ranked_matchups.sources.mls_cup import (
@@ -6474,7 +6474,7 @@ class TestMlsCupCascade:
 
 
 class TestMlsCupSampleResultNoDraws:
-    """Bracket games go to OT then PKs — sample_result must force a winner."""
+    """Bracket games go to OT then PKs: sample_result must force a winner."""
 
     def test_sample_result_never_produces_ties(self):
         import random
@@ -6513,7 +6513,7 @@ class TestMlsCupFetchUpcoming:
             if calls["n"] != 1:
                 return {"events": []}
             return {"events": [
-                # Scheduled bracket game — should emit.
+                # Scheduled bracket game: should emit.
                 {"id": "playoff-1", "date": "2030-10-26T19:00:00Z",
                  "season": {"slug": "eastern-conference-playoffs---round-one"},
                  "competitions": [{
@@ -6523,7 +6523,7 @@ class TestMlsCupFetchUpcoming:
                          {"homeAway": "away", "team": {"displayName": "Inter Miami CF"}},
                      ],
                  }]},
-                # Regular-season game — must be filtered out.
+                # Regular-season game: must be filtered out.
                 {"id": "regular-1", "date": "2030-10-26T22:00:00Z",
                  "season": {"slug": "regular-season"},
                  "competitions": [{
@@ -6596,7 +6596,7 @@ class TestMlsCupMatchdayInferenceDefensive:
             {"game_id": "g2", "stage": "MLS_R1", "matchday": None,
              "home": "A", "away": "B", "home_goals": 1, "away_goals": 0,
              "status": "FINISHED",
-             "start_time": None,  # malformed input — sort to end
+             "start_time": None,  # malformed input: sort to end
              "extra": {}},
         ]
         out = _assign_matchdays_and_dedupe(games, _MLS_SERIES_LENGTHS)
@@ -6737,7 +6737,7 @@ class TestLigaMxSource:
 # =====================================================================
 
 class TestFieldEventSourceContract:
-    """FieldEventSource is the ABC for racing + golf — events that
+    """FieldEventSource is the ABC for racing + golf: events that
     aren't head-to-head. Pin the contract: home=event_name, away="Field"
     sentinel, no importance simulation."""
 
@@ -6839,7 +6839,7 @@ class TestFieldEventFetchUpcoming:
         assert len(games) == 1
         g = games[0]
         assert g.home == "Heineken Chinese Grand Prix"
-        # Sentinel away team — field events have no opponent.
+        # Sentinel away team: field events have no opponent.
         assert g.away == "Field"
         assert g.sport_prefix == "F1"
         assert g.extra.get("stage") == "EVENT"
@@ -6924,7 +6924,7 @@ class TestFieldEventScoring:
             GameSignals(team_a="X", team_b="Field", tournament_stage="MAJOR"),
             weights,
         )
-        # MAJOR must outrank EVENT — golf majors should beat regular
+        # MAJOR must outrank EVENT: golf majors should beat regular
         # tour stops in the guide.
         assert major_score.raw > event_score.raw
 
@@ -6934,7 +6934,7 @@ class TestFieldEventScoring:
 # =====================================================================
 
 class TestUfcSource:
-    """UFC fits the FieldEventSource pattern — one EPG entry per
+    """UFC fits the FieldEventSource pattern: one EPG entry per
     fight card. Numbered PPVs (UFC 309, etc.) get MAJOR; Fight
     Nights and ESPN-broadcast cards get EVENT."""
 
@@ -6955,7 +6955,7 @@ class TestUfcSource:
     def test_ppv_detected_as_major(self):
         src = self._make()
         assert src.MAJOR_REGEX is not None
-        # Numbered PPV — MAJOR.
+        # Numbered PPV: MAJOR.
         assert src.MAJOR_REGEX.search("UFC 309: Jones vs. Miocic")
         assert src.MAJOR_REGEX.search("UFC 310: Pantoja vs. Asakura")
         # Three-digit (future-proofing).
@@ -6964,14 +6964,14 @@ class TestUfcSource:
     def test_fight_night_not_major(self):
         src = self._make()
         assert src.MAJOR_REGEX is not None
-        # Fight Night and ESPN cards — EVENT-tier.
+        # Fight Night and ESPN cards: EVENT-tier.
         assert not src.MAJOR_REGEX.search(
             "UFC Fight Night: Sandhagen vs. Figueiredo"
         )
         assert not src.MAJOR_REGEX.search("UFC on ESPN: Lewis vs. Nascimento")
 
     def test_emits_ppv_with_major_tier(self, monkeypatch):
-        """Live ESPN response shape — UFC card surfaces as one row."""
+        """Live ESPN response shape: UFC card surfaces as one row."""
         import dispatcharr_ranked_matchups.sources.field_event as field_mod
         espn_response = {
             "events": [{
@@ -7018,7 +7018,7 @@ class TestUfcSource:
 class TestTennisSources:
     """ESPN's tennis scoreboard returns whole tournaments (each entry
     spans 1-2 weeks for a Slam, or 5-7 days for tour stops), not
-    individual matches — same FieldEventSource shape as racing + UFC."""
+    individual matches: same FieldEventSource shape as racing + UFC."""
 
     def test_atp_identity(self):
         from dispatcharr_ranked_matchups.sources.field_event import AtpSource
@@ -7616,8 +7616,8 @@ class TestDoubleEliminationSource:
             self._game("g1", "BSB_REG", "Site1", "A", "B", (5, 2), matchday=1),
             self._game("g2", "BSB_REG", "Site2", "A", "B", (4, 1), matchday=1),
             # Same {A, B} teams in two different sub-bracket grouping_keys.
-            # This shouldn't happen with real source data — teams don't
-            # span sub-brackets — but the contract should honor the
+            # This shouldn't happen with real source data: teams don't
+            # span sub-brackets: but the contract should honor the
             # grouping_key without ambiguity.
         ]
         src = self._make_source(games)
@@ -7723,7 +7723,7 @@ class TestGroupStageSoccerSource:
 
     def test_team_group_map_ignores_knockout_matches(self):
         # Knockout fixtures don't carry a group field. Make sure they're
-        # filtered out — including them would put a Group A winner into
+        # filtered out: including them would put a Group A winner into
         # "no group" classification when the knockout schedule resolves.
         matches = [
             self._match(1, "GROUP_A", "Mexico", "South Africa"),
@@ -7757,7 +7757,7 @@ class TestGroupStageSoccerSource:
             # Argentina 2-0 Chile
             self._match(2, "GROUP_A", "Argentina", "Chile",
                         hg=2, ag=0, status="FINISHED"),
-            # Knockout match — must NOT be applied.
+            # Knockout match: must NOT be applied.
             self._ko_match(99, "LAST_32", "Mexico", "Germany"),
         ]
         src = self._make_source(matches)
@@ -7795,7 +7795,7 @@ class TestGroupStageSoccerSource:
             # Scheduled group matches
             self._match(1, "GROUP_A", "Mexico", "South Africa"),
             self._match(2, "GROUP_A", "Argentina", "Chile"),
-            # Knockout — should NOT be in remaining_matches
+            # Knockout: should NOT be in remaining_matches
             self._ko_match(99, "LAST_32", "Mexico", "Germany"),
         ]
         src = self._make_source(matches)
@@ -7818,7 +7818,7 @@ class TestGroupStageSoccerSource:
 
     def test_terminal_outcomes_top_2_per_group_advance(self):
         # Group A finished: Mexico 9pts, Argentina 6pts, Chile 3pts, SA 0pts.
-        # Top 2 (Mexico, Argentina) advance. Chile is 3rd — could be
+        # Top 2 (Mexico, Argentina) advance. Chile is 3rd: could be
         # promoted via best-3rd-place (#52) in a multi-group fixture, so
         # this test focuses ONLY on the top-2-per-group claim and the
         # bottom-of-group elimination. 4th place (South Africa) never
@@ -7836,7 +7836,7 @@ class TestGroupStageSoccerSource:
         outcomes = src.terminal_outcomes(state)
         assert outcomes["Mexico"] == ["advance"]
         assert outcomes["Argentina"] == ["advance"]
-        # South Africa is 4th in the group — never advances via any path.
+        # South Africa is 4th in the group: never advances via any path.
         assert outcomes["South Africa"] == ["eliminated"]
         # Chile is 3rd. Best-3rd promotion is verified in TestGroupStageBestThirdPlace.
 
@@ -7967,7 +7967,7 @@ class TestKnockoutSoccerSourceSkipsGroupStage:
         assert out_ids == {2, 3}
 
     def test_filter_no_op_for_competitions_without_group_stage(self):
-        # UCL fixtures don't carry stage="GROUP_STAGE" — the filter is a
+        # UCL fixtures don't carry stage="GROUP_STAGE": the filter is a
         # safe no-op, ALL rows pass through.
         from dispatcharr_ranked_matchups.sources.base import GameRow
         from dispatcharr_ranked_matchups.sources.soccer import (
@@ -8001,7 +8001,7 @@ class TestKnockoutSoccerSourceSeedFromChain:
     Downstream stages use placeholder team names ("L32_W1" etc.) wired
     to L32 ties via feeds_from. The bracket machinery resolves them at
     each remaining_matches call via `_winner_of` recursively walking
-    `_resolve_participants` against the simulated tie_results — see
+    `_resolve_participants` against the simulated tie_results: see
     bracket.py:418.
     """
 
@@ -8103,7 +8103,7 @@ class TestKnockoutSoccerSourceSeedFromChain:
         # If _winner_of were broken, L16 would never emit a game and the
         # drain would converge after the L32 round, not iterate.
         assert passes_with_games >= 2, (
-            "L16 tie failed to emit after L32 resolved — _winner_of fix "
+            "L16 tie failed to emit after L32 resolved: _winner_of fix "
             "regression suspected"
         )
         # L16 tie_results should exist with REAL team names (the L32 winners).
@@ -8291,7 +8291,7 @@ class TestBuildBracketSeedWC2026:
         # pair "1E" with "GE3" (same group).
         src = self._wc_source()
         # Use a scenario where all 8 best-3rd-placers come from
-        # groups that include E — so the greedy assignment MIGHT
+        # groups that include E: so the greedy assignment MIGHT
         # accidentally place GE3 in M74's slot if the constraint
         # were ignored.
         state = self._full_wc_state(third_qualifiers=set("ABCDEFGH"))
@@ -8522,7 +8522,7 @@ class TestWC2026ChainEndToEnd:
         # every downstream query (which would be the bug #53 reports).
         max_leverage = max(out.values())
         assert max_leverage > 0.01, (
-            f"chain returned ~zero leverage on all knockout queries: {out!r} — "
+            f"chain returned ~zero leverage on all knockout queries: {out!r}: "
             "the #53 bug pattern (group games show 0 on every downstream "
             "band) appears to be unfixed"
         )
@@ -8561,13 +8561,13 @@ class TestMlbWsPlaceholder:
     have published games but the postseason endpoint hasn't yet
     populated the World Series (which only happens after both LCS
     resolve). Without the placeholder, ws_winner leverage reads 0
-    during LCS week — exactly when LCS-Game-7 leverage should max.
+    during LCS week: exactly when LCS-Game-7 leverage should max.
     Mirrors NhlPlayoffSource's #17 fix.
     """
 
     @staticmethod
     def _two_lcs_in_progress_games():
-        """7-game LCS pair × 2, all SCHEDULED + no WS games yet —
+        """7-game LCS pair × 2, all SCHEDULED + no WS games yet:
         mimics live shape during LCS week."""
         games = []
         # AL LCS: Yankees vs Astros
@@ -8659,7 +8659,7 @@ class TestMlbWsPlaceholderGating:
 
     def test_no_synthesis_when_only_one_lcs_series_started(self, monkeypatch):
         # Only one LCS series has games (other still in LDS), so the
-        # placeholder should NOT fire — we don't know both participants yet.
+        # placeholder should NOT fire: we don't know both participants yet.
         from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
         src = MlbPlayoffSource(season=2025)
         # Stub _http_get to return a payload with 1 LCS series
@@ -8683,7 +8683,7 @@ class TestMlbWsPlaceholderGating:
         assert sum(1 for g in out if g["stage"] == "LCS") == 1
 
     def test_no_synthesis_when_ws_already_published(self, monkeypatch):
-        # Both LCS resolved AND WS published — real data, no placeholder.
+        # Both LCS resolved AND WS published: real data, no placeholder.
         from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
         from dispatcharr_ranked_matchups.sources import mlb as mlb_mod
         src = MlbPlayoffSource(season=2025)
@@ -8729,7 +8729,7 @@ class TestMlbWsPlaceholderGating:
         assert ws_games[0]["game_id"] > 0, "Real WS game, should not be synthetic (negative ID)"
 
     def test_synthesis_fires_when_lcs_in_progress(self, monkeypatch):
-        # Both LCS have published games, no WS yet — synthesizer should fire.
+        # Both LCS have published games, no WS yet: synthesizer should fire.
         from dispatcharr_ranked_matchups.sources.mlb import MlbPlayoffSource
         from dispatcharr_ranked_matchups.sources import mlb as mlb_mod
         src = MlbPlayoffSource(season=2025)
@@ -8766,7 +8766,7 @@ class TestGroupStageBestThirdPlace:
     """Issue #52: WC 2026 / EURO 2024 best-3rd-place advancement.
     WC 2026 advances 8 third-place teams across 12 groups; EURO 2024
     advances 4 across 6 groups. Without this, the GroupStageSoccerSource
-    classifies all 3rd-place teams as eliminated — ~25% misclassification
+    classifies all 3rd-place teams as eliminated: ~25% misclassification
     for advancing teams in WC 2026."""
 
     @staticmethod
@@ -8867,7 +8867,7 @@ class TestGroupStageBestThirdPlace:
 
     def test_third_place_tiebreaker_by_gd_then_gf(self):
         # 4 third-placers all tied on 3 pts. Tiebreaker is GD → GF → alphabetical.
-        # Send WC source — best_third_place_count=8, but we only have 8 groups
+        # Send WC source: best_third_place_count=8, but we only have 8 groups
         # constructed so all 8 3rd-placers advance. To test the tiebreaker
         # specifically, give only 4 groups + best_third_place_count effective
         # at picking 1 of them. Simulate by limiting groups.
@@ -8911,13 +8911,13 @@ class TestGroupStageBestThirdPlace:
             teams = [
                 (f"top_{gi}_1st", 9, 5, 8),
                 (f"top_{gi}_2nd", 6, 2, 5),
-                (f"top_{gi}_3rd", 10 - gi, 0, 3),  # 10, 9, 8, 7, 6, 5, 4 — all strictly above 3
+                (f"top_{gi}_3rd", 10 - gi, 0, 3),  # 10, 9, 8, 7, 6, 5, 4: all strictly above 3
                 (f"top_{gi}_4th", 0, -5, 1),
             ]
             for t, *_ in teams:
                 team_group[t] = grp
             group_data[grp] = teams
-        # 5 groups (H..L) with identical 3rd-placer stats — alphabetical chosen by NAME.
+        # 5 groups (H..L) with identical 3rd-placer stats: alphabetical chosen by NAME.
         for gi, name_prefix in enumerate(["aaa", "bbb", "ccc", "ddd", "eee"]):
             grp = f"GROUP_{chr(ord('H') + gi)}"
             teams = [
@@ -9000,7 +9000,7 @@ class TestGroupStageBestThirdPlace:
             group_data[grp] = t
         state = self._make_state(group_data, team_group)
         outcomes = src.terminal_outcomes(state)
-        # Delta is 4th in her own group, regardless of stats — must be eliminated.
+        # Delta is 4th in her own group, regardless of stats: must be eliminated.
         assert outcomes["Delta"] == ["eliminated"]
 
 
@@ -9186,7 +9186,7 @@ class TestComputeGroupStandings:
         from dispatcharr_ranked_matchups.scoring import LEAGUE_CONTEXTS
 
         # `bundesliga` is a registered competition but Bundesliga is not
-        # a group-stage tournament — its `<fd_code>_GS` ("BL1_GS") has
+        # a group-stage tournament: its `<fd_code>_GS` ("BL1_GS") has
         # no LEAGUE_CONTEXTS entry, so the ctx lookup falls through.
         src = GroupStageSoccerSource("bundesliga", fd_api_key="x", odds_api_key="")
         assert src._group_stage_context_code() not in LEAGUE_CONTEXTS
@@ -9333,7 +9333,7 @@ class TestFdCacheBatching:
 
     def test_tier_fixtures_returns_empty_on_http_error(self, monkeypatch):
         # 429 / 5xx / network failure must return [] for every source
-        # rather than raising — keeps the rest of the refresh
+        # rather than raising: keeps the rest of the refresh
         # pipeline functioning.
         from dispatcharr_ranked_matchups.sources import soccer
 
@@ -9430,7 +9430,7 @@ class TestFdCacheBatching:
 
     def test_instance_level_cache_still_wins_for_test_injection(self, monkeypatch):
         # Existing tests inject fake season data via
-        # `src._all_matches_cache = [...]`. That MUST keep working —
+        # `src._all_matches_cache = [...]`. That MUST keep working:
         # if the module cache shadowed the instance attribute, the
         # injection becomes a no-op and 200+ existing tests silently
         # stop testing what they think they test.
@@ -9449,7 +9449,7 @@ class TestFdCacheBatching:
 
     def test_season_matches_independent_cache_per_fd_code(self, monkeypatch):
         # Two different competitions (WC and EC) each get their own
-        # entry in the module cache — they do NOT collapse into one.
+        # entry in the module cache: they do NOT collapse into one.
         from dispatcharr_ranked_matchups.sources import soccer
 
         call_log = []
@@ -9477,7 +9477,7 @@ class TestFdCacheBatching:
         wc_matches = wc._fetch_all_season_matches()
         ec_matches = ec._fetch_all_season_matches()
 
-        # Each fd_code gets its own fetch — no cross-contamination.
+        # Each fd_code gets its own fetch: no cross-contamination.
         assert len(call_log) == 2
         assert wc_matches[0]["_marker"] == "WC"
         assert ec_matches[0]["_marker"] == "EC"
@@ -9568,7 +9568,7 @@ class TestTierFixturesChunkingForLongWindows:
         chunk2_from = _dt.strptime(call_log[1]["dateFrom"], "%Y-%m-%d")
         assert chunk2_from > chunk1_to, (
             f"chunk2 starts {chunk2_from.date()} but chunk1 ended "
-            f"{chunk1_to.date()} — boundary overlap would double-fetch "
+            f"{chunk1_to.date()}: boundary overlap would double-fetch "
             "the boundary day"
         )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -82,7 +82,7 @@ class TestExtractGameNumberAfterMarker:
 
     def test_marker_not_present(self):
         # If the marker substring isn't in the headline, return None
-        # — caller is expected to try a different marker or skip.
+        #: caller is expected to try a different marker or skip.
         assert extract_game_number_after_marker(
             "Some other headline", "Super Regional - Game "
         ) is None


### PR DESCRIPTION
## Summary

Mechanical refactor: 640 em dashes across 40 `.py` files replaced with ASCII punctuation per the project style ("never use em dashes or double dashes"). Zero behavior change; full test suite (1028) passes unchanged.

## Replacement strategy

| Pattern | Replacement | Rationale |
|---|---|---|
| `<num> — <num>` (digits only on both sides) | ` to ` | Numeric range |
| `<month> — <month>` (whitelisted month names/abbrevs) | ` to ` | Calendar range |
| `<qualifier> — <qualifier>` ("early"/"mid"/"late") | ` to ` | Phase range |
| ` — \n` (end of line) | `:\n` | Clause-introducer with continuation |
| ` — ` (default) | `: ` | Most em dashes here introduce explanation/aside; colon is the natural ASCII equivalent |

The dominant em-dash usage pattern in this codebase is clause-introducer / explanation-introducer, so colon is faithful. Cosmetic awkwardness (occasional "colon-heavy" prose) is acceptable per the issue body's "comma if continuing the thought, colon if introducing a list, parens for an aside" guidance.

## What was tricky

A first pass used an aggressive range heuristic that matched any pair of short alphanumeric tokens separated by ` — ` — that mis-matched cases like `race — toss-up` (where `race` + `toss` are both ≤4 chars), producing `race to toss-up`. That heuristic also wrong-converted ~40 non-range em dashes (`row — no new API calls` → `row to no new API calls`). Reverted and replaced with the conservative whitelist above, which only fires on explicit ranges.

Tests pinned the consistency: production code's f-string templates and test assertions both reference the same prose. Any heuristic that diverges the two paths fails the build (caught 4 such cases in the first iteration).

## Validation

```bash
$ grep -rcP "—" --include="*.py" /coding/dispatcharr_ranked_matchups | awk -F: '{s+=$2} END {print s}'
0
```

Tests: 1028 pass, identical to pre-sweep baseline.

## Out of scope

Per the issue body: `.md` files, where em dashes are stylistically acceptable in long-form prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)