### PR TITLE
Add international-friendlies source (ESPN fifa.friendly)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -91,6 +91,20 @@
       "help_text": "UEFA's quadrennial national-team tournament. Pure knockout in V1 — group-stage importance not yet modeled. R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
     },
     {
+      "id": "enable_intl_friendlies",
+      "type": "boolean",
+      "label": "International Friendlies (Men's)",
+      "default": false,
+      "help_text": "Senior men's national-team friendlies and FIFA-window warm-ups (e.g. a USMNT tune-up the week before the World Cup) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. Add a national team to Favorites to see its friendlies. Offseason → no rows. No API key required."
+    },
+    {
+      "id": "enable_intl_friendlies_women",
+      "type": "boolean",
+      "label": "International Friendlies (Women's)",
+      "default": false,
+      "help_text": "Senior women's national-team friendlies and FIFA-window warm-ups (e.g. a USWNT tune-up) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. Add a national team to Favorites to see its friendlies. Offseason → no rows. No API key required."
+    },
+    {
       "id": "enable_eredivisie",
       "type": "boolean",
       "label": "Eredivisie (Netherlands, top flight)",

--- a/plugin.py
+++ b/plugin.py
@@ -533,6 +533,7 @@ def _build_sources(settings: Dict[str, Any]):
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
         F1Source, NascarSource, GolfSource, UfcSource,
         AtpSource, WtaSource,
+        InternationalFriendliesSource,
     )
     from .sources.soccer import COMPETITIONS
     from .scoring import LEAGUE_CONTEXTS
@@ -601,6 +602,17 @@ def _build_sources(settings: Dict[str, Any]):
         sources.append(GroupStageSoccerSource(
             "euros", fd_api_key=fd_key, odds_api_key=odds_key,
         ))
+
+    # International friendlies (ESPN, no API key). Exhibition games with no
+    # standings, so these sources don't support importance simulation; a
+    # friendly surfaces on favorite / rivalry / narrative signals alone. This
+    # is the only path for a pre-tournament national-team warm-up (e.g. a
+    # USMNT friendly the week before the World Cup) to reach the guide: the
+    # world_cup source carries only FD.org tournament fixtures, not friendlies.
+    if settings.get("enable_intl_friendlies", False):
+        sources.append(InternationalFriendliesSource(gender="m"))
+    if settings.get("enable_intl_friendlies_women", False):
+        sources.append(InternationalFriendliesSource(gender="w"))
 
     # Additional FD.org free-tier leagues. Same _make_soccer
     # router; LEAGUE_CONTEXTS uses format="league" so dispatch goes

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -10,6 +10,7 @@ from .field_event import (
     F1Source, NascarSource, GolfSource, UfcSource,
     AtpSource, WtaSource, FieldEventSource,
 )
+from .friendlies import InternationalFriendliesSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
 from .ncaaw_basketball import (
@@ -45,6 +46,7 @@ __all__ = [
     "NwslSource", "LigaMxSource",
     "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
     "AtpSource", "WtaSource",
+    "InternationalFriendliesSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",
     "NcaawBasketballRegularSource", "NcaawBasketballPlayoffSource",

--- a/sources/friendlies.py
+++ b/sources/friendlies.py
@@ -1,0 +1,150 @@
+"""International friendlies source: ESPN's unofficial soccer API.
+
+Senior national-team friendlies (FIFA international windows + pre-tournament
+warm-ups, e.g. a USMNT vs Senegal tune-up the week before the World Cup).
+
+These are EXHIBITION games: no league table, no standings, no elimination
+stakes. This source therefore DELIBERATELY does not implement the Monte Carlo
+importance interface; `supports_importance` stays False (the base-class
+default). A friendly surfaces in Top Matchups purely on the favorite / rivalry
+/ narrative signals in score_game, which is honest: a USA warm-up is worth
+watching because it's USA, not because it swings a standings position. DO NOT
+flip supports_importance on here and fabricate a league context for it: there
+is no table to simulate, and compute_match_importance would have nothing to
+threshold against.
+
+Why this source exists: the FIFA World Cup source (sources/soccer.py, config
+key "world_cup") reads ONLY tournament fixtures from Football-Data.org. It
+does not, and should not, contain warm-up friendlies. Before this source there
+was no path for a pre-tournament national-team friendly to appear in the guide
+at all (the teams aren't playing a league fixture and aren't yet in a World
+Cup match). See the "USA vs Senegal didn't show up" investigation.
+
+Parametrized on gender ("m"/"w"), mirroring NcaaSoccerSource:
+  - men's   -> ESPN league slug "fifa.friendly"
+  - women's -> ESPN league slug "fifa.friendly.w"
+
+Offseason (no friendlies scheduled in the lookahead window) returns []. No API
+key required (ESPN's site API is free, same as the NFL/NHL/NCAA-soccer
+sources).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base import GameRow, SportSource
+from ._espn import extract_espn_scoreboard_event
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.friendlies")
+
+ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/soccer"
+
+
+def _http_get(url: str, timeout: float = 15.0) -> Optional[Dict[str, Any]]:
+    try:
+        r = requests.get(url, timeout=timeout)
+        if r.status_code >= 400:
+            logger.warning("[friendlies] %s → %d", url, r.status_code)
+            return None
+        return r.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("[friendlies] %s failed: %s", url, exc)
+        return None
+
+
+def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
+    """National-team namer. ESPN populates `location` with the country name
+    ("United States", "Senegal") for international fixtures, which is exactly
+    the form the favorites list and EPG provider titles use. Fall back to
+    displayName / name / abbreviation if a row is missing location."""
+    for key in ("location", "displayName", "name", "abbreviation"):
+        val = (team_obj.get(key) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+class InternationalFriendliesSource(SportSource):
+    """Senior national-team friendlies from ESPN, parametrized on gender
+    ("m" or "w"). Lightweight: implements only fetch_upcoming. No importance
+    simulation (exhibition games have no standings), so a friendly scores on
+    favorite / rivalry / narrative signals alone."""
+
+    def __init__(self, gender: str = "m") -> None:
+        g = (gender or "").lower().strip()
+        if g not in ("m", "w"):
+            raise ValueError(f"gender must be 'm' or 'w', got {gender!r}")
+        self.gender = g
+
+    @property
+    def sport_prefix(self) -> str:
+        return "FRIENDLY" if self.gender == "m" else "FRIENDLYW"
+
+    @property
+    def sport_label(self) -> str:
+        return (
+            "International Friendly" if self.gender == "m"
+            else "Women's International Friendly"
+        )
+
+    @property
+    def _espn_slug(self) -> str:
+        return "fifa.friendly" if self.gender == "m" else "fifa.friendly.w"
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Per-day scoreboard sweep. ESPN's date-RANGE syntax silently caps at
+        25 events, so we walk one day at a time (same trap documented in
+        ncaa_baseball.py / ncaa_soccer.py). Drops FINISHED games: a friendly
+        that already kicked off and ended is not an upcoming Top Matchup. A
+        live (in-progress) game classifies as SCHEDULED in the shared parser
+        and is kept, so a game "playing right now" still surfaces."""
+        today = datetime.now(timezone.utc).date()
+        out: List[GameRow] = []
+        seen_ids: set = set()
+        for offset in range(days_ahead + 1):
+            day = today + timedelta(days=offset)
+            data = _http_get(
+                f"{ESPN_BASE}/{self._espn_slug}/scoreboard"
+                f"?dates={day.strftime('%Y%m%d')}"
+            )
+            if not data:
+                continue
+            for event in data.get("events") or []:
+                rec = extract_espn_scoreboard_event(
+                    event, team_namer=_team_canonical_name,
+                )
+                if rec is None:
+                    continue
+                eid = rec.get("id")
+                if eid in seen_ids:
+                    continue
+                seen_ids.add(eid)
+                if rec.get("status") == "FINISHED":
+                    continue
+                start = rec.get("start_time")
+                if start is None:
+                    continue
+                # No rank (national-team friendlies have no poll), no spread,
+                # no closeness, no fd_competition_code: the scoring loop sees
+                # no league context and contributes zero importance, which is
+                # correct for an exhibition. Favorite / rivalry / narrative
+                # carry the signal.
+                out.append(GameRow(
+                    sport_prefix=self.sport_prefix,
+                    sport_label=self.sport_label,
+                    home=rec["home"],
+                    away=rec["away"],
+                    rank_home=None,
+                    rank_away=None,
+                    start_time=start,
+                    extra={
+                        "espn_event_id": eid,
+                        "espn_league_slug": self._espn_slug,
+                    },
+                ))
+        return out

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 import pytest
 
 from dispatcharr_ranked_matchups.sources import (
+    InternationalFriendliesSource,
     KnockoutSoccerSource,
     NcaafSource,
     NcaamSource,
@@ -9629,3 +9630,73 @@ class TestTierFixturesChunkingForLongWindows:
         # First chunk's data is still in the result.
         assert "PL" in out
         assert len(out["PL"]) == 1
+
+
+class TestInternationalFriendliesSource:
+    """ESPN national-team friendlies. Exhibition games: no importance
+    simulation, FINISHED games dropped, surfaces via favorite/rivalry only."""
+
+    def test_implements_interface(self):
+        assert issubclass(InternationalFriendliesSource, SportSource)
+
+    def test_no_importance_simulation(self):
+        # Friendlies have no standings table, so the source must NOT claim
+        # importance support: compute_match_importance would have nothing to
+        # threshold against. supports_importance is the base-class default.
+        assert InternationalFriendliesSource(gender="m").supports_importance is False
+
+    def test_gender_constants(self):
+        m = InternationalFriendliesSource(gender="m")
+        w = InternationalFriendliesSource(gender="w")
+        assert m.sport_prefix == "FRIENDLY"
+        assert m.sport_label == "International Friendly"
+        assert m._espn_slug == "fifa.friendly"
+        assert w.sport_prefix == "FRIENDLYW"
+        assert w.sport_label == "Women's International Friendly"
+        assert w._espn_slug == "fifa.friendly.w"
+
+    def test_invalid_gender_raises(self):
+        with pytest.raises(ValueError):
+            InternationalFriendliesSource(gender="x")
+
+    def test_fetch_drops_finished_keeps_scheduled(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import friendlies as friendlies_mod
+
+        def _event(eid, home, away, completed):
+            return {
+                "id": eid,
+                "date": "2026-05-31T19:30Z",
+                "competitions": [{
+                    "status": {"type": {"completed": completed,
+                                        "state": "post" if completed else "pre"}},
+                    "competitors": [
+                        {"homeAway": "home", "score": "1" if completed else None,
+                         "team": {"location": home}},
+                        {"homeAway": "away", "score": "0" if completed else None,
+                         "team": {"location": away}},
+                    ],
+                }],
+            }
+
+        payload = {"events": [
+            _event("1", "United States", "Senegal", completed=False),
+            _event("2", "Brazil", "Panama", completed=True),  # finished -> dropped
+        ]}
+
+        class FakeResp:
+            status_code = 200
+            def json(self): return payload
+
+        monkeypatch.setattr(friendlies_mod.requests, "get",
+                            lambda *a, **kw: FakeResp())
+
+        rows = InternationalFriendliesSource(gender="m").fetch_upcoming(days_ahead=0)
+
+        # Only the scheduled game survives; the finished one is dropped.
+        assert len(rows) == 1
+        row = rows[0]
+        assert (row.home, row.away) == ("United States", "Senegal")
+        assert row.sport_prefix == "FRIENDLY"
+        # No poll for national-team friendlies, no league context.
+        assert row.rank_home is None and row.rank_away is None
+        assert row.extra["espn_league_slug"] == "fifa.friendly"


### PR DESCRIPTION
## Why

National-team friendlies (FIFA windows + pre-tournament warm-ups, e.g. USMNT vs Senegal the week before the World Cup) had **no source**. The only USA-soccer source is the World Cup, which reads Football-Data.org tournament fixtures only, never friendlies. So a USA friendly could not reach Top Matchups at all. This was surfaced by the "USA vs Senegal isn't showing up" investigation.

## What

- New `sources/friendlies.py`: `InternationalFriendliesSource`, gender-parametrized (`m` → `fifa.friendly`, `w` → `fifa.friendly.w`) over ESPN's free site API (no key, same as NFL/NHL/NCAA-soccer).
- Lightweight: `fetch_upcoming` only. Reuses the shared `extract_espn_scoreboard_event` helper (no fourth ESPN-parse copy).
- **Deliberately no importance simulation** (`supports_importance=False`): exhibitions have no league table to simulate. A friendly surfaces on favorite / rivalry / narrative signals alone, which is honest. The expensive Monte Carlo path is skipped for these by the existing `supports_importance` guard.
- FINISHED games dropped; live (in-progress) games kept.
- Two opt-in toggles (`enable_intl_friendlies`, `enable_intl_friendlies_women`), both default off, mirroring the NCAA men's/women's soccer convention.

## Live verification

Exercised `fetch_upcoming` against the real ESPN endpoint (not mocked):

```
LIVE rows fetched: 83
USA games: 2
  2026-05-31T19:30:00+00:00 | FRIENDLY | United States vs Senegal
  2026-06-06T18:30:00+00:00 | FRIENDLY | United States vs Germany
```

Deterministic unit tests (interface, `supports_importance is False`, gender constants/slugs, gender validation, FINISHED-drop/SCHEDULED-keep) pass in `tests/test_sources.py::TestInternationalFriendliesSource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)