### PR TITLE
Closes #74: typed contracts for simulator soccer state + team row

### DIFF
--- a/sources/base.py
+++ b/sources/base.py
@@ -16,7 +16,46 @@ import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional, TypedDict
+
+
+class SoccerTeamRow(TypedDict):
+    """Per-team standings row used by SoccerSource / GroupStageSoccerSource.
+
+    DO NOT add fields here without checking every producer and consumer in
+    sources/soccer.py -- this row is constructed in two `initial_state`
+    methods and mutated in `_mutate_apply`; a missing field is a runtime
+    KeyError on the first match the simulator applies. A renamed field is
+    worse: silent miscounting in the standings sort that drives
+    terminal_outcomes' advance/eliminated labels."""
+    played: int
+    points: int
+    gf: int   # goals for
+    ga: int   # goals against
+
+
+class PointsBasedTeamRow(TypedDict):
+    """Per-team row used by PointsBasedSportSource (NCAAF / NCAAM / NFL /
+    NHL / MLB / NBA / MLS conference standings / NCAA baseball / etc.).
+
+    NHL subclasses extend with a `standings_points` field via
+    `_record_result_into_state` override; the TypedDict is total=False so
+    a typed consumer can read it without pyright complaining that it might
+    be missing on non-NHL rows."""
+    wins: int
+    losses: int
+    pf: int            # points-for (aggregated across games)
+    pa: int            # points-against
+    games_played: int
+
+
+class PointsBasedTeamRowWithStandings(PointsBasedTeamRow, total=False):
+    """NHL extends the base row with `standings_points` (regulation +
+    OT + shootout per the NHL 2-point regulation / 1-point OT-loss
+    rule). Other points-based sports don't need this field. Optional
+    via total=False so consumers can read row.get('standings_points')
+    safely."""
+    standings_points: int
 
 
 @dataclass

--- a/sources/soccer.py
+++ b/sources/soccer.py
@@ -24,13 +24,43 @@ import logging
 import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional, Tuple, TypedDict
 
 import requests
 
-from .base import GameRow, MatchResult, SportSource
+from .base import GameRow, MatchResult, SoccerTeamRow, SportSource
 from .bracket import AggregateLegSource
 from .._util import parse_iso_utc, poisson_sample as _poisson
+
+
+class SoccerLeagueState(TypedDict):
+    """State shape for `SoccerSource.initial_state` (and every consumer:
+    apply_result, remaining_matches, terminal_outcomes). Single home for
+    the contract the points/gf/ga/played per-team row contributes to.
+
+    `_applied` is the set of fd_ids (match identifiers) already folded
+    into the per-team rows. `_teams` is the per-team standings table.
+
+    See `GroupStageState` for the group-stage extension that adds the
+    team->group lookup `_team_group`."""
+    _applied: FrozenSet[Any]
+    _teams: Dict[str, SoccerTeamRow]
+
+
+class GroupStageState(SoccerLeagueState):
+    """State shape for `GroupStageSoccerSource.initial_state` (WC, EURO,
+    other international group-stage tournaments). Extends `SoccerLeagueState`
+    with `_team_group` so terminal_outcomes can group teams by their
+    drawn group when classifying advance / eliminated. The team-group
+    map is computed once from FD.org's group-stage fixture metadata
+    and frozen at `initial_state` time -- mutations to `_teams` during
+    simulation never touch it.
+
+    Subclassing SoccerLeagueState (rather than redeclaring the shared
+    fields) means `GroupStageSoccerSource` can safely inherit
+    `SoccerSource.apply_result` and `_mutate_apply` -- a GroupStageState
+    IS-A SoccerLeagueState at the type level."""
+    _team_group: Dict[str, str]
 from ..scoring import LEAGUE_CONTEXTS, TEAM_SUFFIX_TOKENS
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.soccer")
@@ -836,13 +866,15 @@ class SoccerSource(SportSource):
         from finished matches in the season (NOT from the FD.org standings
         endpoint: that endpoint can include in-progress results that
         de-sync from the fixture list, and the simulator needs the two to
-        agree).
+        agree). Returns the structurally-typed `SoccerLeagueState` shape
+        (return annotation is Dict[str, Any] to stay compatible with
+        bracket-subclass overrides via MRO; consumers should treat the
+        returned dict as `SoccerLeagueState`).
 
-        State shape:
+        State shape (`SoccerLeagueState`):
           {
             "_applied": frozenset of fd_ids already reflected in points/gf/ga,
-            <team_name>: {"played": int, "points": int, "gf": int, "ga": int},
-            ...
+            "_teams": {<team_name>: SoccerTeamRow, ...},
           }
 
         Teams that appear in the fixture list but haven't played yet still
@@ -852,18 +884,23 @@ class SoccerSource(SportSource):
         if self._initial_state_cache is not None:
             return self._initial_state_cache
         matches = self._fetch_all_season_matches()
-        state: Dict[str, Any] = {"_applied": frozenset()}
+        teams: Dict[str, SoccerTeamRow] = {}
         applied: List[Any] = []
-        teams_seen: set = set()
         # Seed every team that appears anywhere in the season fixtures with
         # a zero row, so apply_result doesn't need to defensively create
         # rows for newly-encountered teams.
         for m in matches:
             for side in ("homeTeam", "awayTeam"):
                 name = (m.get(side) or {}).get("name")
-                if name and name not in teams_seen:
-                    teams_seen.add(name)
-                    state[name] = {"played": 0, "points": 0, "gf": 0, "ga": 0}
+                if name and name not in teams:
+                    teams[name] = SoccerTeamRow(played=0, points=0, gf=0, ga=0)
+        # Construct as plain dict so the producer's return type stays
+        # `Dict[str, Any]` (TypedDict and Dict[str, Any] are not subtype-
+        # compatible at the static-check level; the MRO collision with
+        # BracketSportSource forces the loose return type). Consumers
+        # that want the narrower static type can `cast(SoccerLeagueState,
+        # state)` -- the runtime shape is exactly that.
+        state: Dict[str, Any] = {"_applied": frozenset(), "_teams": teams}
         # Apply FINISHED matches to populate the standings snapshot.
         for m in matches:
             if m.get("status") != "FINISHED":
@@ -888,9 +925,15 @@ class SoccerSource(SportSource):
     def _mutate_apply(state: Dict[str, Any], home: str, away: str, hg: int, ag: int) -> None:
         """Apply one finished result to a state dict in place. Used by
         `initial_state` (where mutation is fine: we own the new state) and
-        `apply_result` (which copies first to preserve immutability)."""
-        h = state[home]
-        a = state[away]
+        `apply_result` (which copies first to preserve immutability).
+
+        Accepts either `SoccerLeagueState` or `GroupStageState` (both
+        carry the `_teams` dict the implementation reads); both narrow
+        to `Dict[str, SoccerTeamRow]` at the team-row access path so
+        pyright catches field-name typos like `row["pts"]` for `points`."""
+        teams: Dict[str, SoccerTeamRow] = state["_teams"]
+        h = teams[home]
+        a = teams[away]
         h["played"] += 1
         a["played"] += 1
         h["gf"] += hg
@@ -909,7 +952,7 @@ class SoccerSource(SportSource):
         """All matches not yet applied. The simulator uses this to know
         which matches still need sampling after applying the target match.
         """
-        applied = state.get("_applied", frozenset())
+        applied = state["_applied"]
         matches = self._fetch_all_season_matches()
         out: List[GameRow] = []
         for m in matches:
@@ -970,18 +1013,22 @@ class SoccerSource(SportSource):
         """Return a NEW state with `match`'s `result` applied. Pure: the
         simulator depends on this NOT mutating `state` so one initial_state
         can seed many sampled seasons.
+
+        Splat-copies the input state so subclass metadata (e.g.,
+        `_team_group` from GroupStageState) is preserved; then deeply
+        copies the two team rows we'll mutate. Other teams are shared
+        by reference, which is safe because we never write back through
+        them in this update.
         """
-        # Shallow-copy the state dict plus the two team rows we'll mutate.
-        # Other teams are shared by reference; cheap and correct because
-        # we never write back through them in this update.
-        new_state = dict(state)
-        new_state[match.home] = dict(state[match.home])
-        new_state[match.away] = dict(state[match.away])
+        new_teams: Dict[str, SoccerTeamRow] = dict(state["_teams"])
+        new_teams[match.home] = dict(new_teams[match.home])  # type: ignore[typeddict-item]
+        new_teams[match.away] = dict(new_teams[match.away])  # type: ignore[typeddict-item]
+        new_state: Dict[str, Any] = {**state, "_teams": new_teams}
         self._mutate_apply(new_state, match.home, match.away,
                            result.home_goals, result.away_goals)
         fd_id = match.extra.get("fd_id") if isinstance(match.extra, dict) else None
         if fd_id is not None:
-            new_state["_applied"] = state.get("_applied", frozenset()) | {fd_id}
+            new_state["_applied"] = state["_applied"] | {fd_id}
         return new_state
 
     def terminal_outcomes(self, state: Dict[str, Any]) -> Dict[str, List[str]]:
@@ -996,8 +1043,9 @@ class SoccerSource(SportSource):
         decides aggregation per the cross-sport sum rule.
         """
         ctx = LEAGUE_CONTEXTS.get(self.config.fd_code)
+        teams_dict: Dict[str, SoccerTeamRow] = state["_teams"]
         if ctx is None:
-            return {team: [] for team in state if team != "_applied"}
+            return {team: [] for team in teams_dict}
         # DO NOT use this method for knockout-format contexts (UCL, etc.).
         # The cutoff in knockout thresholds is a stage string ("LAST_16"),
         # not an int position: the `pos > cutoff` comparison below would
@@ -1012,8 +1060,8 @@ class SoccerSource(SportSource):
                 "factory should route this competition to KnockoutSoccerSource.",
                 self.config.fd_code, ctx.format,
             )
-            return {team: [] for team in state if team != "_applied"}
-        teams = [(name, row) for name, row in state.items() if name != "_applied"]
+            return {team: [] for team in teams_dict}
+        teams = list(teams_dict.items())
         teams.sort(
             key=lambda kv: (
                 -kv[1]["points"],
@@ -1389,8 +1437,8 @@ class GroupStandings(NamedTuple):
     Tuple-unpackable for legacy call sites; field-accessible for new ones.
     See the helper's docstring for field semantics.
     """
-    by_group: Dict[str, List[Tuple[str, Dict[str, int]]]]
-    best_third_order: List[Tuple[str, Dict[str, int]]]
+    by_group: Dict[str, List[Tuple[str, SoccerTeamRow]]]
+    best_third_order: List[Tuple[str, SoccerTeamRow]]
     n_best_third_advance: int
 
 
@@ -2072,15 +2120,18 @@ class GroupStageSoccerSource(SoccerSource):
             return self._initial_state_cache
         team_group = self._team_group_map()
         matches = self._fetch_all_season_matches()
+        # Seed every group-stage participant with a zero row so apply_result
+        # doesn't need to defensively create rows.
+        teams: Dict[str, SoccerTeamRow] = {
+            team: SoccerTeamRow(played=0, points=0, gf=0, ga=0)
+            for team in team_group
+        }
         state: Dict[str, Any] = {
             "_applied": frozenset(),
             "_team_group": team_group,
+            "_teams": teams,
         }
         applied: List[Any] = []
-        # Seed every group-stage participant with a zero row so apply_result
-        # doesn't need to defensively create rows.
-        for team in team_group:
-            state[team] = {"played": 0, "points": 0, "gf": 0, "ga": 0}
         # Apply FINISHED group-stage matches.
         for m in matches:
             if m.get("stage") != "GROUP_STAGE":
@@ -2097,7 +2148,7 @@ class GroupStageSoccerSource(SoccerSource):
             fd_id = m.get("id")
             if not home or not away or fd_id is None:
                 continue
-            if home not in state or away not in state:
+            if home not in state["_teams"] or away not in state["_teams"]:
                 continue  # defensive: team_group_map should have covered them
             applied.append(fd_id)
             self._mutate_apply(state, home, away, int(hg), int(ag))
@@ -2107,7 +2158,7 @@ class GroupStageSoccerSource(SoccerSource):
 
     def remaining_matches(self, state: Dict[str, Any]) -> List[GameRow]:
         """Only emit GROUP_STAGE matches the simulator hasn't applied yet."""
-        applied = state.get("_applied", frozenset())
+        applied = state["_applied"]
         out: List[GameRow] = []
         for m in self._fetch_all_season_matches():
             if m.get("stage") != "GROUP_STAGE":
@@ -2133,7 +2184,7 @@ class GroupStageSoccerSource(SoccerSource):
         return out
 
     @staticmethod
-    def _fifa_tiebreaker_key(row: Dict[str, int]) -> Tuple[int, int, int]:
+    def _fifa_tiebreaker_key(row: SoccerTeamRow) -> Tuple[int, int, int]:
         """FIFA's group-stage tiebreaker chain (points, goal diff, goals
         for), negated for descending sort. The same chain governs the
         within-group ranking AND the cross-group best-3rd-place ranking
@@ -2171,17 +2222,16 @@ class GroupStageSoccerSource(SoccerSource):
         from collections import defaultdict
         from ..scoring import LEAGUE_CONTEXTS
 
-        team_group = state.get("_team_group", {})
-        by_group: Dict[str, List[Tuple[str, Dict[str, int]]]] = defaultdict(list)
-        for team, row in state.items():
-            if team in ("_applied", "_team_group"):
-                continue
+        team_group: Dict[str, str] = state["_team_group"]
+        teams_dict: Dict[str, SoccerTeamRow] = state["_teams"]
+        by_group: Dict[str, List[Tuple[str, SoccerTeamRow]]] = defaultdict(list)
+        for team, row in teams_dict.items():
             group = team_group.get(team)
             if group is None:
                 continue
             by_group[group].append((team, row))
 
-        third_placers: List[Tuple[str, Dict[str, int]]] = []
+        third_placers: List[Tuple[str, SoccerTeamRow]] = []
         for teams in by_group.values():
             teams.sort(key=lambda kv: self._fifa_tiebreaker_key(kv[1]))
             if len(teams) > _GROUP_ADVANCE_TOP_N:
@@ -2330,7 +2380,7 @@ class GroupStageSoccerSource(SoccerSource):
             return None
 
         # Build the team -> group-letter lookup for the 3rd-placers.
-        team_group_map = primary_state.get("_team_group", {})
+        team_group_map = primary_state["_team_group"]
 
         def _letter_of(team: str) -> Optional[str]:
             grp = team_group_map.get(team)

--- a/tests/test_annex_c_table.py
+++ b/tests/test_annex_c_table.py
@@ -173,8 +173,8 @@ class TestBuildBracketSeedUsesCanonicalMapping:
     def _state_with_thirds_abcdefgh(soccer):
         # Lifted from test_sources.py::TestBuildBracketSeedWC2026._full_wc_state
         # but inlined to avoid cross-file fixture coupling.
-        team_group = {}
-        state = {"_applied": frozenset(), "_team_group": team_group}
+        team_group: dict = {}
+        teams_dict: dict = {}
         for gi in range(12):
             letter = chr(ord("A") + gi)
             grp = f"GROUP_{letter}"
@@ -189,8 +189,8 @@ class TestBuildBracketSeedUsesCanonicalMapping:
             ]
             for team, points, gd, gf in teams:
                 team_group[team] = grp
-                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
-        return state
+                teams_dict[team] = {"points": points, "gf": gf, "ga": gf - gd, "played": 3}
+        return {"_applied": frozenset(), "_team_group": team_group, "_teams": teams_dict}
 
     def test_canonical_m74_assignment(self, soccer):
         """Annex C row {ABCDEFGH}: M74's away (the slot whose home is

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -106,10 +106,10 @@ class FakeSource(SportSource):
         return self.strengths_map
 
     def initial_state(self) -> Dict[str, Any]:
-        state: Dict[str, Any] = {"_applied": frozenset()}
-        for t in self.teams:
-            state[t] = {"played": 0, "points": 0, "gf": 0, "ga": 0}
-        return state
+        teams: Dict[str, Dict[str, int]] = {
+            t: {"played": 0, "points": 0, "gf": 0, "ga": 0} for t in self.teams
+        }
+        return {"_applied": frozenset(), "_teams": teams}
 
     def remaining_matches(self, state: Dict[str, Any]) -> List[GameRow]:
         applied = state.get("_applied", frozenset())
@@ -123,11 +123,11 @@ class FakeSource(SportSource):
         return MatchResult(home_goals=_poisson(lam_h, rng), away_goals=_poisson(lam_a, rng))
 
     def apply_result(self, state, match, result):
-        new_state = dict(state)
-        new_state[match.home] = dict(state[match.home])
-        new_state[match.away] = dict(state[match.away])
-        h = new_state[match.home]
-        a = new_state[match.away]
+        new_teams = dict(state["_teams"])
+        new_teams[match.home] = dict(new_teams[match.home])
+        new_teams[match.away] = dict(new_teams[match.away])
+        h = new_teams[match.home]
+        a = new_teams[match.away]
         h["played"] += 1
         a["played"] += 1
         h["gf"] += result.home_goals
@@ -141,13 +141,14 @@ class FakeSource(SportSource):
         else:
             h["points"] += 1
             a["points"] += 1
+        new_state = {"_applied": state.get("_applied", frozenset()), "_teams": new_teams}
         fd_id = match.extra.get("fd_id")
         if fd_id is not None:
             new_state["_applied"] = state.get("_applied", frozenset()) | {fd_id}
         return new_state
 
     def terminal_outcomes(self, state):
-        teams = [(name, row) for name, row in state.items() if name != "_applied"]
+        teams = [(name, row) for name, row in state["_teams"].items()]
         teams.sort(key=lambda kv: (-kv[1]["points"], -(kv[1]["gf"] - kv[1]["ga"]), -kv[1]["gf"]))
         out: Dict[str, List[str]] = {n: [] for n, _ in teams}
         if teams:
@@ -402,7 +403,7 @@ class FakePlayoffSource(SportSource):
 def _group_winner_seed_fn(primary_state: Dict[str, Any]) -> Dict[str, Any]:
     """Map primary FakeSource standings to playoff seeding. Top finisher
     qualifies; the bottom finisher is eliminated_in_playoffs."""
-    teams = [(n, r) for n, r in primary_state.items() if n != "_applied"]
+    teams = list(primary_state["_teams"].items())
     teams.sort(key=lambda kv: (-kv[1]["points"], -(kv[1]["gf"] - kv[1]["ga"]), -kv[1]["gf"]))
     if not teams:
         return {"qualified": [], "eliminated": []}
@@ -524,7 +525,7 @@ class TestMonteCarloImportanceBatchChain:
         # which is 6 games × 2 teams = matches).
         for state in captured:
             for team in ("Alpha", "Beta", "Gamma", "Delta"):
-                assert state[team]["played"] == 3
+                assert state["_teams"][team]["played"] == 3
 
 
 # ---------- _same_match ----------

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -724,7 +724,7 @@ class TestSoccerImportanceInterface:
         src = SoccerSource("ucl", fd_api_key="fake")  # ucl → fd_code="CL", knockout
         src._all_matches_cache = []  # avoid HTTP
         # Hand-built minimal state: the guard short-circuits before reading it.
-        state = {"_applied": frozenset(), "Some Team": {"played": 0, "points": 0, "gf": 0, "ga": 0}}
+        state = {"_applied": frozenset(), "_teams": {"Some Team": {"played": 0, "points": 0, "gf": 0, "ga": 0}}}
         with caplog.at_level("WARNING"):
             out = src.terminal_outcomes(state)
         assert out == {"Some Team": []}
@@ -768,16 +768,16 @@ class TestSoccerImportanceInterface:
         state = src.initial_state()
         # Team A won twice (3 pts × 2 = 6); Team C beat Team D (3 pts);
         # Team B lost (0 pts); Team D lost twice (0 pts).
-        assert state["Team A"]["played"] == 2
-        assert state["Team A"]["points"] == 6
-        assert state["Team A"]["gf"] == 5
-        assert state["Team A"]["ga"] == 0
-        assert state["Team B"]["played"] == 1
-        assert state["Team B"]["points"] == 0
-        assert state["Team C"]["played"] == 2
-        assert state["Team C"]["points"] == 3
-        assert state["Team D"]["played"] == 1
-        assert state["Team D"]["points"] == 0
+        assert state["_teams"]["Team A"]["played"] == 2
+        assert state["_teams"]["Team A"]["points"] == 6
+        assert state["_teams"]["Team A"]["gf"] == 5
+        assert state["_teams"]["Team A"]["ga"] == 0
+        assert state["_teams"]["Team B"]["played"] == 1
+        assert state["_teams"]["Team B"]["points"] == 0
+        assert state["_teams"]["Team C"]["played"] == 2
+        assert state["_teams"]["Team C"]["points"] == 3
+        assert state["_teams"]["Team D"]["played"] == 1
+        assert state["_teams"]["Team D"]["points"] == 0
 
     def test_initial_state_tracks_applied_matches(self):
         src = self._make_source()
@@ -841,15 +841,15 @@ class TestSoccerImportanceInterface:
     def test_apply_result_does_not_mutate_input_state(self):
         src = self._make_source()
         state = src.initial_state()
-        original_a_pts = state["Team A"]["points"]
+        original_a_pts = state["_teams"]["Team A"]["points"]
         original_applied = state["_applied"]
         match = next(m for m in src.remaining_matches(state) if m.extra["fd_id"] == 105)
         new_state = src.apply_result(state, match, MatchResult(home_goals=2, away_goals=0))
         # Input state untouched.
-        assert state["Team A"]["points"] == original_a_pts
+        assert state["_teams"]["Team A"]["points"] == original_a_pts
         assert state["_applied"] == original_applied
         # New state reflects the result.
-        assert new_state["Team A"]["points"] == original_a_pts + 3
+        assert new_state["_teams"]["Team A"]["points"] == original_a_pts + 3
         assert 105 in new_state["_applied"]
 
     def test_apply_result_draw(self):
@@ -857,16 +857,16 @@ class TestSoccerImportanceInterface:
         state = src.initial_state()
         match = next(m for m in src.remaining_matches(state) if m.extra["fd_id"] == 104)
         new_state = src.apply_result(state, match, MatchResult(home_goals=1, away_goals=1))
-        assert new_state["Team B"]["points"] == state["Team B"]["points"] + 1
-        assert new_state["Team D"]["points"] == state["Team D"]["points"] + 1
+        assert new_state["_teams"]["Team B"]["points"] == state["_teams"]["Team B"]["points"] + 1
+        assert new_state["_teams"]["Team D"]["points"] == state["_teams"]["Team D"]["points"] + 1
 
     def test_apply_result_away_win(self):
         src = self._make_source()
         state = src.initial_state()
         match = next(m for m in src.remaining_matches(state) if m.extra["fd_id"] == 104)
         new_state = src.apply_result(state, match, MatchResult(home_goals=0, away_goals=2))
-        assert new_state["Team B"]["points"] == state["Team B"]["points"]  # no change
-        assert new_state["Team D"]["points"] == state["Team D"]["points"] + 3
+        assert new_state["_teams"]["Team B"]["points"] == state["_teams"]["Team B"]["points"]  # no change
+        assert new_state["_teams"]["Team D"]["points"] == state["_teams"]["Team D"]["points"] + 3
 
     # ---------- terminal_outcomes ----------
 
@@ -875,9 +875,9 @@ class TestSoccerImportanceInterface:
         # position 1 should match all three top-side labels.
         src = self._make_source()
         # Hand-craft a fake final state with 20 teams.
-        state = {"_applied": frozenset()}
+        state = {"_applied": frozenset(), "_teams": {}}
         for i in range(1, 21):
-            state[f"Team {i}"] = {"played": 38, "points": 100 - i * 3, "gf": 80 - i, "ga": 20}
+            state["_teams"][f"Team {i}"] = {"played": 38, "points": 100 - i * 3, "gf": 80 - i, "ga": 20}
         outcomes = src.terminal_outcomes(state)
         assert "title" in outcomes["Team 1"]
         assert "UCL" in outcomes["Team 1"]
@@ -890,9 +890,9 @@ class TestSoccerImportanceInterface:
     def test_terminal_outcomes_assigns_bottom_side_exclusively(self):
         # In EPL: relegation cutoff = 17 (bottom-side, pos > 17 → relegated).
         src = self._make_source()
-        state = {"_applied": frozenset()}
+        state = {"_applied": frozenset(), "_teams": {}}
         for i in range(1, 21):
-            state[f"Team {i}"] = {"played": 38, "points": 100 - i * 3, "gf": 80 - i, "ga": 20}
+            state["_teams"][f"Team {i}"] = {"played": 38, "points": 100 - i * 3, "gf": 80 - i, "ga": 20}
         outcomes = src.terminal_outcomes(state)
         # Team 17 should be safe (pos 17 is not > 17).
         assert "relegation" not in outcomes["Team 17"]
@@ -904,16 +904,16 @@ class TestSoccerImportanceInterface:
     def test_terminal_outcomes_sorts_by_points_then_gd(self):
         # Two teams tied on points; goal differential breaks the tie.
         src = self._make_source()
-        state = {"_applied": frozenset()}
-        state["Tied A"] = {"played": 38, "points": 80, "gf": 70, "ga": 50}  # gd=20
-        state["Tied B"] = {"played": 38, "points": 80, "gf": 60, "ga": 50}  # gd=10
+        state = {"_applied": frozenset(), "_teams": {}}
+        state["_teams"]["Tied A"] = {"played": 38, "points": 80, "gf": 70, "ga": 50}  # gd=20
+        state["_teams"]["Tied B"] = {"played": 38, "points": 80, "gf": 60, "ga": 50}  # gd=10
         # Two stronger fillers (one above each tied team) plus weaker fillers
         # so Tied A / Tied B land at positions 3 and 4: straddling the UCL
         # cutoff so the GD tiebreak is observable.
-        state["Strong 1"] = {"played": 38, "points": 90, "gf": 60, "ga": 30}
-        state["Strong 2"] = {"played": 38, "points": 85, "gf": 60, "ga": 35}
+        state["_teams"]["Strong 1"] = {"played": 38, "points": 90, "gf": 60, "ga": 30}
+        state["_teams"]["Strong 2"] = {"played": 38, "points": 85, "gf": 60, "ga": 35}
         for i in range(5, 21):
-            state[f"Filler {i}"] = {"played": 38, "points": 100 - i * 5, "gf": 40, "ga": 50}
+            state["_teams"][f"Filler {i}"] = {"played": 38, "points": 100 - i * 5, "gf": 40, "ga": 50}
         outcomes = src.terminal_outcomes(state)
         # Tied A finishes #3 (UCL cutoff = top 4 → in UCL).
         # Tied B finishes #4 (also in UCL, but the next teams below are
@@ -7745,7 +7745,7 @@ class TestGroupStageSoccerSource:
         src = self._make_source(matches)
         state = src.initial_state()
         for team in ("Mexico", "South Africa", "Argentina", "Chile"):
-            assert state[team] == {"played": 0, "points": 0, "gf": 0, "ga": 0}
+            assert state["_teams"][team] == {"played": 0, "points": 0, "gf": 0, "ga": 0}
         assert state["_applied"] == frozenset()
         assert state["_team_group"]["Mexico"] == "GROUP_A"
 
@@ -7762,10 +7762,10 @@ class TestGroupStageSoccerSource:
         ]
         src = self._make_source(matches)
         state = src.initial_state()
-        assert state["Mexico"] == {"played": 1, "points": 3, "gf": 3, "ga": 1}
-        assert state["South Africa"] == {"played": 1, "points": 0, "gf": 1, "ga": 3}
-        assert state["Argentina"] == {"played": 1, "points": 3, "gf": 2, "ga": 0}
-        assert state["Chile"] == {"played": 1, "points": 0, "gf": 0, "ga": 2}
+        assert state["_teams"]["Mexico"] == {"played": 1, "points": 3, "gf": 3, "ga": 1}
+        assert state["_teams"]["South Africa"] == {"played": 1, "points": 0, "gf": 1, "ga": 3}
+        assert state["_teams"]["Argentina"] == {"played": 1, "points": 3, "gf": 2, "ga": 0}
+        assert state["_teams"]["Chile"] == {"played": 1, "points": 0, "gf": 0, "ga": 2}
         assert state["_applied"] == frozenset({1, 2})
 
     def test_initial_state_skips_knockout_matches(self):
@@ -7783,8 +7783,8 @@ class TestGroupStageSoccerSource:
         ]
         src = self._make_source(matches)
         state = src.initial_state()
-        assert state["Mexico"]["points"] == 3  # ONLY the group match counts
-        assert state["Mexico"]["gf"] == 3
+        assert state["_teams"]["Mexico"]["points"] == 3  # ONLY the group match counts
+        assert state["_teams"]["Mexico"]["gf"] == 3
         # Germany isn't in the group map → no row at all.
         assert "Germany" not in state
 
@@ -7907,8 +7907,8 @@ class TestGroupStageSoccerSource:
         matches = [self._match(1, "GROUP_A", "Mexico", "South Africa")]
         src = self._make_source(matches)
         state = src.initial_state()
-        snap_mex = dict(state["Mexico"])
-        snap_sa = dict(state["South Africa"])
+        snap_mex = dict(state["_teams"]["Mexico"])
+        snap_sa = dict(state["_teams"]["South Africa"])
         snap_applied = set(state["_applied"])
 
         match = GameRow(
@@ -7920,12 +7920,12 @@ class TestGroupStageSoccerSource:
         result = MatchResult(home_goals=3, away_goals=1)
         new_state = src.apply_result(state, match, result)
         # Original untouched.
-        assert state["Mexico"] == snap_mex
-        assert state["South Africa"] == snap_sa
+        assert state["_teams"]["Mexico"] == snap_mex
+        assert state["_teams"]["South Africa"] == snap_sa
         assert set(state["_applied"]) == snap_applied
         # New state has the result.
-        assert new_state["Mexico"]["points"] == 3
-        assert new_state["Mexico"]["gf"] == 3
+        assert new_state["_teams"]["Mexico"]["points"] == 3
+        assert new_state["_teams"]["Mexico"]["gf"] == 3
         assert 1 in new_state["_applied"]
 
 
@@ -8216,10 +8216,10 @@ class TestBuildBracketSeedWC2026:
     @staticmethod
     def _make_wc_state(group_data, team_group):
         """Build a primary_state shaped like GroupStageSoccerSource produces."""
-        state = {"_applied": frozenset(), "_team_group": team_group}
+        state = {"_applied": frozenset(), "_team_group": team_group, "_teams": {}}
         for _grp, rows in group_data.items():
             for team, points, gd, gf in rows:
-                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
+                state["_teams"][team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
         return state
 
     @classmethod
@@ -8787,11 +8787,10 @@ class TestGroupStageBestThirdPlace:
     def _make_state(group_data, team_group):
         """Build a state dict from {group: [(team, points, gd, gf), ...]}.
         Each group should have 4 teams pre-sorted by position."""
-        state = {"_applied": set(), "_team_group": team_group}
+        state = {"_applied": set(), "_team_group": team_group, "_teams": {}}
         for group, rows in group_data.items():
             for team, points, gd, gf in rows:
-                state[team] = {
-                    "points": points,
+                state["_teams"][team] = {"points": points,
                     "gf": gf,
                     "ga": gf - gd,  # we only need gf-ga for diff; ga value here doesn't matter
                     "_played": 3,
@@ -9028,10 +9027,10 @@ class TestComputeGroupStandings:
     def _make_state(group_data, team_group):
         """Same shape as TestGroupStageBestThirdPlace's helper: per-team
         rows with points / gf / ga; the helper computes gd = gf - ga."""
-        state = {"_applied": set(), "_team_group": team_group}
+        state = {"_applied": set(), "_team_group": team_group, "_teams": {}}
         for _grp, rows in group_data.items():
             for team, points, gd, gf in rows:
-                state[team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
+                state["_teams"][team] = {"points": points, "gf": gf, "ga": gf - gd, "_played": 3}
         return state
 
     def test_by_group_sorted_by_fifa_tiebreaker(self):
@@ -9096,7 +9095,7 @@ class TestComputeGroupStandings:
         # best_third_place_count=8.
         src = self._wc_source()
         _, _, n = src._compute_group_standings(
-            {"_applied": set(), "_team_group": {}}
+            {"_applied": set(), "_team_group": {}, "_teams": {}}
         )
         assert n == 8
 
@@ -9104,7 +9103,7 @@ class TestComputeGroupStandings:
         # EURO 2024+ config maps to EC_GS with best_third_place_count=4.
         src = self._euro_source()
         _, _, n = src._compute_group_standings(
-            {"_applied": set(), "_team_group": {}}
+            {"_applied": set(), "_team_group": {}, "_teams": {}}
         )
         assert n == 4
 
@@ -9165,7 +9164,7 @@ class TestComputeGroupStandings:
         # supported because Phase B's call sites and earlier ones rely on
         # it. Pin both contracts here.
         src = self._wc_source()
-        state = {"_applied": set(), "_team_group": {}}
+        state = {"_applied": set(), "_team_group": {}, "_teams": {}}
         standings = src._compute_group_standings(state)
         # Field access shape.
         assert standings.by_group == {}
@@ -9191,7 +9190,7 @@ class TestComputeGroupStandings:
         src = GroupStageSoccerSource("bundesliga", fd_api_key="x", odds_api_key="")
         assert src._group_stage_context_code() not in LEAGUE_CONTEXTS
         standings = src._compute_group_standings(
-            {"_applied": set(), "_team_group": {}}
+            {"_applied": set(), "_team_group": {}, "_teams": {}}
         )
         assert standings.n_best_third_advance == 0
 


### PR DESCRIPTION
## Summary

Adds TypedDict contracts for the SoccerSource / GroupStageSoccerSource state shape and refactors the producers so per-team standings rows nest under `state["_teams"]: Dict[str, SoccerTeamRow]` instead of mixing with metadata keys (`_applied`, `_team_group`) at the top level.

## The bug pattern this kills

Pre-refactor, every consumer in soccer.py had to filter metadata via string-literal exclusion:

```python
for team in state if team != "_applied"
[(n, r) for n, r in state.items() if n not in ("_applied", "_team_group")]
```

If a future refactor renamed `"points"` to `"pts"` in `initial_state` and missed any downstream reader (terminal_outcomes, `_compute_group_standings`, the mock in test_simulation.py, etc.), the helper would silently return wrong rankings. No test would catch it because every caller agreed with itself.

After this PR: `SoccerTeamRow(TypedDict)` is the schema. Renames fail pyright with the exact message the issue body promises.

## Live verification of the rename-catching benefit

```bash
$ sed -i 's/h\["points"\] += 3/h["pts"] += 3/' sources/soccer.py
$ pyright sources/soccer.py
  sources/soccer.py:944:13 - error: Could not access item in TypedDict
    "pts" is not a defined key in "SoccerTeamRow"
  sources/soccer.py:944:13 - error: Could not assign item in TypedDict
    "pts" is not a defined key in "SoccerTeamRow"
2 errors, 1 warning, 0 informations
```

Restore the typo and pyright is clean.

## What ships

- `sources/base.py`: new `SoccerTeamRow`, `PointsBasedTeamRow`, `PointsBasedTeamRowWithStandings` TypedDicts. Module-level comments call out the rename-mismatch motivation.
- `sources/soccer.py`: new `SoccerLeagueState`, `GroupStageState` (extends SoccerLeagueState via TypedDict inheritance). `SoccerSource.initial_state` and `GroupStageSoccerSource.initial_state` now build `state["_teams"]` as the canonical team-row dict. Every consumer (`_mutate_apply`, `apply_result`, `terminal_outcomes`, `_compute_group_standings`, `_build_bracket_seed`) reads `state["_teams"][team]` rather than `state[team]`. Hot-path consumers narrow via `teams_dict: Dict[str, SoccerTeamRow] = state["_teams"]` so pyright catches field-name typos at the use site.
- `tests/test_simulation.py`: the hand-rolled mock SoccerSource updated to the nested shape.
- `tests/test_sources.py`: ~30 state construction sites + assertions updated. Migration was scripted; the few f-string keys (`state[f"Team {i}"]`) the script missed were hand-fixed.

## Why the public signatures stay `Dict[str, Any]`

`KnockoutSoccerSource` inherits from both `SoccerSource` (league shape with `_teams`) and `AggregateLegSource` (bracket shape with `_tie_results / _bracket / _round_reached`). Narrowing the abstract `apply_result(state: ...)` etc. on the ABC to either shape breaks the Liskov contract for the other subclass. Public signatures stay `Dict[str, Any]`; consumer-side narrowing is opt-in and verified above.

This still meets the issue's primary goal -- consumers that read team-row fields get static field-name checking -- without a broader rework of the bracket/knockout hierarchy.

## Scope

- IN: soccer.py league + group-stage. This is exactly the shape the issue body describes (with the field names `_applied`, `_team_group`, `points`, `gf`, `ga`, `played`).
- IN (bonus): `PointsBasedTeamRow` TypedDict added to base.py for opt-in narrowing in points_based.py / NCAA / NFL / NHL / MLB consumers when callers want it. The points_based state shape was already structurally typed (`state["_teams"]`) so no producer refactor was needed; just the TypedDict for documentation + narrowing.
- OUT: bracket.py state shape (`_tie_results / _bracket / _round_reached`). Fundamentally different shape with no team-name keys at the top level; it does not suffer from the issue's bug pattern.

## Test plan

- [x] Full suite: **1028 pass**, identical to pre-refactor baseline. Pure refactor, zero behavior change.
- [x] **pyright clean** on `sources/base.py` and `sources/soccer.py`.
- [x] **Rename-catching benefit verified live** by deliberately introducing a `row["pts"]` typo and observing pyright flag it (output above).
- [x] State copy semantics preserved: `apply_result` uses `{**state, "_teams": new_teams}` so subclass metadata (`_team_group` from GroupStageState) survives across simulator iterations. This caught a regression in the first pass where the apply path was dropping `_team_group`, breaking the WC 2026 chain tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)