### PR TITLE
Ground EPG descriptions in playoff series state

### DIFF
--- a/_util.py
+++ b/_util.py
@@ -7,7 +7,7 @@ import hashlib
 import math
 import random
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 
 def parse_iso_utc(s: Optional[str]) -> Optional[datetime]:
@@ -109,3 +109,84 @@ GENERIC_TEAM_SECOND_WORDS = (
     "forest", "wanderers", "rangers", "palace", "hotspur", "villa",
     "wednesday", "real",
 )
+
+
+# ---------- playoff-series rendering ----------
+#
+# The sport-agnostic `extra["series"]` schema that best-of-N sources populate
+# (NHL today; NBA / MLB / NCAA series can follow the same shape). Both the
+# deterministic EPG description (plugin._build_description) and the LLM context
+# (llm_descriptions.build_llm_context) render from these helpers, so the wording
+# and the model's grounding never drift apart:
+#
+#   {
+#     "title":       str,   # "Stanley Cup Final" (optional, may be "")
+#     "game_number": int,   # this game's number within the series (1-based)
+#     "best_of":     int,   # series length (7 for an NHL round)
+#     "home_wins":   int,   # wins by THIS game's home team
+#     "away_wins":   int,   # wins by THIS game's away team
+#     "results":     [ {game_number, home, away, home_goals, away_goals, ot}, ... ],
+#   }
+#
+# These functions are the ONLY place series state becomes prose. Grounding the
+# LLM with `series_record_text` is what stops Haiku inventing "facing
+# elimination" on a Game 1 (the bug these helpers exist to kill): do not write
+# a parallel series-phrasing path in the description or context builders.
+
+
+def series_phase_text(series: Optional[Dict[str, Any]]) -> str:
+    """Headline phrase for a series game: "Stanley Cup Final, Game 2 of 7", or
+    "Game 2 of 7" when no series title is set. Returns "" when the series dict
+    lacks a usable game_number / best_of."""
+    if not isinstance(series, dict):
+        return ""
+    gnum = series.get("game_number")
+    best_of = series.get("best_of")
+    if not isinstance(gnum, int) or not isinstance(best_of, int) or best_of <= 0:
+        return ""
+    core = f"Game {gnum} of {best_of}"
+    title = (series.get("title") or "").strip()
+    return f"{title}, {core}" if title else core
+
+
+def series_record_text(
+    series: Optional[Dict[str, Any]], home: str, away: str
+) -> str:
+    """One-line series record: "Series tied 1-1" or
+    "Carolina Hurricanes lead the series 2-1". Returns "" when win counts are
+    missing. `home` / `away` are this game's team names (the schema's win
+    counts are already keyed to them)."""
+    if not isinstance(series, dict):
+        return ""
+    hw = series.get("home_wins")
+    aw = series.get("away_wins")
+    if not isinstance(hw, int) or not isinstance(aw, int):
+        return ""
+    if hw == aw:
+        return f"Series tied {hw}-{aw}"
+    leader, hi, lo = (home, hw, aw) if hw > aw else (away, aw, hw)
+    return f"{leader} lead the series {hi}-{lo}"
+
+
+def series_result_lines(series: Optional[Dict[str, Any]]) -> List[str]:
+    """Per-completed-game recap lines, oldest first, e.g.
+    ["Game 1: Carolina Hurricanes 3, Vegas Golden Knights 2 (OT)", ...].
+    Returns [] when no results are recorded. Skips malformed result rows
+    rather than raising: a bad recap should degrade to the record line, never
+    break the refresh."""
+    out: List[str] = []
+    if not isinstance(series, dict):
+        return out
+    for r in series.get("results") or []:
+        if not isinstance(r, dict):
+            continue
+        gn = r.get("game_number")
+        home = r.get("home")
+        away = r.get("away")
+        hg = r.get("home_goals")
+        ag = r.get("away_goals")
+        if None in (gn, home, away, hg, ag):
+            continue
+        tag = " (OT)" if r.get("ot") else ""
+        out.append(f"Game {gn}: {home} {hg}, {away} {ag}{tag}")
+    return out

--- a/llm_descriptions.py
+++ b/llm_descriptions.py
@@ -25,6 +25,8 @@ import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, List, Optional
 
+from ._util import series_phase_text, series_record_text, series_result_lines
+
 logger = logging.getLogger(__name__)
 
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
@@ -49,6 +51,14 @@ Hard rules:
 - If a favorite team for this user is playing, that's a "personal interest":
   ground the preview in their angle.
 - Plain text only. No markdown, no asterisks, no bullet points.
+- Do NOT fabricate playoff series facts. The only series facts you may use are
+  the "Series", "Series record", and "Results so far" lines above. Never invent
+  a series score, a game number, or a best-of-N length.
+- Do not write "facing elimination", "must win to force a Game 7", or "their
+  season ends tonight" unless the given Series record makes it literally true
+  (a team one loss from elimination in a best-of-N). If no series lines are
+  given the match may still be a one-off knockout, so general "win or go home"
+  framing is fine, but never assert a series standing or game number.
 """
 
 # How many standings rows above/below each team to include in the context.
@@ -122,6 +132,23 @@ def build_llm_context(g: Dict[str, Any], tagline: str, boundary_summary: str = "
     lines.append(f"Match: {away} at {home}, {kickoff_local}")
     lines.append(f"Competition: {sport_label}")
 
+    # Playoff series grounding (best-of-N sources populate extra["series"]).
+    # This is the load-bearing fix for the false-"elimination" bug: without the
+    # record and game number, the model invents playoff drama. The SYSTEM_PROMPT
+    # hard rule below forbids guessing series state when these lines are absent.
+    series = extra.get("series")
+    series_phase = series_phase_text(series)
+    if series_phase:
+        lines.append(f"Series: {series_phase}")
+    series_record = series_record_text(series, home, away)
+    if series_record:
+        lines.append(f"Series record: {series_record}")
+    series_recap = series_result_lines(series)
+    if series_recap:
+        lines.append("Results so far:")
+        for recap_line in series_recap:
+            lines.append(f"  - {recap_line}")
+
     matchday = extra.get("matchday")
     matchdays_total = extra.get("matchdays_total")
     if matchday and matchdays_total:
@@ -176,11 +203,17 @@ def build_llm_context(g: Dict[str, Any], tagline: str, boundary_summary: str = "
 
 
 def prompt_hash(context: str, model: str) -> str:
-    """Stable short hash used as part of the cache key. Includes the model so
-    a model swap invalidates cached prose without manual cache-bust.
+    """Stable short hash used as part of the cache key. Folds in the model AND
+    the SYSTEM_PROMPT so that a model swap OR a system-prompt edit invalidates
+    cached prose without a manual cache-bust. The system prompt matters because
+    it carries the behavioral rules (e.g. the anti-"elimination" guardrail): a
+    cache keyed only on the user-message context would keep serving prose
+    written under the OLD rules after a prompt tightening.
     """
     h = hashlib.sha256()
     h.update(model.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(SYSTEM_PROMPT.encode("utf-8"))
     h.update(b"\x00")
     h.update(context.encode("utf-8"))
     return h.hexdigest()[:16]

--- a/plugin.py
+++ b/plugin.py
@@ -40,7 +40,13 @@ try:
 except ImportError:  # py < 3.9 fallback (won't hit on Dispatcharr's Python 3.13)
     ZoneInfo = None  # type: ignore
 
-from ._util import parse_iso_utc, stable_hash_int
+from ._util import (
+    parse_iso_utc,
+    series_phase_text,
+    series_record_text,
+    series_result_lines,
+    stable_hash_int,
+)
 
 # Eager-import tasks so the background-thread launchers and inflight Redis
 # helpers are available before any action handler runs. tasks.py used to
@@ -1580,6 +1586,8 @@ def _build_description(
     Layout (each block separated by a blank line):
       1. Placeholder note (only if EPG hasn't matched a source yet)
       2. Headline: tagline + spread descriptor ("A title race: toss-up.")
+      2b. Series state (playoff best-of-N games only): phase + record, then
+          a completed-game recap line. Renders nothing for league fixtures.
       3. Matchday + league boundary summary (where applicable)
       4. Standings posture line (league fixtures only: see #10)
       5. Favorite-impact narratives (rooting framing, both deltas)
@@ -1619,6 +1627,25 @@ def _build_description(
         headline_parts.append(spread_desc)
     if headline_parts:
         sections.append(": ".join(headline_parts) + ".")
+
+    # 2b. Series state for playoff best-of-N games. `extra["series"]` is the
+    # sport-agnostic schema populated by series sources (NHL today). The phase
+    # + record sentence is what tells the reader this is Game 1 of 7 with the
+    # series tied, instead of leaving the framing to guesswork: it's the same
+    # grounding the LLM context uses to avoid hallucinating "elimination".
+    series = extra.get("series")
+    series_phase = series_phase_text(series)
+    series_record = series_record_text(series, g.get("home", ""), g.get("away", ""))
+    if series_phase or series_record:
+        parts = []
+        if series_phase:
+            parts.append(series_phase + ".")
+        if series_record:
+            parts.append(series_record + ".")
+        sections.append(" ".join(parts))
+        recap = series_result_lines(series)
+        if recap:
+            sections.append(" · ".join(recap))
 
     # 3. Matchday line + league boundary reminder. Both are league-based
     # ("why is this a race"). Matchday tells you where in the season we

--- a/sources/nhl.py
+++ b/sources/nhl.py
@@ -69,6 +69,16 @@ NHL_TEAM_ABBREVS: Tuple[str, ...] = (
 _DEFAULT_GOALS_FOR = 3.0
 _DEFAULT_GOALS_AGAINST = 3.0
 
+# api-web `gameState` values that mean the game is over. "OFF" and "FINAL"
+# both appear depending on the host's firmware version; both are terminal.
+# Anything else ("LIVE", "PRE", "FUT") is not a usable final result.
+_FINAL_GAME_STATES = ("OFF", "FINAL")
+
+# `gameOutcome.lastPeriodType` values that mean the game was NOT decided in
+# regulation. Drives both the standings OT/SO-loss consolation point and the
+# "(OT)" tag on the playoff-series recap.
+_NON_REGULATION_PERIODS = ("OT", "SO")
+
 
 def _team_canonical_name(team_obj: Dict[str, Any]) -> str:
     """Return "Place Name + Common Name", matching the format Dispatcharr
@@ -221,12 +231,11 @@ class NhlRegularSource(PointsBasedSportSource):
                 state = g.get("gameState")
                 hg = (g.get("homeTeam") or {}).get("score")
                 ag = (g.get("awayTeam") or {}).get("score")
-                # api-web marks finished games as "OFF" (final) or "FINAL"
-                # depending on the firmware version; both are terminal.
                 # Active live games have state == "LIVE": we treat them
                 # as SCHEDULED for the simulator (don't seed in-progress
-                # results because the score is still moving).
-                is_final = state in ("OFF", "FINAL") and hg is not None and ag is not None
+                # results because the score is still moving). See
+                # _FINAL_GAME_STATES for the terminal-state set.
+                is_final = state in _FINAL_GAME_STATES and hg is not None and ag is not None
                 status = "FINISHED" if is_final else "SCHEDULED"
                 last_period = (g.get("gameOutcome") or {}).get("lastPeriodType")
                 seen[gid] = {
@@ -309,7 +318,7 @@ class NhlRegularSource(PointsBasedSportSource):
         h.setdefault("standings_points", 0)
         a.setdefault("standings_points", 0)
         # Loser's OT/SO consolation: 1 standings point.
-        loser_consolation = 1 if last_period in ("OT", "SO") else 0
+        loser_consolation = 1 if last_period in _NON_REGULATION_PERIODS else 0
         if home_pts > away_pts:
             h["standings_points"] += 2
             a["standings_points"] += loser_consolation
@@ -397,6 +406,11 @@ class NhlPlayoffSource(BestOfNSeriesSource):
         self._strengths_cache: Optional[Dict[str, Dict[str, float]]] = None
         self._bracket_games_cache: Optional[List[Dict[str, Any]]] = None
         self._team_strengths_from_regular: Optional[Dict[str, Dict[str, float]]] = None
+        # Per-series completed-game recaps, memoized by series letter so a
+        # 7-day fetch_upcoming that sees the same series on several days hits
+        # the per-series schedule endpoint once. Populated lazily, only for
+        # series that are already underway (see _series_from_status).
+        self._series_results_cache: Dict[str, List[Dict[str, Any]]] = {}
 
     @property
     def sport_prefix(self) -> str:
@@ -439,6 +453,19 @@ class NhlPlayoffSource(BestOfNSeriesSource):
                     start = parse_iso_utc(g.get("startTimeUTC"))
                     if not home or not away or start is None:
                         continue
+                    extra = {
+                        "nhl_game_id": gid,
+                        "fd_competition_code": self._league_context_code(),
+                    }
+                    # Series grounding for the EPG description / LLM context.
+                    # The daily-schedule game already carries a `seriesStatus`
+                    # block (game number, best-of length, per-seed win counts),
+                    # so this costs no extra call for the record line: only the
+                    # completed-game recap hits the per-series schedule, and
+                    # only once a series is underway.
+                    series = self._series_from_status(g)
+                    if series:
+                        extra["series"] = series
                     out.append(GameRow(
                         sport_prefix=self.sport_prefix,
                         sport_label=self.sport_label,
@@ -447,12 +474,114 @@ class NhlPlayoffSource(BestOfNSeriesSource):
                         rank_home=None,
                         rank_away=None,
                         start_time=start,
-                        extra={
-                            "nhl_game_id": gid,
-                            "fd_competition_code": self._league_context_code(),
-                        },
+                        extra=extra,
                     ))
         return out
+
+    def _series_schedule_url(self, series_letter: str) -> str:
+        """URL for a per-series game schedule:
+        `/v1/schedule/playoff-series/{full_season}/{lower_letter}`.
+
+        DO NOT substitute the bracket endpoint's season form here: this endpoint
+        takes the FULL 8-digit season ("20252026"), NOT the end-year ("2026")
+        the `/v1/playoff-bracket/{season}` endpoint uses. Two different season
+        conventions on the same API, confirmed empirically against the live
+        host. The single source of truth for both callers (importance bracket
+        fetch and the EPG-recap fetch).
+        """
+        return f"{NHL_API_BASE}/schedule/playoff-series/{self.season}/{series_letter}"
+
+    def _series_from_status(
+        self, g: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Normalize the daily-schedule `seriesStatus` block into the
+        sport-agnostic `extra['series']` schema that the EPG description and LLM
+        context read (see _util.series_phase_text and friends). Returns None
+        when the block is absent or unusable.
+
+        Win counts arrive keyed by top/bottom SEED, but home ice alternates
+        across a series, so they're re-keyed to THIS game's home/away by
+        matching team abbreviations. `best_of = neededToWin * 2 - 1` (4 wins
+        clinches a best-of-7).
+        """
+        ss = g.get("seriesStatus") or {}
+        gnum = ss.get("gameNumberOfSeries")
+        needed = ss.get("neededToWin")
+        if not isinstance(gnum, int) or not isinstance(needed, int) or needed <= 0:
+            return None
+        top_wins = ss.get("topSeedWins") or 0
+        bot_wins = ss.get("bottomSeedWins") or 0
+        home_abbrev = (g.get("homeTeam") or {}).get("abbrev")
+        top_abbrev = ss.get("topSeedTeamAbbrev")
+        bot_abbrev = ss.get("bottomSeedTeamAbbrev")
+        if home_abbrev == top_abbrev:
+            home_wins, away_wins = top_wins, bot_wins
+        elif home_abbrev == bot_abbrev:
+            home_wins, away_wins = bot_wins, top_wins
+        else:
+            # Abbrev mismatch shouldn't happen on a live playoff feed; record
+            # the seed-keyed counts as-is rather than guess the mapping.
+            home_wins, away_wins = top_wins, bot_wins
+        series: Dict[str, Any] = {
+            "title": ss.get("seriesTitle") or "",
+            "game_number": gnum,
+            "best_of": needed * 2 - 1,
+            "home_wins": home_wins,
+            "away_wins": away_wins,
+            "results": [],
+        }
+        # Only fetch the per-game recap once a game has actually been played;
+        # on Game 1 the record is 0-0 and there is nothing to recap.
+        if home_wins + away_wins > 0:
+            series["results"] = self._fetch_series_results(
+                (ss.get("seriesLetter") or "").lower()
+            )
+        return series
+
+    def _fetch_series_results(self, series_letter: str) -> List[Dict[str, Any]]:
+        """Completed-game results for a playoff series, oldest first, for the
+        EPG-description recap. Reads the same per-series schedule endpoint the
+        importance bracket uses. Memoized per series letter. Best-effort:
+        returns [] on any fetch/parse failure, so the deterministic record line
+        (free from seriesStatus) still renders without it.
+        """
+        if not series_letter:
+            return []
+        cached = self._series_results_cache.get(series_letter)
+        if cached is not None:
+            return cached
+        results: List[Dict[str, Any]] = []
+        try:
+            sched = _http_get(self._series_schedule_url(series_letter))
+            for game in (sched or {}).get("games", []) or []:
+                state = game.get("gameState")
+                ht = game.get("homeTeam") or {}
+                at = game.get("awayTeam") or {}
+                hg = ht.get("score")
+                ag = at.get("score")
+                gn = game.get("gameNumber")
+                if state not in _FINAL_GAME_STATES or hg is None or ag is None:
+                    continue
+                if not isinstance(gn, int):
+                    continue
+                last_period = (game.get("gameOutcome") or {}).get("lastPeriodType")
+                results.append({
+                    "game_number": gn,
+                    "home": _team_canonical_name(ht),
+                    "away": _team_canonical_name(at),
+                    "home_goals": hg,
+                    "away_goals": ag,
+                    "ot": last_period in _NON_REGULATION_PERIODS,
+                })
+            results.sort(key=lambda r: r["game_number"])
+        except Exception as e:  # best-effort enrichment, never break refresh
+            logger.warning(
+                "[ranked_matchups] series-results fetch failed for %s: %s",
+                series_letter, e,
+            )
+            results = []
+        self._series_results_cache[series_letter] = results
+        return results
 
     # ---------- strengths (reused from regular season) ----------
 
@@ -551,16 +680,10 @@ class NhlPlayoffSource(BestOfNSeriesSource):
             if not top_name or not bot_name:
                 continue
 
-            # Per-series schedule for the actual game records. URL is
-            # `/v1/schedule/playoff-series/{full_season}/{lower_letter}`
-            #: empirically confirmed against the live host. NB: this
-            # uses the full 8-digit season, not the end-year used by
-            # the bracket endpoint above.
-            series_url = (
-                f"{NHL_API_BASE}/schedule/playoff-series/"
-                f"{self.season}/{series_letter}"
-            )
-            sched = _http_get(series_url)
+            # Per-series schedule for the actual game records. The
+            # full-8-digit-season vs end-year season-convention gotcha lives in
+            # _series_schedule_url (the single source of truth for this URL).
+            sched = _http_get(self._series_schedule_url(series_letter))
             games = (sched or {}).get("games", []) or []
 
             for g in games:

--- a/tests/test_llm_descriptions.py
+++ b/tests/test_llm_descriptions.py
@@ -115,6 +115,41 @@ class TestBuildLlmContext:
         ctx = llm.build_llm_context(_sample_game(), tagline="")
         assert "User's favorite teams playing: Tottenham" in ctx
 
+    def test_series_state_surfaced(self):
+        # Playoff grounding: without these lines the model invents
+        # "elimination" framing (the bug this feature fixes).
+        g = _sample_game()
+        g["home"] = "Carolina Hurricanes"
+        g["away"] = "Vegas Golden Knights"
+        g["extra"]["series"] = {
+            "title": "Stanley Cup Final", "game_number": 3, "best_of": 7,
+            "home_wins": 2, "away_wins": 0,
+            "results": [
+                {"game_number": 1, "home": "Carolina Hurricanes",
+                 "away": "Vegas Golden Knights", "home_goals": 3,
+                 "away_goals": 2, "ot": True},
+            ],
+        }
+        ctx = llm.build_llm_context(g, tagline="")
+        assert "Series: Stanley Cup Final, Game 3 of 7" in ctx
+        assert "Series record: Carolina Hurricanes lead the series 2-0" in ctx
+        assert "Results so far:" in ctx
+        assert "Game 1: Carolina Hurricanes 3, Vegas Golden Knights 2 (OT)" in ctx
+
+    def test_no_series_state_emits_no_series_lines(self):
+        ctx = llm.build_llm_context(_sample_game(), tagline="")
+        assert "Series:" not in ctx
+        assert "Series record:" not in ctx
+
+    def test_system_prompt_forbids_inventing_series_facts(self):
+        # The guardrail string must be present: it's the model-facing half of
+        # the fix (grounding lines are the data half). It targets fabricated
+        # SERIES facts specifically, so single-game knockouts can still be
+        # framed as win-or-go-home.
+        assert "Do NOT fabricate playoff series facts" in llm.SYSTEM_PROMPT
+        assert "facing elimination" in llm.SYSTEM_PROMPT
+        assert "win or go home" in llm.SYSTEM_PROMPT
+
     def test_importance_thresholds_surfaced(self):
         # Phase C.4 renamed the prompt label "Stakes thresholds" →
         # "Outcome bands" to match the importance-signal vocabulary.

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -927,6 +927,52 @@ class TestBuildDescription:
         # run the headline into the following block.
         assert out.split("\n\n", 1)[0].endswith(".")
 
+    # ---------- block 2b: playoff series state ----------
+
+    def test_series_phase_and_record_render(self, plugin):
+        # Game 1 of a tied series: the canonical bug case. The description must
+        # say "Game 1 of 7" and "Series tied", NEVER imply elimination.
+        g = self._g(
+            home="Carolina Hurricanes",
+            away="Vegas Golden Knights",
+            extra={"series": {
+                "title": "Stanley Cup Final", "game_number": 1, "best_of": 7,
+                "home_wins": 0, "away_wins": 0, "results": [],
+            }},
+        )
+        out = plugin._build_description(g, "", False)
+        assert "Stanley Cup Final, Game 1 of 7." in out
+        assert "Series tied 0-0." in out
+        assert "elimination" not in out.lower()
+
+    def test_series_recap_line_renders(self, plugin):
+        g = self._g(
+            home="Carolina Hurricanes",
+            away="Vegas Golden Knights",
+            extra={"series": {
+                "title": "Stanley Cup Final", "game_number": 3, "best_of": 7,
+                "home_wins": 1, "away_wins": 1,
+                "results": [
+                    {"game_number": 1, "home": "Carolina Hurricanes",
+                     "away": "Vegas Golden Knights", "home_goals": 3,
+                     "away_goals": 2, "ot": False},
+                    {"game_number": 2, "home": "Carolina Hurricanes",
+                     "away": "Vegas Golden Knights", "home_goals": 1,
+                     "away_goals": 2, "ot": True},
+                ],
+            }},
+        )
+        out = plugin._build_description(g, "", False)
+        assert "Game 3 of 7." in out
+        assert "Game 1: Carolina Hurricanes 3, Vegas Golden Knights 2" in out
+        assert "(OT)" in out
+
+    def test_no_series_key_renders_no_series_block(self, plugin):
+        # League fixtures (no extra["series"]) must be unaffected.
+        out = plugin._build_description(self._g(extra={"matchday": 7, "matchdays_total": 38}), "", False)
+        assert "of 7." not in out
+        assert "Series" not in out
+
     # ---------- block 3: matchday + league boundary ----------
 
     def test_matchday_line_uses_explicit_totals(self, plugin):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2225,6 +2225,142 @@ class TestNhlPlayoffSource:
         assert s["Avalanche"]["pf_per_game"] == 3.5
 
 
+class TestNhlSeriesGrounding:
+    """fetch_upcoming attaches a normalized extra['series'] block from the
+    daily-schedule seriesStatus, so the EPG description / LLM context can ground
+    "Game N of 7, series record" instead of letting the model guess. The win
+    counts arrive seed-keyed and must be re-keyed to THIS game's home/away.
+    """
+
+    @staticmethod
+    def _src():
+        from dispatcharr_ranked_matchups.sources.nhl import NhlPlayoffSource
+        return NhlPlayoffSource(season="20252026")
+
+    @staticmethod
+    def _daily_game(home_abbrev, away_abbrev, series_status):
+        return {
+            "id": 2025030411,
+            "homeTeam": {"abbrev": home_abbrev},
+            "awayTeam": {"abbrev": away_abbrev},
+            "seriesStatus": series_status,
+        }
+
+    def test_game_1_tied_no_recap_fetch(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import nhl as nhl_mod
+        # A recap fetch on a 0-0 series would be wasted: assert it isn't made.
+        monkeypatch.setattr(nhl_mod, "_http_get",
+                            lambda *a, **k: pytest.fail("should not fetch recap at 0-0"))
+        src = self._src()
+        g = self._daily_game("CAR", "VGK", {
+            "seriesTitle": "Stanley Cup Final", "seriesLetter": "O",
+            "neededToWin": 4, "gameNumberOfSeries": 1,
+            "topSeedTeamAbbrev": "CAR", "topSeedWins": 0,
+            "bottomSeedTeamAbbrev": "VGK", "bottomSeedWins": 0,
+        })
+        series = src._series_from_status(g)
+        assert series["title"] == "Stanley Cup Final"
+        assert series["game_number"] == 1
+        assert series["best_of"] == 7
+        assert series["home_wins"] == 0 and series["away_wins"] == 0
+        assert series["results"] == []
+
+    def test_win_counts_rekeyed_when_home_is_bottom_seed(self):
+        # Home ice alternates; in Game 3 the bottom seed (VGK) hosts. The
+        # top-seed win count must map to the AWAY side here.
+        src = self._src()
+        g = self._daily_game("VGK", "CAR", {
+            "seriesTitle": "Stanley Cup Final", "seriesLetter": "O",
+            "neededToWin": 4, "gameNumberOfSeries": 3,
+            "topSeedTeamAbbrev": "CAR", "topSeedWins": 2,
+            "bottomSeedTeamAbbrev": "VGK", "bottomSeedWins": 0,
+        })
+        # No HTTP: stub the recap fetch so the test stays offline.
+        src._series_results_cache["o"] = []
+        series = src._series_from_status(g)
+        # CAR (top seed, 2 wins) is the AWAY team this game.
+        assert series["home_wins"] == 0  # VGK
+        assert series["away_wins"] == 2  # CAR
+
+    def test_abbrev_mismatch_falls_back_to_seed_keyed_counts(self):
+        # Defensive branch: if the home abbrev matches neither seed (shouldn't
+        # happen on a live feed), record the seed-keyed counts as-is rather
+        # than guess the home/away mapping.
+        src = self._src()
+        src._series_results_cache["o"] = []
+        g = self._daily_game("XXX", "YYY", {
+            "seriesTitle": "Stanley Cup Final", "seriesLetter": "O",
+            "neededToWin": 4, "gameNumberOfSeries": 3,
+            "topSeedTeamAbbrev": "CAR", "topSeedWins": 2,
+            "bottomSeedTeamAbbrev": "VGK", "bottomSeedWins": 1,
+        })
+        series = src._series_from_status(g)
+        assert series["home_wins"] == 2  # top-seed count, unmapped
+        assert series["away_wins"] == 1
+
+    def test_missing_series_status_returns_none(self):
+        src = self._src()
+        assert src._series_from_status({"homeTeam": {"abbrev": "CAR"}}) is None
+
+    def test_fetch_series_results_parses_completed_games(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import nhl as nhl_mod
+        payload = {"games": [
+            {"gameNumber": 1, "gameState": "OFF",
+             "homeTeam": {"placeName": {"default": "Carolina"}, "commonName": {"default": "Hurricanes"}, "score": 3},
+             "awayTeam": {"placeName": {"default": "Vegas"}, "commonName": {"default": "Golden Knights"}, "score": 2},
+             "gameOutcome": {"lastPeriodType": "OT"}},
+            {"gameNumber": 2, "gameState": "FUT",  # not played: skipped
+             "homeTeam": {"placeName": {"default": "Carolina"}, "commonName": {"default": "Hurricanes"}, "score": None},
+             "awayTeam": {"placeName": {"default": "Vegas"}, "commonName": {"default": "Golden Knights"}, "score": None}},
+        ]}
+        monkeypatch.setattr(nhl_mod, "_http_get", lambda *a, **k: payload)
+        src = self._src()
+        results = src._fetch_series_results("o")
+        assert len(results) == 1
+        assert results[0]["game_number"] == 1
+        assert results[0]["home_goals"] == 3 and results[0]["away_goals"] == 2
+        assert results[0]["ot"] is True
+        # Second call is memoized: a failing fetch now must not be consulted.
+        monkeypatch.setattr(nhl_mod, "_http_get",
+                            lambda *a, **k: pytest.fail("memoized, should not refetch"))
+        assert src._fetch_series_results("o") == results
+
+    def test_fetch_series_results_swallows_errors(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import nhl as nhl_mod
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+        monkeypatch.setattr(nhl_mod, "_http_get", boom)
+        src = self._src()
+        # Best-effort: a failed recap fetch returns [] rather than raising.
+        assert src._fetch_series_results("o") == []
+
+    def test_fetch_series_results_empty_letter_short_circuits(self, monkeypatch):
+        from dispatcharr_ranked_matchups.sources import nhl as nhl_mod
+        monkeypatch.setattr(nhl_mod, "_http_get",
+                            lambda *a, **k: pytest.fail("empty letter must not fetch"))
+        assert self._src()._fetch_series_results("") == []
+
+    def test_fetch_series_results_shootout_counts_as_overtime(self, monkeypatch):
+        # lastPeriodType "SO" (shootout) is non-regulation, same as "OT".
+        from dispatcharr_ranked_matchups.sources import nhl as nhl_mod
+        payload = {"games": [
+            {"gameNumber": 1, "gameState": "FINAL",
+             "homeTeam": {"placeName": {"default": "Carolina"}, "commonName": {"default": "Hurricanes"}, "score": 4},
+             "awayTeam": {"placeName": {"default": "Vegas"}, "commonName": {"default": "Golden Knights"}, "score": 3},
+             "gameOutcome": {"lastPeriodType": "SO"}},
+        ]}
+        monkeypatch.setattr(nhl_mod, "_http_get", lambda *a, **k: payload)
+        results = self._src()._fetch_series_results("o")
+        assert results[0]["ot"] is True
+
+    def test_series_schedule_url_uses_full_season(self):
+        # The per-series endpoint takes the full 8-digit season, NOT the
+        # bracket endpoint's end-year. Pinning this guards the season-convention
+        # gotcha the helper docstring documents.
+        url = self._src()._series_schedule_url("o")
+        assert url.endswith("/schedule/playoff-series/20252026/o")
+
+
 # =====================================================================
 # Phase E: PointsBasedSportSource _count_field generalization
 # =====================================================================

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,14 @@
-"""Tests for _util.parse_iso_utc, stable_hash_int, extract_game_number_after_marker."""
+"""Tests for _util.parse_iso_utc, stable_hash_int, extract_game_number_after_marker,
+and the playoff-series rendering helpers."""
 
 from datetime import datetime, timezone
 
 from dispatcharr_ranked_matchups._util import (
     extract_game_number_after_marker,
     parse_iso_utc,
+    series_phase_text,
+    series_record_text,
+    series_result_lines,
     stable_hash_int,
 )
 
@@ -100,3 +104,90 @@ class TestExtractGameNumberAfterMarker:
         assert extract_game_number_after_marker(
             "Super Regional - Game ", "Super Regional - Game "
         ) is None
+
+
+# The series schema these render from is documented in _util.py. CAR is this
+# game's home team, VGK the away team, in every fixture below.
+def _series(**overrides):
+    s = {
+        "title": "Stanley Cup Final",
+        "game_number": 1,
+        "best_of": 7,
+        "home_wins": 0,
+        "away_wins": 0,
+        "results": [],
+    }
+    s.update(overrides)
+    return s
+
+
+class TestSeriesPhaseText:
+    def test_title_and_game_number(self):
+        assert series_phase_text(_series(game_number=2)) == "Stanley Cup Final, Game 2 of 7"
+
+    def test_no_title_drops_prefix(self):
+        assert series_phase_text(_series(title="", game_number=3)) == "Game 3 of 7"
+
+    def test_missing_game_number_returns_empty(self):
+        assert series_phase_text(_series(game_number=None)) == ""
+
+    def test_zero_best_of_returns_empty(self):
+        assert series_phase_text(_series(best_of=0)) == ""
+
+    def test_none_and_non_dict_return_empty(self):
+        assert series_phase_text(None) == ""
+        assert series_phase_text("nope") == ""
+
+
+class TestSeriesRecordText:
+    def test_tied(self):
+        assert series_record_text(_series(home_wins=1, away_wins=1),
+                                  "Carolina Hurricanes", "Vegas Golden Knights") == "Series tied 1-1"
+
+    def test_home_team_leads(self):
+        out = series_record_text(_series(home_wins=2, away_wins=1),
+                                 "Carolina Hurricanes", "Vegas Golden Knights")
+        assert out == "Carolina Hurricanes lead the series 2-1"
+
+    def test_away_team_leads(self):
+        # Win counts are keyed to home/away; when away leads, the AWAY name
+        # must be the subject and the bigger number must come first.
+        out = series_record_text(_series(home_wins=1, away_wins=3),
+                                 "Carolina Hurricanes", "Vegas Golden Knights")
+        assert out == "Vegas Golden Knights lead the series 3-1"
+
+    def test_missing_counts_returns_empty(self):
+        assert series_record_text(_series(home_wins=None), "A", "B") == ""
+
+    def test_none_returns_empty(self):
+        assert series_record_text(None, "A", "B") == ""
+
+
+class TestSeriesResultLines:
+    def test_empty_results(self):
+        assert series_result_lines(_series()) == []
+
+    def test_oldest_first_with_ot_tag(self):
+        s = _series(results=[
+            {"game_number": 1, "home": "Carolina Hurricanes", "away": "Vegas Golden Knights",
+             "home_goals": 3, "away_goals": 2, "ot": False},
+            {"game_number": 2, "home": "Carolina Hurricanes", "away": "Vegas Golden Knights",
+             "home_goals": 1, "away_goals": 2, "ot": True},
+        ])
+        assert series_result_lines(s) == [
+            "Game 1: Carolina Hurricanes 3, Vegas Golden Knights 2",
+            "Game 2: Carolina Hurricanes 1, Vegas Golden Knights 2 (OT)",
+        ]
+
+    def test_malformed_row_skipped(self):
+        # A result missing a score is skipped, not raised: a bad recap degrades
+        # to the surviving rows rather than breaking the description.
+        s = _series(results=[
+            {"game_number": 1, "home": "A", "away": "B", "home_goals": 3, "away_goals": 2},
+            {"game_number": 2, "home": "A", "away": "B"},  # missing scores
+            "garbage",
+        ])
+        assert series_result_lines(s) == ["Game 1: A 3, B 2"]
+
+    def test_none_returns_empty(self):
+        assert series_result_lines(None) == []


### PR DESCRIPTION
## Problem

Carolina vs Vegas (Stanley Cup Final **Game 1**) showed an EPG description claiming it was an **elimination game**. Root cause: the LLM description rewriter (Haiku) gets zero series grounding for best-of-N games, so it invents playoff drama. `llm_descriptions_cache.json` held three different hallucinations for that one game ("facing elimination", "force a Game 7", "season ends here"). The deterministic builder had no series branch either, and the structured series data was being dropped before the cache row.

## Fix (series grounding + completed-game recap)

- **`sources/nhl.py`** — `fetch_upcoming` normalizes the daily-schedule `seriesStatus` (already in the response, no extra call) into a sport-agnostic `extra["series"]`: game number, best-of-N, per-team record. Completed-game scores for the recap come from the per-series schedule endpoint, fetched best-effort, memoized, and only once a series is underway (Game 1 = zero extra calls).
- **`_util.py`** — three pure render helpers, the single home for turning series state into prose (shared by both renderers so wording can't drift). The `extra["series"]` schema is documented here for other series sports (NBA/MLB/NCAA) to adopt.
- **`plugin.py`** — deterministic `_build_description` renders a series block too (correct even with the LLM off).
- **`llm_descriptions.py`** — series lines added to the context; `SYSTEM_PROMPT` hardened to forbid fabricating series facts (without banning legit win-or-go-home framing for single-game knockouts). `SYSTEM_PROMPT` now folds into `prompt_hash` so prompt edits self-bust the cache.

DRY cleanups in the same change: extracted `_FINAL_GAME_STATES` / `_NON_REGULATION_PERIODS` constants (were magic tuples at 3 sites) and a single `_series_schedule_url` helper (URL was built in 2 places, consolidating the full-8-digit-season gotcha comment).

## Tests

`3069 passed`. New coverage: the three render helpers, `_series_from_status` (Game-1-no-fetch, seed→home/away re-keying, abbrev-mismatch fallback, missing-status), `_fetch_series_results` (parse, memoization, error-swallow, empty-letter, SO-as-overtime), the URL helper, both renderers' integration, and the prompt guardrail contract.

## Live verification (prod codepath, container `Dispatcharr` 0.25.1)

Deployed all files byte-identical to the running container, forced `POST /api/plugins/plugins/reload/`, then ran `refresh` + `apply` via the HTTP API.

- `cache.json` after refresh: NHL game now carries `extra.series = {title: "Stanley Cup Final", game_number: 1, best_of: 7, home_wins: 0, away_wins: 0, results: []}`.
- Live `ProgramData` description read back off the `!Top Matchups` EPG source:

  > Carolina gets its first shot at hoisting the Cup tonight as they host Vegas in **Game 1 of the Stanley Cup Final**. The Hurricanes have weathered the entire playoff gauntlet to reach this moment... now they face a Golden Knights team that's equally battle-tested and hungry for their second title in franchise history.

  Correctly framed as Game 1; no false elimination. `apply` reported `LLM descriptions: 4 written, 0 fell back`. Logs over the deploy window showed no `ImportError`/`AttributeError`/`KeyError` from the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)