### PR TITLE
Closes #66: DRY ESPN scoreboard event parser across mls_standings / ncaa_soccer / ncaa_baseball

### DIFF
--- a/sources/_espn.py
+++ b/sources/_espn.py
@@ -1,0 +1,117 @@
+"""Shared helpers for ESPN scoreboard event parsing.
+
+`mls_standings`, `ncaa_soccer`, `ncaa_baseball`, and (via the bracket
+helpers) the cup-bracket sources all consume ESPN's
+`/scoreboard?dates=YYYYMMDD` shape. The per-event extraction logic is
+the same across these: pull the two competitors, canonicalize team
+names, classify status, parse scores, demote FINISHED-without-scores
+to SCHEDULED, emit the canonical PointsBasedSportSource record.
+
+Per-source variation is restricted to:
+
+  - How team names are canonicalized. Soccer uses
+    `team.location` -> `team.name` -> `team.abbreviation`; baseball
+    uses `team.displayName`. Callers pass `team_namer`.
+
+  - What extra metadata the source wants on each record (e.g.,
+    `mls_standings` wants `season_slug` for bracket vs regular-season
+    routing; ncaa_soccer wants nothing). Callers pass `extras_fn`,
+    a callable that receives the full event dict and returns a dict
+    of extra top-level fields (NOT inside the `extra` sub-dict --
+    those are first-class fields like `season_slug`).
+
+DO NOT inline a fourth copy of this in a new ESPN-backed source.
+Import from here. See #66 for the consolidation history.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from .._util import parse_iso_utc
+
+
+def extract_espn_scoreboard_event(
+    event: Dict[str, Any],
+    *,
+    team_namer: Callable[[Dict[str, Any]], str],
+    extras_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Convert one ESPN scoreboard event into the canonical
+    PointsBasedSportSource game record, or return None when the event
+    is malformed (missing competitors, missing teams, etc.).
+
+    Output shape (always present):
+      id, home, away, home_points, away_points, status, start_time, extra
+
+    Plus any top-level keys returned by `extras_fn(event)` if provided
+    (e.g., `season_slug` for ESPN soccer events).
+
+    Status classification:
+      - `completed=True` or `state == "post"` -> FINISHED
+      - Anything else -> SCHEDULED
+      - FINISHED with missing scores demotes to SCHEDULED (the
+        importance simulator must not seed a 0-0 result from a
+        score-less FINISHED tag, which happens on some preseason and
+        forfeited rows).
+
+    home_points and away_points are integers (parsed from
+    `competitor.score`) when status is FINISHED, otherwise None.
+    Tied final scores in FINISHED games are LEFT TIED -- soccer-
+    flavored callers want `hp == ap` to read as a draw. Sports that
+    "force a winner via overtime" (NCAAF / NCAAM) coin-flip the tie
+    upstream, not here.
+    """
+    comps = event.get("competitions") or []
+    if not comps:
+        return None
+    comp = comps[0]
+    competitors = comp.get("competitors") or []
+    if len(competitors) != 2:
+        return None
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if home is None or away is None:
+        return None
+    home_team = team_namer(home.get("team") or {})
+    away_team = team_namer(away.get("team") or {})
+    if not home_team or not away_team:
+        return None
+
+    status_type = (comp.get("status") or {}).get("type") or {}
+    completed = bool(status_type.get("completed"))
+    state = (status_type.get("state") or "").lower()
+    if completed or state == "post":
+        status = "FINISHED"
+    else:
+        status = "SCHEDULED"
+
+    try:
+        hp = int(home.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        hp = None
+    try:
+        ap = int(away.get("score")) if status == "FINISHED" else None
+    except (TypeError, ValueError):
+        ap = None
+
+    # FINISHED but missing scores demotes to SCHEDULED: the importance
+    # simulator must not seed a 0-0 result. This happens on some
+    # preseason and forfeit rows in ESPN's data.
+    if status == "FINISHED" and (hp is None or ap is None):
+        status = "SCHEDULED"
+        hp = None
+        ap = None
+
+    out: Dict[str, Any] = {
+        "id": event.get("id"),
+        "home": home_team,
+        "away": away_team,
+        "home_points": hp,
+        "away_points": ap,
+        "status": status,
+        "start_time": parse_iso_utc(event.get("date")),
+        "extra": {},
+    }
+    if extras_fn is not None:
+        out.update(extras_fn(event))
+    return out

--- a/sources/mls_standings.py
+++ b/sources/mls_standings.py
@@ -75,6 +75,7 @@ from .mls import (
     _team_canonical_name,
 )
 from .._util import parse_iso_utc
+from ._espn import extract_espn_scoreboard_event
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.mls_standings")
 
@@ -162,65 +163,19 @@ def _fetch_conference_map() -> Dict[str, str]:
 
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert one ESPN MLS scoreboard event into the canonical
-    PointsBasedSportSource game record. Soccer-specific: a tied score
-    in a finished regulation game IS a draw (1 point each): DO NOT
-    coin-flip it into a win the way NCAAF / NCAAM do. Same shape as
-    `ncaa_soccer._extract_game_record`.
-
-    Returns None when the event is malformed (missing competitors,
-    missing teams) or when status reads as in-progress with no
-    final score.
+    PointsBasedSportSource game record. Adds `season_slug` (top-level
+    AND inside `extra`) so callers can route bracket vs regular-season
+    rows. Soccer-specific: a tied score in a finished regulation game
+    IS a draw (1 point each) -- the shared parser preserves this
+    (NCAAF / NCAAM coin-flip the tie upstream, not here).
     """
-    comps = event.get("competitions") or []
-    if not comps:
-        return None
-    comp = comps[0]
-    competitors = comp.get("competitors") or []
-    if len(competitors) != 2:
-        return None
-    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
-    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
-    if home is None or away is None:
-        return None
-    home_team = _team_canonical_name(home.get("team") or {})
-    away_team = _team_canonical_name(away.get("team") or {})
-    if not home_team or not away_team:
-        return None
+    def _mls_extras(ev: Dict[str, Any]) -> Dict[str, Any]:
+        season_slug = ((ev.get("season") or {}).get("slug") or "").lower()
+        return {"season_slug": season_slug, "extra": {"season_slug": season_slug}}
 
-    status_type = (comp.get("status") or {}).get("type") or {}
-    completed = bool(status_type.get("completed"))
-    state = (status_type.get("state") or "").lower()
-    if completed or state == "post":
-        status = "FINISHED"
-    else:
-        status = "SCHEDULED"
-
-    try:
-        hp = int(home.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        hp = None
-    try:
-        ap = int(away.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        ap = None
-
-    if status == "FINISHED" and (hp is None or ap is None):
-        status = "SCHEDULED"
-        hp = None
-        ap = None
-
-    season_slug = ((event.get("season") or {}).get("slug") or "").lower()
-    return {
-        "id": event.get("id"),
-        "home": home_team,
-        "away": away_team,
-        "home_points": hp,
-        "away_points": ap,
-        "status": status,
-        "start_time": parse_iso_utc(event.get("date")),
-        "season_slug": season_slug,
-        "extra": {"season_slug": season_slug},
-    }
+    return extract_espn_scoreboard_event(
+        event, team_namer=_team_canonical_name, extras_fn=_mls_extras,
+    )
 
 
 class MlsStandingsSourceBase(PointsBasedSportSource):

--- a/sources/ncaa_baseball.py
+++ b/sources/ncaa_baseball.py
@@ -56,6 +56,7 @@ from .._util import (
     parse_iso_utc,
     poisson_sample as _poisson,
 )
+from ._espn import extract_espn_scoreboard_event
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_baseball")
 
@@ -137,61 +138,11 @@ def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert one ESPN scoreboard event into the canonical PointsBased
     game record. Returns None if the event isn't a two-team competition
     we can score (cancellations, postponements with no competitors, etc.).
-    """
-    comps = event.get("competitions") or []
-    if not comps:
-        return None
-    comp = comps[0]
-    competitors = comp.get("competitors") or []
-    if len(competitors) != 2:
-        return None
-    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
-    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
-    if home is None or away is None:
-        return None
-    home_team = _team_canonical_name(home.get("team") or {})
-    away_team = _team_canonical_name(away.get("team") or {})
-    if not home_team or not away_team:
-        return None
-
-    status_type = (comp.get("status") or {}).get("type") or {}
-    completed = bool(status_type.get("completed"))
-    state = (status_type.get("state") or "").lower()
-    if completed or state == "post":
-        status = "FINISHED"
-    elif state == "in":
-        # In-progress games are unstable scores. Treat as SCHEDULED so
-        # the simulator doesn't seed wins/losses from mid-game state.
-        status = "SCHEDULED"
-    else:
-        status = "SCHEDULED"
-
-    try:
-        hp = int(home.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        hp = None
-    try:
-        ap = int(away.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        ap = None
-
-    # If "FINISHED" but scores are missing, demote to SCHEDULED: the
-    # importance simulator must not seed a 0-0 result.
-    if status == "FINISHED" and (hp is None or ap is None):
-        status = "SCHEDULED"
-        hp = None
-        ap = None
-
-    return {
-        "id": event.get("id"),
-        "home": home_team,
-        "away": away_team,
-        "home_points": hp,
-        "away_points": ap,
-        "status": status,
-        "start_time": parse_iso_utc(event.get("date")),
-        "extra": {},
-    }
+    The shared parser handles status / score / FINISHED-without-scores
+    demotion; ncaa_baseball's previous explicit `state == "in"` branch
+    is collapsed because the shared parser's else-branch produces the
+    same SCHEDULED outcome for in-progress games."""
+    return extract_espn_scoreboard_event(event, team_namer=_team_canonical_name)
 
 
 class NcaaBaseballRegularSource(PointsBasedSportSource):

--- a/sources/ncaa_soccer.py
+++ b/sources/ncaa_soccer.py
@@ -33,6 +33,7 @@ import requests
 from .base import GameRow
 from .points_based import PointsBasedSportSource
 from .._util import parse_iso_utc
+from ._espn import extract_espn_scoreboard_event
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.ncaa_soccer")
 
@@ -76,58 +77,10 @@ def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
 def _extract_game_record(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert one ESPN scoreboard event into the canonical PointsBased
     game record. Soccer-specific: a tied score in a regulation game IS
-    a draw (not a "force a winner via overtime" outcome). Status
-    classification mirrors ncaa_baseball but allows hp == ap in FINISHED
-    games.
-    """
-    comps = event.get("competitions") or []
-    if not comps:
-        return None
-    comp = comps[0]
-    competitors = comp.get("competitors") or []
-    if len(competitors) != 2:
-        return None
-    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
-    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
-    if home is None or away is None:
-        return None
-    home_team = _team_canonical_name(home.get("team") or {})
-    away_team = _team_canonical_name(away.get("team") or {})
-    if not home_team or not away_team:
-        return None
-
-    status_type = (comp.get("status") or {}).get("type") or {}
-    completed = bool(status_type.get("completed"))
-    state = (status_type.get("state") or "").lower()
-    if completed or state == "post":
-        status = "FINISHED"
-    else:
-        status = "SCHEDULED"
-
-    try:
-        hp = int(home.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        hp = None
-    try:
-        ap = int(away.get("score")) if status == "FINISHED" else None
-    except (TypeError, ValueError):
-        ap = None
-
-    if status == "FINISHED" and (hp is None or ap is None):
-        status = "SCHEDULED"
-        hp = None
-        ap = None
-
-    return {
-        "id": event.get("id"),
-        "home": home_team,
-        "away": away_team,
-        "home_points": hp,
-        "away_points": ap,
-        "status": status,
-        "start_time": parse_iso_utc(event.get("date")),
-        "extra": {},
-    }
+    a draw (not a "force a winner via overtime" outcome). The shared
+    parser preserves the tie semantics; this wrapper just supplies the
+    soccer team-name canonicalizer."""
+    return extract_espn_scoreboard_event(event, team_namer=_team_canonical_name)
 
 
 class NcaaSoccerSource(PointsBasedSportSource):


### PR DESCRIPTION
## Summary

Extracts the duplicated `_extract_game_record` function from three sources into a single shared parser at `sources/_espn.py:extract_espn_scoreboard_event`. Each caller now passes a small `team_namer` callable (and `extras_fn` if it needs source-specific top-level fields), eliminating ~120 lines of cut-and-paste while preserving every documented behavior difference.

## What was duplicated

All three of `mls_standings.py`, `ncaa_soccer.py`, and `ncaa_baseball.py` had a near-identical ~60-line `_extract_game_record` doing:

1. Pull `event.competitions[0].competitors[]`, find home/away
2. Canonicalize each team name
3. Classify status: `completed=True` or `state == "post"` -> FINISHED, else SCHEDULED
4. Parse `competitor.score` as int when FINISHED, else None
5. Demote FINISHED-without-scores to SCHEDULED (importance simulator must not seed 0-0 from a forfeit row)
6. Emit `{id, home, away, home_points, away_points, status, start_time, extra}`

The documented variation:

| Variation | mls_standings | ncaa_soccer | ncaa_baseball |
|---|---|---|---|
| Team namer | `team.location` -> `name` -> `abbreviation` | same as MLS | `team.displayName` |
| `season_slug` field | yes (top-level + `extra.season_slug`) | no | no |
| `state == "in"` handling | falls through (SCHEDULED) | falls through (SCHEDULED) | explicit branch (SCHEDULED) |

After consolidation:

- `team_namer` callable supplies the per-source canonicalizer.
- `extras_fn` callable lets mls_standings inject `season_slug`.
- `state == "in"` no longer needs an explicit branch — the shared parser's else-branch produces the same SCHEDULED outcome, identical net behavior.

## Files

- `sources/_espn.py` (new, 110 lines) — canonical `extract_espn_scoreboard_event(event, *, team_namer, extras_fn=None)`. Module-level docstring documents the variation points and points #66 for history.
- `sources/mls_standings.py` — `_extract_game_record` shrunk from 58 lines to 13 (8 of which are the closure for the `season_slug` extras_fn).
- `sources/ncaa_soccer.py` — `_extract_game_record` shrunk from 55 lines to 6.
- `sources/ncaa_baseball.py` — `_extract_game_record` shrunk from 59 lines to 8.

## Test plan

- [x] Full suite: 1028 pass, identical to baseline. Each source's existing tests in `test_sources.py` exercise the consolidated parser via the wrapper.
- [x] No behavior change verified: `state == "in"` collapses into the shared else-branch with the same SCHEDULED outcome.

## Related

- Sibling to #69 (consolidated `_dedupe_pk_shootout_pairs` across the cup-bracket sources). Same DRY theme; both PRs land before the next ESPN schema change that would otherwise have to be fixed in N places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)