### PR TITLE
Align Plugin.version to 1.0.0 (match manifest + __init__)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2540,7 +2540,10 @@ def _release_scheduler_lock() -> None:
 
 class Plugin:
     name = "Ranked Matchups (Top Games)"
-    version = "0.1.0"
+    # Single source of truth for the displayed version: the loader uses this
+    # class attr over plugin.json's "version". Keep all three in sync
+    # (this attr, plugin.json, __init__.py __version__).
+    version = "1.0.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than


### PR DESCRIPTION
Pre-existing 3-way version mismatch: `plugin.json` and `__init__.py` declared `1.0.0`, but the `Plugin` class attr (which the loader displays in preference to the manifest) was still `0.1.0`, so Dispatcharr showed a stale `0.1.0`. Bumps the class attr so all three agree at `1.0.0`, with a comment naming the precedence to prevent re-drift.

Surfaced during the international-friendlies build (#94). Per-direction decision confirmed with the maintainer: complete the bump to 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)