### PR TITLE
Gate international friendlies to favorite national teams

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
   "author": "Jake (with Claude)",
   "license": "MIT",
@@ -95,14 +95,21 @@
       "type": "boolean",
       "label": "International Friendlies (Men's)",
       "default": false,
-      "help_text": "Senior men's national-team friendlies and FIFA-window warm-ups (e.g. a USMNT tune-up the week before the World Cup) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. Add a national team to Favorites to see its friendlies. Offseason → no rows. No API key required."
+      "help_text": "Senior men's national-team friendlies and FIFA-window warm-ups (e.g. a USMNT tune-up the week before the World Cup) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. By default only friendlies involving a Favorite national team are shown (see 'Friendlies: favorite national teams only' below); add the team to Favorites using the country name as ESPN spells it (e.g. \"United States\", not \"USA\"). Offseason → no rows. No API key required."
     },
     {
       "id": "enable_intl_friendlies_women",
       "type": "boolean",
       "label": "International Friendlies (Women's)",
       "default": false,
-      "help_text": "Senior women's national-team friendlies and FIFA-window warm-ups (e.g. a USWNT tune-up) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. Add a national team to Favorites to see its friendlies. Offseason → no rows. No API key required."
+      "help_text": "Senior women's national-team friendlies and FIFA-window warm-ups (e.g. a USWNT tune-up) from ESPN's unofficial API. Exhibition games: no standings/importance signal, so they surface via favorite + rivalry + narrative only. By default only friendlies involving a Favorite national team are shown (see 'Friendlies: favorite national teams only' below); add the team to Favorites using the country name as ESPN spells it (e.g. \"United States\", not \"USA\"). Offseason → no rows. No API key required."
+    },
+    {
+      "id": "friendlies_favorites_only",
+      "type": "boolean",
+      "label": "Friendlies: favorite national teams only",
+      "default": true,
+      "help_text": "When on (default), International Friendlies (men's and women's) show ONLY games involving a national team in your Favorites. A friendly is an exhibition with no standings or rank, so a game between two teams you don't follow has nothing to earn a guide slot, and a FIFA window produces dozens of them (Kenya vs Lesotho, Cambodia vs Hong Kong, ...). Match by the country name as ESPN spells it (\"United States\", not \"USA\"). Turn this OFF to see every international friendly in the lookahead window. No effect unless a Friendlies toggle above is on."
     },
     {
       "id": "enable_eredivisie",

--- a/plugin.py
+++ b/plugin.py
@@ -615,10 +615,25 @@ def _build_sources(settings: Dict[str, Any]):
     # is the only path for a pre-tournament national-team warm-up (e.g. a
     # USMNT friendly the week before the World Cup) to reach the guide: the
     # world_cup source carries only FD.org tournament fixtures, not friendlies.
+    # friendlies_favorites_only (default on) gates these to favorite national
+    # teams only: a FIFA window yields dozens of exhibitions between teams the
+    # user doesn't follow, and a friendly has no standings/rank to earn a slot
+    # on its own. The source does the matching (reusing scoring.match_favorites)
+    # so we just hand it the user's favorites and the toggle.
+    intl_favorites = _parse_favorites(settings.get("favorites", ""))
+    intl_favorites_only = bool(settings.get("friendlies_favorites_only", True))
     if settings.get("enable_intl_friendlies", False):
-        sources.append(InternationalFriendliesSource(gender="m"))
+        sources.append(InternationalFriendliesSource(
+            gender="m",
+            favorites=intl_favorites,
+            favorites_only=intl_favorites_only,
+        ))
     if settings.get("enable_intl_friendlies_women", False):
-        sources.append(InternationalFriendliesSource(gender="w"))
+        sources.append(InternationalFriendliesSource(
+            gender="w",
+            favorites=intl_favorites,
+            favorites_only=intl_favorites_only,
+        ))
 
     # Additional FD.org free-tier leagues. Same _make_soccer
     # router; LEAGUE_CONTEXTS uses format="league" so dispatch goes
@@ -2570,7 +2585,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.0.0"
+    version = "1.1.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/sources/friendlies.py
+++ b/sources/friendlies.py
@@ -24,6 +24,16 @@ Parametrized on gender ("m"/"w"), mirroring NcaaSoccerSource:
   - men's   -> ESPN league slug "fifa.friendly"
   - women's -> ESPN league slug "fifa.friendly.w"
 
+Favorites gate (favorites_only): because a friendly's ONLY claim to a guide
+slot is the favorite signal, the source can be told to emit only games that
+involve a configured favorite national team. A FIFA window produces dozens of
+fixtures between teams a given user doesn't follow (Kenya vs Lesotho, Cambodia
+vs Hong Kong); surfacing all of them buries the one game the user cares about.
+With the gate on, a friendly between two non-favorite teams is dropped EVEN IF
+it would otherwise pick up a rivalry/narrative signal: an exhibition between
+teams you don't follow isn't a Top Matchup. The gate is opt-out (the plugin
+defaults it on) so users who genuinely want every friendly can disable it.
+
 Offseason (no friendlies scheduled in the lookahead window) returns []. No API
 key required (ESPN's site API is free, same as the NFL/NHL/NCAA-soccer
 sources).
@@ -73,13 +83,28 @@ class InternationalFriendliesSource(SportSource):
     """Senior national-team friendlies from ESPN, parametrized on gender
     ("m" or "w"). Lightweight: implements only fetch_upcoming. No importance
     simulation (exhibition games have no standings), so a friendly scores on
-    favorite / rivalry / narrative signals alone."""
+    favorite / rivalry / narrative signals alone. Optionally gated to favorite
+    national teams only (favorites_only); see the module docstring."""
 
-    def __init__(self, gender: str = "m") -> None:
+    def __init__(
+        self,
+        gender: str = "m",
+        favorites: Optional[List[str]] = None,
+        favorites_only: bool = False,
+    ) -> None:
         g = (gender or "").lower().strip()
         if g not in ("m", "w"):
             raise ValueError(f"gender must be 'm' or 'w', got {gender!r}")
         self.gender = g
+        # favorites_only gates fetch_upcoming to games involving a configured
+        # favorite national team. Matching reuses scoring.match_favorites so
+        # the word-boundary rules are IDENTICAL to how the favorite SCORING
+        # signal is computed; DO NOT reimplement substring matching here and
+        # risk the gate and the score disagreeing on what "involves a favorite"
+        # means. self.favorites holds the user's own Favorites list (country
+        # names as ESPN spells them: "United States", not "USA").
+        self.favorites = list(favorites or [])
+        self.favorites_only = bool(favorites_only)
 
     @property
     def sport_prefix(self) -> str:
@@ -102,7 +127,24 @@ class InternationalFriendliesSource(SportSource):
         ncaa_baseball.py / ncaa_soccer.py). Drops FINISHED games: a friendly
         that already kicked off and ended is not an upcoming Top Matchup. A
         live (in-progress) game classifies as SCHEDULED in the shared parser
-        and is kept, so a game "playing right now" still surfaces."""
+        and is kept, so a game "playing right now" still surfaces.
+
+        When favorites_only is set, drops any game not involving a favorite
+        national team (see the module docstring on the favorites gate)."""
+        # Lazy import to keep the source module's top-level import graph free of
+        # scoring (matches the lazy-import idiom used across sources/*.py).
+        from ..scoring import match_favorites
+
+        if self.favorites_only and not self.favorites:
+            # Gate is on but the user configured no favorites, so every game
+            # would be dropped. Surface this once per fetch rather than fail
+            # silently with an empty guide section.
+            logger.warning(
+                "[friendlies] favorites_only is on but no favorites are "
+                "configured: all %s friendlies will be suppressed",
+                self.sport_label,
+            )
+
         today = datetime.now(timezone.utc).date()
         out: List[GameRow] = []
         seen_ids: set = set()
@@ -129,6 +171,15 @@ class InternationalFriendliesSource(SportSource):
                 start = rec.get("start_time")
                 if start is None:
                     continue
+                home = rec["home"]
+                away = rec["away"]
+                if self.favorites_only and not match_favorites(
+                    home, away, self.favorites
+                ):
+                    # Exhibition between teams the user doesn't follow: no
+                    # standings/rank to earn a slot and no favorite to rescue
+                    # it. Drop rather than let it pad the guide.
+                    continue
                 # No rank (national-team friendlies have no poll), no spread,
                 # no closeness, no fd_competition_code: the scoring loop sees
                 # no league context and contributes zero importance, which is
@@ -137,8 +188,8 @@ class InternationalFriendliesSource(SportSource):
                 out.append(GameRow(
                     sport_prefix=self.sport_prefix,
                     sport_label=self.sport_label,
-                    home=rec["home"],
-                    away=rec["away"],
+                    home=home,
+                    away=away,
                     rank_home=None,
                     rank_away=None,
                     start_time=start,

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -162,6 +162,55 @@ class TestParseFavorites:
         assert plugin._parse_favorites("") == []
 
 
+class TestBuildSourcesFriendliesGate:
+    """_build_sources is where the friendlies favorites-gate is wired: it
+    reads friendlies_favorites_only (defaulting ON) and the user's Favorites
+    and hands both to InternationalFriendliesSource. Enable ONLY friendlies so
+    no API keys are needed and the returned list is just the friendlies
+    source(s)."""
+
+    def _friendlies(self, plugin, settings):
+        from dispatcharr_ranked_matchups.sources.friendlies import (
+            InternationalFriendliesSource,
+        )
+        return [
+            s for s in plugin._build_sources(settings)
+            if isinstance(s, InternationalFriendliesSource)
+        ]
+
+    def test_default_gates_on_and_passes_favorites(self, plugin):
+        # friendlies_favorites_only OMITTED must default to True (the manifest
+        # default), and the user's Favorites must reach the source.
+        srcs = self._friendlies(plugin, {
+            "favorites": "United States, Tottenham",
+            "enable_intl_friendlies": True,
+        })
+        assert len(srcs) == 1
+        assert srcs[0].gender == "m"
+        assert srcs[0].favorites_only is True
+        assert srcs[0].favorites == ["United States", "Tottenham"]
+
+    def test_explicit_opt_out(self, plugin):
+        srcs = self._friendlies(plugin, {
+            "favorites": "United States",
+            "enable_intl_friendlies": True,
+            "friendlies_favorites_only": False,
+        })
+        assert len(srcs) == 1
+        assert srcs[0].favorites_only is False
+
+    def test_women_source_also_gated(self, plugin):
+        # The gate applies to both genders from the single toggle.
+        srcs = self._friendlies(plugin, {
+            "favorites": "United States",
+            "enable_intl_friendlies_women": True,
+        })
+        assert len(srcs) == 1
+        assert srcs[0].gender == "w"
+        assert srcs[0].favorites_only is True
+        assert srcs[0].favorites == ["United States"]
+
+
 class TestBuildMarkerKey:
     """The fallback path MUST be process-stable (issue: Python's hash() is
     salted by PYTHONHASHSEED, causing every soccer game to look like a new

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9836,3 +9836,80 @@ class TestInternationalFriendliesSource:
         # No poll for national-team friendlies, no league context.
         assert row.rank_home is None and row.rank_away is None
         assert row.extra["espn_league_slug"] == "fifa.friendly"
+
+    @staticmethod
+    def _scheduled_event(eid, home, away):
+        return {
+            "id": eid,
+            "date": "2026-06-09T19:30Z",
+            "competitions": [{
+                "status": {"type": {"completed": False, "state": "pre"}},
+                "competitors": [
+                    {"homeAway": "home", "score": None,
+                     "team": {"location": home}},
+                    {"homeAway": "away", "score": None,
+                     "team": {"location": away}},
+                ],
+            }],
+        }
+
+    def _patch_events(self, monkeypatch, events):
+        from dispatcharr_ranked_matchups.sources import friendlies as friendlies_mod
+
+        class FakeResp:
+            status_code = 200
+            def json(self): return {"events": events}
+
+        monkeypatch.setattr(friendlies_mod.requests, "get",
+                            lambda *a, **kw: FakeResp())
+
+    def test_favorites_only_keeps_favorite_drops_rest(self, monkeypatch):
+        # The favorites gate: only games involving a configured favorite
+        # national team survive. The country name must match ESPN's `location`
+        # spelling ("United States"), which is what match_favorites sees.
+        self._patch_events(monkeypatch, [
+            self._scheduled_event("1", "United States", "Senegal"),
+            self._scheduled_event("2", "Kenya", "Lesotho"),       # dropped
+            self._scheduled_event("3", "Cambodia", "Hong Kong"),  # dropped
+        ])
+        rows = InternationalFriendliesSource(
+            gender="m",
+            favorites=["United States", "Tottenham"],
+            favorites_only=True,
+        ).fetch_upcoming(days_ahead=0)
+        assert len(rows) == 1
+        assert (rows[0].home, rows[0].away) == ("United States", "Senegal")
+
+    def test_favorites_only_off_keeps_all(self, monkeypatch):
+        # Opt-out path: a user who wants every friendly disables the gate.
+        self._patch_events(monkeypatch, [
+            self._scheduled_event("1", "United States", "Senegal"),
+            self._scheduled_event("2", "Kenya", "Lesotho"),
+        ])
+        rows = InternationalFriendliesSource(
+            gender="m",
+            favorites=["United States"],
+            favorites_only=False,
+        ).fetch_upcoming(days_ahead=0)
+        assert len(rows) == 2
+
+    def test_favorites_only_default_off_keeps_all(self, monkeypatch):
+        # The SOURCE defaults favorites_only False (the plugin layer is what
+        # defaults it on). A bare source must not silently filter.
+        self._patch_events(monkeypatch, [
+            self._scheduled_event("1", "Kenya", "Lesotho"),
+        ])
+        rows = InternationalFriendliesSource(gender="m").fetch_upcoming(
+            days_ahead=0)
+        assert len(rows) == 1
+
+    def test_favorites_only_no_favorites_drops_all(self, monkeypatch):
+        # Gate on but no favorites configured: nothing can match, so the
+        # section is empty (and a warning is logged, not an exception).
+        self._patch_events(monkeypatch, [
+            self._scheduled_event("1", "United States", "Senegal"),
+        ])
+        rows = InternationalFriendliesSource(
+            gender="m", favorites=[], favorites_only=True,
+        ).fetch_upcoming(days_ahead=0)
+        assert rows == []


### PR DESCRIPTION
## Problem

International friendlies flood the guide. A FIFA window produces dozens of fixtures (36 in the current 7-day window) between teams a given user doesn't follow (Kenya vs Lesotho, Cambodia vs Hong Kong, ...). A friendly is an exhibition with no standings, rank, or elimination stakes, so its only claim to a guide slot is the favorite signal. There was no gate, so every fixture surfaced as noise. The help text already *claimed* favorites gated friendlies ("Add a national team to Favorites to see its friendlies") but nothing enforced it.

## Change

New setting `friendlies_favorites_only` (boolean, **default on**, opt-out for users who genuinely want every friendly):

- When on, `InternationalFriendliesSource.fetch_upcoming` drops any game not involving a configured favorite national team.
- Matching reuses `scoring.match_favorites` so the gate and the favorite *scoring* signal agree on what "involves a favorite" means (no parallel matching logic).
- The plugin layer (`_build_sources`) owns the default and passes the user's Favorites + toggle; the source stays neutral (defaults off).
- Help text steers users to the country name as ESPN spells it ("United States", not "USA").
- Version bumped 1.0.0 → 1.1.0 (class attr, manifest, `__init__`).

## Tests

- 4 source-level gate tests (`tests/test_sources.py`): favorite kept / others dropped, gate-off keeps all, source-default keeps all, gate-on-no-favorites drops all.
- 3 wiring tests (`tests/test_plugin_helpers.py`): default-gates-on + favorites passthrough, explicit opt-out, women's source also gated.

## Live verification (prod, running container)

- Pre-fix cache: 13 FRIENDLY rows with `favorites_matched: []` (Kenya vs Lesotho, Liechtenstein vs Cyprus, ...).
- After deploy + container restart (to clear stale uWSGI worker modules) + refresh via the HTTP action: log shows `International Friendly: pulled 0 games` (was 36), cache holds **0 FRIENDLY rows**. With "United States" in Favorites, a US friendly would still match `match_favorites` and surface (proven by the source gate test against the deployed code).
- Plugins API confirms the new field renders (type boolean, default true) with no serializer-drop warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)