### PR TITLE
Closes #69: DRY _dedupe_pk_shootout_pairs across ncaa_soccer_cup + mls_cup

### DIFF
--- a/sources/_soccer_bracket_helpers.py
+++ b/sources/_soccer_bracket_helpers.py
@@ -1,0 +1,86 @@
+"""Shared helpers for ESPN-derived soccer bracket sources.
+
+`ncaa_soccer_cup` and `mls_cup` both pull bracket games from ESPN's
+scoreboard. ESPN occasionally publishes two records for the same
+elimination-stage match: one for the regulation 0-0 tie marked
+FINISHED, and a second for the PK shootout final score (e.g., 3-2)
+also marked FINISHED. Both sources have to collapse these pairs into
+the single decisive record before downstream stage / matchday logic
+sees them.
+
+The helpers in this module are the canonical implementations.
+DO NOT inline a parallel copy in a new source -- import from here.
+See #69 (the consolidation issue) and the original duplicates in
+ncaa_soccer_cup.py / mls_cup.py prior to extraction.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, FrozenSet, List, Tuple
+
+
+def dedupe_pk_shootout_pairs(
+    records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Collapse multiple events at the same (stage, participants) tuple
+    into the single decisive event. ESPN occasionally publishes two
+    records for a soccer bracket game that goes to OT / PKs: one with
+    the regulation tie (e.g., 0-0) marked finished, and a second with
+    the PK shootout final score (e.g., 3-2). Both are tagged complete
+    in ESPN's scoreboard.
+
+    Preference order when multiple records collide on
+    (stage, frozenset(home, away)):
+      1. SCHEDULED records lose to any FINISHED record (real outcomes
+         beat placeholders).
+      2. Among FINISHED records, non-tie outcomes beat tie outcomes
+         (PK shootout score beats the regulation tie).
+      3. Among non-tie FINISHED records, the LATEST `start_time` wins
+         (handles a real same-day duplicate; in practice the shootout
+         event is published with a later timestamp than the regulation
+         tie).
+
+    This is conservative: single-game elimination brackets cannot have
+    a real second leg between the same two teams at the same stage, so
+    any (stage, participants) collision IS data noise. Best-of-N stages
+    (e.g., MLS Round One) should already have matchday-assigned records
+    by the time they reach this helper; the (stage, participants) key
+    is enough because each record carries a distinct matchday.
+    """
+    buckets: Dict[Tuple[str, FrozenSet[str]], List[Dict[str, Any]]] = {}
+    for rec in records:
+        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
+        buckets.setdefault(key, []).append(rec)
+
+    out: List[Dict[str, Any]] = []
+    for _key, bucket in buckets.items():
+        if len(bucket) == 1:
+            out.append(bucket[0])
+            continue
+        out.append(pick_decisive_event(bucket))
+    return out
+
+
+def pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Apply the (FINISHED > SCHEDULED, non-tie > tie, latest > earliest)
+    preference order. Bucket must have 2+ records (callers should
+    short-circuit single-record buckets before calling here)."""
+    finished = [r for r in bucket if r.get("status") == "FINISHED"]
+    if not finished:
+        # All scheduled: keep the latest by start_time (most recent
+        # info is the canonical one).
+        return max(
+            bucket,
+            key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
+        )
+    non_tie = [
+        r for r in finished
+        if r.get("home_goals") is not None
+        and r.get("away_goals") is not None
+        and r["home_goals"] != r["away_goals"]
+    ]
+    pool = non_tie if non_tie else finished
+    return max(
+        pool,
+        key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
+    )

--- a/sources/mls_cup.py
+++ b/sources/mls_cup.py
@@ -311,10 +311,10 @@ class MlsCupSource(BestOfNSeriesSource):
         Single-game-elim stages (MLS_WC, MLS_CSF, MLS_CF, MLS_CUP) also
         need PK dedup. ESPN sometimes publishes two events when a game
         goes to PKs (one with the regulation tie, one with the PK
-        result): see `_dedupe_pk_shootout_pairs` in
-        `ncaa_soccer_cup.py` for the same shape. We import that helper
-        rather than re-implementing; the dedup criterion is sport-
-        agnostic for single-game-elim brackets.
+        result): see `dedupe_pk_shootout_pairs` in
+        `sources/_soccer_bracket_helpers.py` (the canonical impl shared
+        with ncaa_soccer_cup). The dedup criterion is sport-agnostic
+        for single-game-elim brackets.
 
         Best-of-3 stages are NOT deduped on (stage, participants):
         the same teams legitimately play 2-3 games in a series, so
@@ -442,62 +442,14 @@ class MlsCupSource(BestOfNSeriesSource):
         }
 
 
-def _dedupe_pk_shootout_pairs(
-    records: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
-    """Collapse multiple events at the same (stage, participants) tuple
-    into the single decisive event. ESPN occasionally publishes two
-    records for a soccer bracket game that goes to OT / PKs: one with
-    the regulation tie (e.g., 0-0) and a second with the PK shootout
-    final score (e.g., 3-2). Both can show up as FINISHED records.
-
-    NOTE: this is duplicated from `sources/ncaa_soccer_cup.py` while
-    issues #24 and #30 part B land as independent PRs. Once both
-    merge, the helper will be extracted to a shared module and both
-    call sites updated: DO NOT diverge the two implementations in
-    the meantime. Tracked in #69.
-
-    Preference order when multiple records collide on (stage,
-    frozenset(home, away)):
-      1. SCHEDULED records lose to any FINISHED record.
-      2. Among FINISHED records, non-tie outcomes beat tie outcomes.
-      3. Among non-tie FINISHED records, the LATEST start_time wins.
-    """
-    buckets: Dict[Tuple[str, FrozenSet[str]], List[Dict[str, Any]]] = {}
-    for rec in records:
-        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
-        buckets.setdefault(key, []).append(rec)
-
-    out: List[Dict[str, Any]] = []
-    for key, bucket in buckets.items():
-        if len(bucket) == 1:
-            out.append(bucket[0])
-            continue
-        out.append(_pick_decisive_event(bucket))
-    return out
-
-
-def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Apply the (FINISHED > SCHEDULED, non-tie > tie, latest > earliest)
-    preference order. Bucket has 2+ records guaranteed.
-    """
-    finished = [r for r in bucket if r.get("status") == "FINISHED"]
-    if not finished:
-        return max(
-            bucket,
-            key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
-        )
-    non_tie = [
-        r for r in finished
-        if r.get("home_goals") is not None
-        and r.get("away_goals") is not None
-        and r["home_goals"] != r["away_goals"]
-    ]
-    pool = non_tie if non_tie else finished
-    return max(
-        pool,
-        key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc),
-    )
+# Bracket dedup helpers are shared with ncaa_soccer_cup -- canonical
+# impls live in _soccer_bracket_helpers. Re-export under the legacy
+# names so any tests / call sites grepping for
+# `_dedupe_pk_shootout_pairs` in this module still find it.
+from ._soccer_bracket_helpers import (
+    dedupe_pk_shootout_pairs as _dedupe_pk_shootout_pairs,
+    pick_decisive_event as _pick_decisive_event,
+)
 
 
 def _assign_matchdays_and_dedupe(

--- a/sources/ncaa_soccer_cup.py
+++ b/sources/ncaa_soccer_cup.py
@@ -114,65 +114,14 @@ def _http_get(url: str, timeout: float = 15.0) -> Optional[Any]:
         return None
 
 
-def _dedupe_pk_shootout_pairs(
-    records: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
-    """Collapse multiple events at the same (stage, participants) tuple
-    into the single decisive event. ESPN occasionally publishes two
-    records for a soccer bracket game that goes to OT / PKs: one with
-    the regulation tie (e.g., 0-0) marked finished, and a second with
-    the PK shootout final score (e.g., 3-2). Both are tagged complete
-    in ESPN's scoreboard.
-
-    Preference order when multiple records collide on (stage,
-    frozenset(home, away)):
-      1. SCHEDULED records lose to any FINISHED record (real outcomes
-         beat placeholders).
-      2. Among FINISHED records, non-tie outcomes beat tie outcomes
-         (PK shootout score beats the regulation tie).
-      3. Among non-tie FINISHED records, the LATEST `start_time` wins
-         (handles a real same-day duplicate; in practice the shootout
-         event is published with a later timestamp than the regulation
-         tie).
-
-    This is conservative: single-game elimination brackets cannot have
-    a real second leg between the same two teams at the same stage, so
-    any (stage, participants) collision IS data noise.
-    """
-    # Bucket records by their dedup key. order matters: insertion order
-    # in the candidates list is by-date, so the first record we see for
-    # a (stage, participants) pair is the earliest event.
-    buckets: Dict[Tuple[str, frozenset], List[Dict[str, Any]]] = {}
-    for rec in records:
-        key = (rec["stage"], frozenset((rec["home"], rec["away"])))
-        buckets.setdefault(key, []).append(rec)
-
-    out: List[Dict[str, Any]] = []
-    for key, bucket in buckets.items():
-        if len(bucket) == 1:
-            out.append(bucket[0])
-            continue
-        out.append(_pick_decisive_event(bucket))
-    return out
-
-
-def _pick_decisive_event(bucket: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Apply the (FINISHED > SCHEDULED, non-tie > tie, latest > earliest)
-    preference order. Bucket has 2+ records guaranteed.
-    """
-    finished = [r for r in bucket if r.get("status") == "FINISHED"]
-    if not finished:
-        # All scheduled: keep the latest by start_time (most recent
-        # info is the canonical one).
-        return max(bucket, key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc))
-    non_tie = [
-        r for r in finished
-        if r.get("home_goals") is not None
-        and r.get("away_goals") is not None
-        and r["home_goals"] != r["away_goals"]
-    ]
-    pool = non_tie if non_tie else finished
-    return max(pool, key=lambda r: r.get("start_time") or datetime.min.replace(tzinfo=timezone.utc))
+# Bracket dedup helpers are shared with mls_cup -- canonical impls live
+# in _soccer_bracket_helpers. Re-export under the legacy names so any
+# tests / call sites grepping for `_dedupe_pk_shootout_pairs` in this
+# module still find it.
+from ._soccer_bracket_helpers import (
+    dedupe_pk_shootout_pairs as _dedupe_pk_shootout_pairs,
+    pick_decisive_event as _pick_decisive_event,
+)
 
 
 def _team_canonical_name(team_obj: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

Extracts the duplicated `_dedupe_pk_shootout_pairs` / `_pick_decisive_event` helpers from `sources/ncaa_soccer_cup.py` and `sources/mls_cup.py` into a new shared module `sources/_soccer_bracket_helpers.py`. The duplication was intentional (PRs #68 and #72 had to be self-contained) and tracked in #69.

Both call sites now re-export under the `_dedupe_pk_shootout_pairs` / `_pick_decisive_event` private names so test grepping continues to find the symbols in the original module.

## Files

- `sources/_soccer_bracket_helpers.py` (new) — canonical impl. Public names: `dedupe_pk_shootout_pairs`, `pick_decisive_event`. Module-level docstring explains why this exists and links #69.
- `sources/ncaa_soccer_cup.py` — replaced ~60 lines of impl with a 5-line re-export from `_soccer_bracket_helpers`.
- `sources/mls_cup.py` — same. Also updated the `_assign_matchdays_and_dedupe` docstring's cross-reference to point to the canonical home (was pointing to ncaa_soccer_cup.py which itself no longer has the impl).

## Test plan

- [x] Full suite: 1028 pass, identical to baseline. The helpers are pure-function data-shape transforms, so the existing test_sources tests cover the canonical impl via the re-export.
- [x] No production behavior change — both call sites previously used identical impls.

## Related

- Sibling to #66 (broader ESPN-parser DRY-up across mls_standings / ncaa_soccer / ncaa_baseball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)