### PR TITLE
Customizable channel-name template, inline ranks, humanized taglines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this plugin are documented here. Format roughly
 follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
+## [Unreleased]
+
+### Added
+
+- **Customizable channel-name template** (#100). A new "Channel Naming"
+  setting (`name_template`) lets you reshape the channel name with
+  Sonarr/Radarr-style variables: plain text is literal, a `{group}` holds one
+  variable plus any glued literal characters, and the whole group collapses
+  when the variable is blank. Variables include `{league_short}`,
+  `{away_team}`, `{home_team}`, `{rank_away}`, `{rank_home}`, `{rank_pair}`,
+  `{score}`, `{favorite_star}`, `{tagline}`, `{tournament}`, `{venue}`,
+  `{game_date}`, `{start_time}`, `{kickoff}`, and `{rivalry}`. Leave blank for
+  the default. Implemented in the new `naming.py`.
+- **"Test naming convention" action** (`preview_names`, #100). Renders the
+  current template against sample games with no DB writes, reports template
+  errors, and lists every variable, so a template can be checked before it
+  reaches live channels.
+
+### Changed
+
+- **Channel names now show poll ranks inline** after each team, e.g.
+  `Ohio State (5) at Penn State (1)`, replacing the compact `NvN` head prefix
+  that could not say which team held which rank (#99). Ranks only render for
+  poll-ranked leagues (AP / Coaches Top 25); standings-position leagues are
+  unaffected.
+- **Tournament / bracket taglines are humanized** (#98): `omaha_bound` now
+  reads "Road to Omaha", `round_of_32` reads "Round of 32", `elite_8` reads
+  "Elite Eight", and so on, with the incorrect "race" suffix dropped for
+  bracket and championship-event bands. Season-long standings bands keep their
+  "race" framing (title race, relegation race).
+
 ## [1.0.0] — 2026-05-26
 
 First stable release. The plugin has been running daily in production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,9 @@ downstream is sport-agnostic.
 | File | What it does |
 |---|---|
 | `plugin.json` | Manifest: settings (sports toggles, weights, favorites, schedule), actions. Read by Dispatcharr loader. |
-| `plugin.py` | Plugin class + 4 actions: `refresh`, `apply`, `auto_pipeline`, `show_status`. Daemon scheduler. EPG lookup closure. Channel cloning + dummy EPGSource management. |
-| `scoring.py` | `GameSignals`, `Weights`, `GameScore`. `score_game()` sums per-signal contributions, `_compress_to_10()` does the tanh squash. Helpers: `match_favorites`, `compute_match_importance` (Lahvička Monte Carlo), `format_channel_name`. League thresholds in `LEAGUE_CONTEXTS` dict (position, label, consequence_weight). |
+| `plugin.py` | Plugin class + 5 actions: `refresh`, `apply`, `auto_pipeline`, `show_status`, `preview_names` (renders the name template against sample games). Daemon scheduler. EPG lookup closure. Channel cloning + dummy EPGSource management. |
+| `scoring.py` | `GameSignals`, `Weights`, `GameScore`. `score_game()` sums per-signal contributions, `_compress_to_10()` does the tanh squash. Helpers: `match_favorites`, `compute_match_importance` (Lahvička Monte Carlo), `format_channel_name` (delegates to `naming`), `render_importance_tagline` + `STAGE_BANDS` (bracket-band prettify), `tournament_stage_label`. League thresholds in `LEAGUE_CONTEXTS` dict (position, label, consequence_weight). |
+| `naming.py` | Channel-name templating (Sonarr/Radarr `{group}`-collapse convention). `render_name`, `validate_template`, `build_context`, `preview_lines`, `DEFAULT_NAME_TEMPLATE`, `TOKENS`. Pure: no Django, no `scoring` import. |
 | `simulation.py` | Sport-agnostic Monte Carlo importance per Lahvička (2012). `monte_carlo_importance()` for single (team, outcome); `monte_carlo_importance_batch()` shares one set of N season simulations across K queries. `kendall_tau_c()` is the ordinal-association measure. |
 | `matcher.py` | `match_games_to_channels()` resolves cached `GameRow` → Dispatcharr channel via EPG `ProgramData`. Two-stage: regex (both team keywords in EPG title) → Claude batched fallback. |
 | `sources/base.py` | `GameRow` + `MatchResult` dataclasses + abstract `SportSource`. ABC declares the Monte Carlo importance interface (`supports_importance` flag + 7 optional methods); sources opt in by overriding. |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ implementation and testing are done by AI.
 ## Example output
 
 ```
-#9000  EPL 3v9 ★10.0: Brentford FC at Manchester United FC
+#9000  EPL ★10.0 · Brentford at Manchester United · title / UCL race
        — both top-10 (#3 vs #9), title / UCL race, toss-up (line +0.5)
 
        Description (what TiviMate/Plex/Jellyfin show):
@@ -73,13 +73,21 @@ implementation and testing are done by AI.
            importance: +17.0
          Source channel: Manchester United
 
-#9002  EFL 4v6 ⭐ ★10.0: Middlesbrough FC at Wrexham AFC
+#9002  EFL ⭐★10.0 · Middlesbrough at Wrexham · playoff / auto-promotion race
        — both top-10 (#4 vs #6), favorite (Wrexham),
          playoff / auto-promotion race, toss-up (line +0.2)
+
+#9100  CFB ★9.2 · Ohio State (5) at Penn State (1) · top-5 showdown
+       — poll-ranked leagues show the rank inline after each team
 ```
 
 Today's games are sorted to the front (lowest channel numbers) so they appear
 first in any IPTV client.
+
+The channel name is fully customizable (see "Channel Naming" in settings). The
+default renders as above: poll ranks appear inline after each team, and any
+empty field (an unranked team, a game with no tagline) collapses cleanly. Use
+the **Test naming convention** action to preview a template before applying it.
 
 ## Sports supported
 
@@ -163,6 +171,7 @@ form will collect everything needed to scope it.
 | `apply` | Create / update virtual channels in the target group, link to source-channel streams, write `ProgramData` descriptions, delete stale ones. | DB (honors `dry_run`) |
 | `auto_pipeline` | `refresh` + `apply`. The scheduler runs this; the button triggers it on demand. | Both |
 | `show_status` | Print the current curated list with per-game score breakdown. No writes. | — |
+| `preview_names` | Render the channel-name template against sample games so you can check the layout before applying. Reports template errors and lists every variable. No writes. | — |
 
 ## How channels are created
 
@@ -170,7 +179,10 @@ The plugin keeps your source channels untouched. Instead it creates **virtual
 channels** in a target ChannelGroup (default `Top Matchups`; tip: prefix with
 `!` to sort to the top of your group list):
 
-- Channel name: `<SPORT> <RANKS> ★<SCORE>: <AWAY> at <HOME> — <WHY>`
+- Channel name: rendered from a customizable template (default:
+  `{league_short} {favorite_star}★{score} · {away_team}{ (rank_away)} at {home_team}{ (rank_home)}{ · tagline}`).
+  Plain text is literal; a `{group}` collapses entirely when its variable is
+  blank. Set your own under "Channel Naming"; preview with `preview_names`.
 - Streams: cloned via `ChannelStream` from the matched source channel, so
   playback works
 - EPG: a dummy `EPGSource` (auto-created with the same name as the group)

--- a/naming.py
+++ b/naming.py
@@ -1,0 +1,244 @@
+"""Channel-name templating: Sonarr/Radarr-style ``{token}`` substitution.
+
+Bare text in a template is literal. A ``{group}`` holds exactly one known
+token plus optional literal decoration glued around it (brackets, parens,
+separators, spaces). The WHOLE group collapses to nothing when its token
+resolves empty, so optional fields (an unranked team, a game with no tagline)
+leave no orphaned separators, parentheses, or double spaces behind.
+
+This is deliberately the same convention Sonarr and Radarr use for media file
+naming: ``{[Quality Full]}`` renders ``[1080p]`` or disappears entirely. The
+self-hosted media audience this plugin serves already knows it, so a custom
+naming string reads the way they expect.
+
+The module is intentionally free of Django (and of ``scoring``) imports so it
+stays a pure function set: unit-testable in isolation and safe to call from the
+"test naming convention" action without booting the plugin's heavier paths.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+
+# The default ships inline poll ranks after each team (issue #99) and drops the
+# old "NvN" head prefix, since the prefix could not say WHICH team held which
+# rank. Every optional group collapses when empty (issue #100), so the same
+# template serves a ranked college clash and a rankless pro game.
+DEFAULT_NAME_TEMPLATE = (
+    "{league_short} {favorite_star}★{score} · "
+    "{away_team}{ (rank_away)} at {home_team}{ (rank_home)}{ · tagline}"
+)
+
+# Every token the template understands -> a one-line, user-facing description.
+# The descriptions are surfaced verbatim by the test-naming action, so keep
+# them tight. Insertion order is the order they are listed to the user.
+TOKENS: Dict[str, str] = {
+    "league_short": "Short league code, e.g. CFB",
+    "league_full": "Full league name, e.g. NCAA Football",
+    "away_team": "Away team (corporate suffix stripped)",
+    "home_team": "Home team (corporate suffix stripped)",
+    "rank_away": "Away team poll rank, blank unless poll-ranked",
+    "rank_home": "Home team poll rank, blank unless poll-ranked",
+    "rank_pair": "Compact rank pair, e.g. 1v5 (blank unless both poll-ranked)",
+    "score": "Interestingness score 0-10, e.g. 8.5",
+    "favorite_star": "A star when one of your favorites is playing, else blank",
+    "tagline": "Editorial tagline, e.g. top-5 showdown / title race / Final Four",
+    "tournament": "Tournament stage only, e.g. Round of 16 (blank if none)",
+    "venue": "Venue name (blank if unknown)",
+    "game_date": "Local date, e.g. Sat Nov 15",
+    "start_time": "Local start time, e.g. 7:00 PM",
+    "kickoff": "Friendly kickoff, e.g. Today 7:00 PM EST",
+    "rivalry": "The word 'rivalry' for a known rivalry, else blank",
+}
+KNOWN_TOKENS = set(TOKENS)
+
+_FAVORITE_STAR = "⭐"
+
+_GROUP_RE = re.compile(r"\{([^{}]*)\}")
+# Longest-first matching so a token never loses to a shorter token that is a
+# prefix of it (e.g. a future bare "rank" must not pre-empt "rank_home").
+_TOKEN_IN_GROUP_RE = re.compile(
+    r"\b(" + "|".join(re.escape(t) for t in sorted(KNOWN_TOKENS, key=len, reverse=True)) + r")\b"
+)
+
+
+def _find_token(inner: str) -> Optional[str]:
+    """Return the known token inside a group's text, or None if there isn't one."""
+    m = _TOKEN_IN_GROUP_RE.search(inner)
+    return m.group(1) if m else None
+
+
+def render_name(template: str, ctx: Dict[str, str]) -> str:
+    """Render ``template`` against a token -> value map.
+
+    A ``{group}`` emits its inner text with the token replaced by its value, or
+    nothing at all when the value is empty (the collapse that keeps separators
+    from orphaning). Bare text passes through unchanged. A group with no known
+    token is emitted literally (its braces stripped); ``validate_template``
+    reports that case so the test action can warn before it reaches a channel.
+    """
+    def _sub(m: "re.Match[str]") -> str:
+        inner = m.group(1)
+        token = _find_token(inner)
+        if token is None:
+            return inner
+        value = ctx.get(token, "")
+        if value == "":
+            return ""
+        return inner.replace(token, value, 1)
+
+    return _GROUP_RE.sub(_sub, template)
+
+
+def validate_template(template: str) -> List[str]:
+    """Return human-readable problems with a template; empty list means valid."""
+    errors: List[str] = []
+    if template.count("{") != template.count("}"):
+        errors.append("Unbalanced { } braces.")
+    for m in _GROUP_RE.finditer(template):
+        inner = m.group(1)
+        if _find_token(inner) is None:
+            errors.append(f"No known variable in group: {{{inner}}}")
+    return errors
+
+
+def _fmt_rank(rank: Optional[int], is_poll: bool) -> str:
+    # Poll ranks (AP / Coaches Top 25) are meaningful absolute numbers; a
+    # standings "rank" is just a league-table position every team has, so it
+    # must NOT render as an inline rank. The rank_source == "poll" gate mirrors
+    # the one pick_tagline already applies for the rank-pair tagline.
+    return str(rank) if (rank is not None and is_poll) else ""
+
+
+def _kickoff_phrase(local: datetime) -> str:
+    """Today/Tomorrow-aware kickoff, matching the EPG description convention."""
+    today = datetime.now(local.tzinfo).date()
+    delta = (local.date() - today).days
+    if delta == 0:
+        return f"Today {local.strftime('%-I:%M %p %Z')}".strip()
+    if delta == 1:
+        return f"Tomorrow {local.strftime('%-I:%M %p %Z')}".strip()
+    return local.strftime("%a %b %-d, %-I:%M %p %Z").strip()
+
+
+def build_context(
+    *,
+    sport_prefix: str = "",
+    sport_label: str = "",
+    home: str = "",
+    away: str = "",
+    rank_home: Optional[int] = None,
+    rank_away: Optional[int] = None,
+    rank_source: str = "poll",
+    score_final: Optional[float] = None,
+    favorite: bool = False,
+    tagline: str = "",
+    tournament: str = "",
+    venue: Optional[str] = None,
+    is_rivalry: bool = False,
+    start_dt: Optional[datetime] = None,
+    tz=None,
+) -> Dict[str, str]:
+    """Build the token -> value map for one game.
+
+    ``home`` / ``away`` are expected pre-stripped of corporate suffixes by the
+    caller (scoring owns ``strip_team_suffix``); this keeps the module free of a
+    circular import. Every value is a string; empty string is the signal that
+    tells ``render_name`` to collapse the surrounding group.
+    """
+    is_poll = rank_source == "poll"
+    rh = _fmt_rank(rank_home, is_poll)
+    ra = _fmt_rank(rank_away, is_poll)
+    rank_pair = ""
+    if rh and ra:
+        lo, hi = sorted((int(rank_home), int(rank_away)))  # type: ignore[arg-type]
+        rank_pair = f"{lo}v{hi}"
+
+    game_date = start_time = kickoff = ""
+    if start_dt is not None and tz is not None:
+        aware = start_dt if start_dt.tzinfo else start_dt.replace(tzinfo=timezone.utc)
+        local = aware.astimezone(tz)
+        game_date = local.strftime("%a %b %-d")
+        start_time = local.strftime("%-I:%M %p")
+        kickoff = _kickoff_phrase(local)
+
+    return {
+        "league_short": sport_prefix or "",
+        "league_full": sport_label or "",
+        "away_team": away or "",
+        "home_team": home or "",
+        "rank_away": ra,
+        "rank_home": rh,
+        "rank_pair": rank_pair,
+        "score": f"{score_final:.1f}" if score_final is not None else "",
+        "favorite_star": _FAVORITE_STAR if favorite else "",
+        "tagline": tagline or "",
+        "tournament": tournament or "",
+        "venue": venue or "",
+        "game_date": game_date,
+        "start_time": start_time,
+        "kickoff": kickoff,
+        "rivalry": "rivalry" if is_rivalry else "",
+    }
+
+
+# Representative games for the test-naming action: deterministic, always
+# available (no live cache required), and chosen to exercise every collapse
+# path: both ranked, one ranked, none ranked, favorite present/absent, a
+# tournament-stage tagline, a standings "race" tagline, and a rivalry.
+_PREVIEW_SAMPLES = [
+    {
+        "_label": "Ranked vs unranked, favorite, college",
+        "sport_prefix": "CBB", "sport_label": "NCAA Basketball",
+        "away": "Alabama", "home": "St. John's",
+        "rank_away": 15, "rank_home": None, "rank_source": "poll",
+        "score_final": 8.5, "favorite": True, "tagline": "top-25 matchup",
+    },
+    {
+        "_label": "Both ranked, college football",
+        "sport_prefix": "CFB", "sport_label": "NCAA Football",
+        "away": "Ohio State", "home": "Penn State",
+        "rank_away": 5, "rank_home": 1, "rank_source": "poll",
+        "score_final": 9.2, "favorite": False, "tagline": "top-5 showdown",
+    },
+    {
+        "_label": "Standings race, soccer (ranks suppressed)",
+        "sport_prefix": "EPL", "sport_label": "Premier League",
+        "away": "Brentford", "home": "Manchester United",
+        "rank_away": 9, "rank_home": 3, "rank_source": "standings",
+        "score_final": 10.0, "favorite": False, "tagline": "title race",
+    },
+    {
+        "_label": "Pro game, no ranks / no tagline / no favorite",
+        "sport_prefix": "NFL", "sport_label": "NFL",
+        "away": "Buffalo Bills", "home": "Kansas City Chiefs",
+        "rank_away": None, "rank_home": None, "rank_source": "poll",
+        "score_final": 7.2, "favorite": False, "tagline": "",
+    },
+    {
+        "_label": "Tournament stage tagline",
+        "sport_prefix": "CWS", "sport_label": "NCAA Baseball",
+        "away": "LSU", "home": "Tennessee",
+        "rank_away": None, "rank_home": None, "rank_source": "poll",
+        "score_final": 9.0, "favorite": False, "tagline": "Road to Omaha",
+    },
+]
+
+
+def preview_lines(template: str, tz=None) -> "tuple[List[str], List[tuple[str, str]]]":
+    """Render the canned sample games against ``template``.
+
+    Returns ``(errors, [(sample_label, rendered_name), ...])``. ``errors`` is
+    the ``validate_template`` output so the caller can surface problems instead
+    of showing a silently-wrong preview.
+    """
+    errors = validate_template(template)
+    out: List[tuple[str, str]] = []
+    for sample in _PREVIEW_SAMPLES:
+        kwargs = {k: v for k, v in sample.items() if not k.startswith("_")}
+        ctx = build_context(tz=tz, **kwargs)
+        out.append((sample["_label"], render_name(template, ctx)))
+    return errors, out

--- a/plugin.json
+++ b/plugin.json
@@ -310,9 +310,18 @@
       "label": "Claude model",
       "default": "claude-haiku-4-5",
       "options": [
-        {"value": "claude-haiku-4-5", "label": "Claude Haiku 4.5 (cheap, fast)"},
-        {"value": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6"},
-        {"value": "claude-opus-4-7", "label": "Claude Opus 4.7"}
+        {
+          "value": "claude-haiku-4-5",
+          "label": "Claude Haiku 4.5 (cheap, fast)"
+        },
+        {
+          "value": "claude-sonnet-4-6",
+          "label": "Claude Sonnet 4.6"
+        },
+        {
+          "value": "claude-opus-4-7",
+          "label": "Claude Opus 4.7"
+        }
       ],
       "help_text": "Model used for ambiguous EPG matching and (if enabled) narrative scoring."
     },
@@ -335,10 +344,22 @@
       "label": "Curation preset",
       "default": "manual",
       "options": [
-        {"value": "manual", "label": "Manual (use individual weights + max_games below)"},
-        {"value": "high_curation", "label": "High curation (~10 games, only the best)"},
-        {"value": "balanced", "label": "Balanced (~25 games, default v0 behavior)"},
-        {"value": "high_coverage", "label": "High coverage (~50 games, include smaller stakes)"}
+        {
+          "value": "manual",
+          "label": "Manual (use individual weights + max_games below)"
+        },
+        {
+          "value": "high_curation",
+          "label": "High curation (~10 games, only the best)"
+        },
+        {
+          "value": "balanced",
+          "label": "Balanced (~25 games, default v0 behavior)"
+        },
+        {
+          "value": "high_coverage",
+          "label": "High coverage (~50 games, include smaller stakes)"
+        }
       ],
       "help_text": "Bundles weight + max_games tuning into one knob so you don't have to tune 9 sliders. Picking anything other than 'manual' overrides the individual weight_* settings and max_games below with the preset's values. Stick with 'manual' if you've hand-tuned weights."
     },
@@ -440,6 +461,18 @@
       "help_text": "Number of season simulations per match for the importance signal. 500 ≈ 0.5s per match on the test EPL season; total refresh cost stays under 30s for a typical 25-match curated list. 1000 doubles compute time but tightens tau-c convergence (Lahvička 2012 used 10000 for academic-grade stability). Drop to 200 if scheduler runs feel sluggish."
     },
     {
+      "id": "_section_naming",
+      "type": "info",
+      "label": "Channel Naming"
+    },
+    {
+      "id": "name_template",
+      "type": "string",
+      "label": "Channel name template",
+      "default": "{league_short} {favorite_star}★{score} · {away_team}{ (rank_away)} at {home_team}{ (rank_home)}{ · tagline}",
+      "help_text": "Sonarr/Radarr-style template for the channel name. Plain text is literal; a {group} holds one variable plus any literal characters glued to it, and the whole group disappears when the variable is blank (so an unranked team or a game with no tagline leaves no stray parens or separators). Variables: {league_short} {league_full} {away_team} {home_team} {rank_away} {rank_home} {rank_pair} {score} {favorite_star} {tagline} {tournament} {venue} {game_date} {start_time} {kickoff} {rivalry}. Use the 'Test naming convention' button to preview before applying. Leave blank for the default shown above."
+    },
+    {
       "id": "_section_apply",
       "type": "info",
       "label": "Apply Behavior",
@@ -527,6 +560,11 @@
       "id": "show_status",
       "label": "Show current state",
       "description": "Print recent cache contents with score breakdown per game. No writes, no API calls."
+    },
+    {
+      "id": "preview_names",
+      "label": "Test naming convention",
+      "description": "Render the channel name template against sample games (no DB writes, no cache needed) so you can check the layout before applying. Reports any template errors and lists every available variable."
     }
   ]
 }

--- a/plugin.py
+++ b/plugin.py
@@ -1729,6 +1729,23 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     group_name = settings.get("channel_profile_name", "Top Matchups")
     dry_run = bool(settings.get("dry_run", True))
 
+    # Channel-name template (issue #100). Empty/unset -> the built-in default.
+    # A malformed custom template must never crash an apply or poison live
+    # channel names: validate, and on any problem fall back to the default and
+    # log loudly (the "test naming convention" action is where users catch this
+    # before it ships).
+    from . import naming
+    name_template = str(settings.get("name_template") or "").strip() or None
+    if name_template is not None:
+        tmpl_errors = naming.validate_template(name_template)
+        if tmpl_errors:
+            logger.warning(
+                "[ranked_matchups] invalid name_template (%s); using default",
+                "; ".join(tmpl_errors),
+            )
+            name_template = None
+    apply_tz = _resolve_tz(settings.get("local_timezone", "UTC"))
+
     # 1. Ensure target ChannelGroup. Also detect any old groups/sources we own
     # (from a previous target_group_name) and clean them up: fixes the case
     # where the user renames "Top Matchups" → "!Top Matchups" between runs.
@@ -2040,14 +2057,21 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 rank_b=g.get("rank_away"),
                 rank_source=rank_source,
             )
-            new_name = format_channel_name(
-                g["sport_prefix"], signals, score, g["home"], g["away"], tagline=tagline,
-            )
-
             start_dt = parse_iso_utc(g.get("start_time_utc"))
             if start_dt is None:
                 logger.warning("[ranked_matchups] bad start_time_utc on %s", marker)
                 continue
+
+            new_name = format_channel_name(
+                g["sport_prefix"], signals, score, g["home"], g["away"],
+                tagline=tagline,
+                template=name_template,
+                rank_source=rank_source,
+                sport_label=g.get("sport_label", ""),
+                venue=g.get("venue"),
+                start_dt=start_dt,
+                tz=apply_tz,
+            )
             prog_start = start_dt - timedelta(minutes=EPG_PRE_MIN)
             prog_end = start_dt + timedelta(hours=EPG_POST_HOURS)
 
@@ -2387,6 +2411,49 @@ def _action_refresh_async(settings: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+# ---------- preview / test naming convention ----------
+
+def _action_preview_names(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Render the current name_template against canned sample games so a user
+    can eyeball the layout before applying it to live channels (issue #100).
+
+    On an empty or invalid template it previews the DEFAULT (clearly labeled)
+    and lists the validation problems, so a broken template is caught here and
+    never reaches the channel list.
+    """
+    from . import naming
+
+    raw = str(settings.get("name_template") or "").strip()
+    tz = _resolve_tz(settings.get("local_timezone", "UTC"))
+
+    using_default = not raw
+    template = raw or naming.DEFAULT_NAME_TEMPLATE
+    errors = naming.validate_template(template)
+    if errors and not using_default:
+        template = naming.DEFAULT_NAME_TEMPLATE
+        using_default = True
+
+    _, rendered = naming.preview_lines(template, tz=tz)
+
+    lines: List[str] = []
+    if errors:
+        lines.append("Template problems (the DEFAULT is previewed below):")
+        lines += [f"  - {e}" for e in errors]
+        lines.append("")
+    lines.append(f"Previewing {'DEFAULT template' if using_default else 'your template'}:")
+    lines.append(f"  {template}")
+    lines.append("")
+    for label, name in rendered:
+        lines.append(f"  {name}")
+        lines.append(f"      ({label})")
+    lines.append("")
+    lines.append("Variables (wrap optional ones in { } so the group vanishes when blank):")
+    for token, desc in naming.TOKENS.items():
+        lines.append(f"  {{{token}}}: {desc}")
+
+    return {"status": "error" if errors else "ok", "message": "\n".join(lines)}
+
+
 # ---------- show status ----------
 
 def _action_show_status(settings: Dict[str, Any]) -> Dict[str, Any]:
@@ -2645,6 +2712,8 @@ class Plugin:
                 return _action_auto_pipeline_async(settings)
             if action == "show_status":
                 return _action_show_status(settings)
+            if action == "preview_names":
+                return _action_preview_names(settings)
             return {"status": "error", "message": f"Unknown action: {action!r}"}
         except Exception as e:
             logger.exception("[ranked_matchups] action %r failed", action)

--- a/scoring.py
+++ b/scoring.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+
+from . import naming
 
 # Trailing club-tag tokens (FC/AFC/etc) and generic second-words (United/City/
 # etc) live in _util so matcher.py can use them without importing scoring.
@@ -1260,6 +1263,84 @@ def strip_team_suffix(name: str) -> str:
     return name
 
 
+# Tournament-stage display labels. Keyed by the UPPER-cased `tournament_stage`
+# value a source attaches. Module-level (not a pick_tagline local) so the
+# {tournament} naming token can render the same prettified stage independently.
+_TOURNAMENT_STAGE_LABELS: Dict[str, str] = {
+    "FINAL": "Final",
+    "SEMI_FINALS": "Semifinal", "SEMI_FINAL": "Semifinal",
+    "QUARTER_FINALS": "Quarterfinal", "QUARTER_FINAL": "Quarterfinal",
+    "ROUND_OF_16": "Round of 16", "LAST_16": "Round of 16",
+    "ROUND_OF_32": "Round of 32", "LAST_32": "Round of 32",
+    "PLAYOFF_ROUND": "Playoff", "PLAYOFFS": "Playoff",
+    "EVENT": "Event",
+    "MAJOR": "Major",
+}
+
+
+def tournament_stage_label(tournament_stage: Optional[str]) -> str:
+    """Prettify a `tournament_stage` value, or "" when there's no clean label."""
+    if not tournament_stage:
+        return ""
+    return _TOURNAMENT_STAGE_LABELS.get(tournament_stage.upper(), "")
+
+
+# Bracket / knockout / championship-event importance bands render as a clean
+# human stage name with NO "race" suffix: you reach the Final Four, you do not
+# "race" to it (issue #98). Standings / season-pace bands (title, relegation,
+# playoff, the win-count milestones, seeding) are deliberately NOT listed here;
+# they keep the "<label> race" framing, which reads correctly for a season-long
+# pursuit. Unlisted labels fall back to underscore->space humanize + " race".
+STAGE_BANDS: Dict[str, str] = {
+    "round_one": "Round 1", "round_2": "Round 2",
+    "last_32": "Round of 32", "round_of_32": "Round of 32",
+    "round_of_16": "Round of 16",
+    "sweet_16": "Sweet 16", "elite_8": "Elite Eight", "final_four": "Final Four",
+    "quarterfinal": "Quarterfinal", "semifinal": "Semifinal", "final": "Final",
+    "championship": "Championship", "winner": "Championship",
+    "finals_winner": "Finals",
+    "college_cup_semis": "College Cup Semis", "college_cup_final": "College Cup Final",
+    "conf_semis": "Conf Semifinals", "conf_finals": "Conf Finals",
+    "conf_final": "Conf Final", "conf_champ": "Conf Championship",
+    "cup_final": "Cup Final", "cup_winner": "Cup Final",
+    "mls_cup_final": "MLS Cup Final", "mls_cup_winner": "MLS Cup Final",
+    "omaha_bound": "Road to Omaha", "okc_bound": "Road to OKC",
+    "super_regional": "Super Regional",
+    "cws_final": "CWS Final", "cws_champion": "CWS Final",
+    "wcws_final": "WCWS Final", "wcws_champion": "WCWS Final",
+    "national_final": "National Final", "national_champ": "National Championship",
+    "super_bowl": "Super Bowl", "sb_winner": "Super Bowl",
+    "world_series": "World Series", "ws_winner": "World Series",
+    "division_series": "Division Series", "divisional": "Divisional Round",
+    "nba_finals": "NBA Finals",
+    "wnba_finals": "WNBA Finals", "wnba_semis": "WNBA Semifinals",
+    "wnba_winner": "WNBA Finals",
+}
+
+
+def render_importance_tagline(importance_thresholds: List[str]) -> str:
+    """Render the importance-band tagline from the (deduped) thresholds hit.
+
+    Bracket/event bands (STAGE_BANDS) render as a clean stage name. Everything
+    else humanizes its snake_case and takes the "race" suffix. The suffix is
+    appended once, only when a non-stage band is present, so a pure-bracket
+    game reads "Final Four" and a standings game reads "title race" (issue #98).
+    """
+    labels = list(dict.fromkeys(importance_thresholds))[:2]
+    if not labels:
+        return ""
+    parts: List[str] = []
+    has_race_band = False
+    for label in labels:
+        if label in STAGE_BANDS:
+            parts.append(STAGE_BANDS[label])
+        else:
+            parts.append(label.replace("_", " "))
+            has_race_band = True
+    joined = " / ".join(parts)
+    return f"{joined} race" if has_race_band else joined
+
+
 def pick_tagline(
     score_breakdown: Dict[str, float],
     favorites_matched: List[str],
@@ -1281,25 +1362,14 @@ def pick_tagline(
     with proper labels (title race, relegation, etc.) so we drop the
     rank-pair tagline for standings.
     """
-    if tournament_stage:
-        ts = tournament_stage.upper()
-        stage_labels = {
-            "FINAL": "Final",
-            "SEMI_FINALS": "Semifinal", "SEMI_FINAL": "Semifinal",
-            "QUARTER_FINALS": "Quarterfinal", "QUARTER_FINAL": "Quarterfinal",
-            "ROUND_OF_16": "Round of 16", "LAST_16": "Round of 16",
-            "ROUND_OF_32": "Round of 32", "LAST_32": "Round of 32",
-            "PLAYOFF_ROUND": "Playoff", "PLAYOFFS": "Playoff",
-            "EVENT": "Event",
-            "MAJOR": "Major",
-        }
-        if ts in stage_labels:
-            return stage_labels[ts]
+    stage = tournament_stage_label(tournament_stage)
+    if stage:
+        return stage
 
     if "importance" in score_breakdown and importance_thresholds:
-        labels = list(dict.fromkeys(importance_thresholds))[:2]
-        if labels:
-            return " / ".join(labels) + " race"
+        imp = render_importance_tagline(importance_thresholds)
+        if imp:
+            return imp
 
     if rank_source == "poll" and rank_a is not None and rank_b is not None:
         lo, hi = sorted([rank_a, rank_b])
@@ -1331,38 +1401,52 @@ def format_channel_name(
     home: str,
     away: str,
     tagline: str = "",
+    *,
+    template: Optional[str] = None,
+    rank_source: str = "poll",
+    sport_label: str = "",
+    venue: Optional[str] = None,
+    start_dt: Optional[datetime] = None,
+    tz=None,
 ) -> str:
-    """Build the Dispatcharr channel name in the "B" format:
+    """Render the Dispatcharr channel name from a (user-customizable) template.
 
-        EPL 3v9 ★10.0 · Brentford at Manchester United · title race
-        CFB 1v5 ★8.5 · Ohio State at Penn State · top-5 showdown
-        EFL 4v6 ⭐ ★10.0 · Middlesbrough at Wrexham · playoff race
+    The default template (naming.DEFAULT_NAME_TEMPLATE) renders, e.g.:
 
-    The rank pair is normalized so the better (lower-number) rank always
-    appears first: "1v5" not "5v1": for at-a-glance scanning.
+        CBB ⭐★8.5 · Alabama (15) at St. John's · top-25 matchup
+        CFB ★9.2 · Ohio State (5) at Penn State (1) · top-5 showdown
+        EPL ★10.0 · Brentford at Man United · title race
 
-    Team-name suffixes (FC / AFC / CF / SC) are stripped: 'Manchester
-    United FC' renders as 'Manchester United'.
+    Poll ranks render inline after each team (issue #99); the old "NvN" head
+    prefix is gone. A custom `template` (issue #100) reshapes this freely; see
+    naming.py for the token catalog and the {optional}-collapse rules.
+
+    `signals.rank_a`/`team_a` are the HOME side and `rank_b`/`team_b` the AWAY
+    side (see _build_signals_score_from_payload); ranks only render when
+    `rank_source == "poll"`. Team-name corporate suffixes (FC / AFC / ...) are
+    stripped here before the names enter the template context.
     """
-    parts = [sport_prefix]
-    a, b = signals.rank_a, signals.rank_b
-    if a is not None and b is not None:
-        lo, hi = (a, b) if a <= b else (b, a)
-        parts.append(f"{lo}v{hi}")
-    elif a is not None or b is not None:
-        rank = a if a is not None else b
-        parts.append(f"{rank}vUR")
-
-    if signals.favorite_match:
-        parts.append("⭐")
-
-    parts.append(f"★{score.final:.1f}")
-    head = " ".join(parts)
-
-    matchup = f"{strip_team_suffix(away)} at {strip_team_suffix(home)}"
-    name = f"{head} · {matchup}"
-    if tagline:
-        name = f"{name} · {tagline}"
+    ctx = naming.build_context(
+        sport_prefix=sport_prefix,
+        sport_label=sport_label,
+        home=strip_team_suffix(home),
+        away=strip_team_suffix(away),
+        rank_home=signals.rank_a,
+        rank_away=signals.rank_b,
+        rank_source=rank_source,
+        score_final=score.final,
+        favorite=bool(signals.favorite_match),
+        tagline=tagline,
+        tournament=tournament_stage_label(getattr(signals, "tournament_stage", None)),
+        venue=venue,
+        is_rivalry=bool(getattr(signals, "is_rivalry", False)),
+        start_dt=start_dt,
+        tz=tz,
+    )
+    name = naming.render_name(template or naming.DEFAULT_NAME_TEMPLATE, ctx)
+    # render_name collapses empty {groups}; this mops up any double space a
+    # sparse CUSTOM template leaves between bare-literal separators.
+    name = re.sub(r"\s{2,}", " ", name).strip()
     if len(name) > 250:
         name = name[:247] + "..."
     return name

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,244 @@
+"""Tests for the channel-name template engine (naming.py, issue #100), the
+inline-rank default (#99), and the tagline prettifier (#98). Pure logic: no
+Django, no network."""
+
+import json
+import os
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from dispatcharr_ranked_matchups import naming
+from dispatcharr_ranked_matchups.scoring import (
+    GameSignals,
+    Weights,
+    STAGE_BANDS,
+    format_channel_name,
+    pick_tagline,
+    render_importance_tagline,
+    score_game,
+    tournament_stage_label,
+)
+
+
+# --------------------------------------------------------------------------- #
+# render_name: the {group}-collapse contract                                   #
+# --------------------------------------------------------------------------- #
+
+class TestRenderName:
+    def test_bare_text_is_literal(self):
+        assert naming.render_name("hi {away_team}", {"away_team": "LSU"}) == "hi LSU"
+
+    def test_group_keeps_literal_decoration_when_present(self):
+        out = naming.render_name("{away_team}{ (rank_away)}", {"away_team": "LSU", "rank_away": "5"})
+        assert out == "LSU (5)"
+
+    def test_group_collapses_whole_when_empty(self):
+        # The parens + leading space live INSIDE the group and must vanish with
+        # the empty token: no orphaned "( )" or trailing space.
+        out = naming.render_name("{away_team}{ (rank_away)}", {"away_team": "LSU", "rank_away": ""})
+        assert out == "LSU"
+
+    def test_multiple_optional_groups_collapse_independently(self):
+        tmpl = "{league_short} {away_team}{ (rank_away)} at {home_team}{ (rank_home)}{ · tagline}"
+        ctx = {"league_short": "NFL", "away_team": "Bills", "home_team": "Chiefs",
+               "rank_away": "", "rank_home": "", "tagline": ""}
+        assert naming.render_name(tmpl, ctx) == "NFL Bills at Chiefs"
+
+    def test_unknown_group_emitted_literally(self):
+        # No known token -> braces stripped, inner kept (validate_template warns).
+        assert naming.render_name("{nope}", {}) == "nope"
+
+    def test_longest_token_wins(self):
+        # rank_home must not lose to a shorter prefix match.
+        out = naming.render_name("{rank_home}", {"rank_home": "7", "rank": "X"})
+        assert out == "7"
+
+
+class TestDefaultTemplateNoDrift:
+    def test_plugin_json_default_matches_code_constant(self):
+        # plugin.json's name_template default is the pre-filled UI value; the
+        # code uses DEFAULT_NAME_TEMPLATE when the field is blank. They must
+        # stay equal so the UI default and the blank-field default never diverge.
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        manifest = json.load(open(os.path.join(repo_root, "plugin.json"), encoding="utf-8"))
+        field = next(f for f in manifest["fields"] if f["id"] == "name_template")
+        assert field["default"] == naming.DEFAULT_NAME_TEMPLATE
+
+
+class TestValidateTemplate:
+    def test_valid_default(self):
+        assert naming.validate_template(naming.DEFAULT_NAME_TEMPLATE) == []
+
+    def test_unbalanced_braces(self):
+        assert "Unbalanced { } braces." in naming.validate_template("{away_team at {home_team}")
+
+    def test_unknown_variable_reported(self):
+        errs = naming.validate_template("{leag_short} {away_team}")
+        assert any("leag_short" in e for e in errs)
+
+
+# --------------------------------------------------------------------------- #
+# build_context: rank_source gate, favorite star, date/time                    #
+# --------------------------------------------------------------------------- #
+
+class TestBuildContext:
+    def test_poll_rank_renders(self):
+        ctx = naming.build_context(rank_home=5, rank_away=12, rank_source="poll")
+        assert ctx["rank_home"] == "5" and ctx["rank_away"] == "12"
+        assert ctx["rank_pair"] == "5v12"
+
+    def test_standings_rank_suppressed(self):
+        # League-table position is not a poll rank: it must NOT render inline.
+        ctx = naming.build_context(rank_home=3, rank_away=9, rank_source="standings")
+        assert ctx["rank_home"] == "" and ctx["rank_away"] == ""
+        assert ctx["rank_pair"] == ""
+
+    def test_rank_pair_blank_unless_both_ranked(self):
+        ctx = naming.build_context(rank_home=5, rank_away=None, rank_source="poll")
+        assert ctx["rank_pair"] == ""
+        assert ctx["rank_home"] == "5" and ctx["rank_away"] == ""
+
+    def test_favorite_star(self):
+        assert naming.build_context(favorite=True)["favorite_star"] == naming._FAVORITE_STAR
+        assert naming.build_context(favorite=False)["favorite_star"] == ""
+
+    def test_score_formatted_one_decimal(self):
+        assert naming.build_context(score_final=8.0)["score"] == "8.0"
+
+    def test_date_time_tokens_use_tz(self):
+        # A fixed UTC kickoff rendered into a +0 tz is deterministic.
+        dt = datetime(2026, 11, 14, 19, 30, tzinfo=timezone.utc)
+        ctx = naming.build_context(start_dt=dt, tz=timezone.utc)
+        assert ctx["game_date"] == "Sat Nov 14"
+        assert ctx["start_time"] == "7:30 PM"
+
+    def test_date_time_blank_without_start_dt(self):
+        ctx = naming.build_context(tz=timezone.utc)
+        assert ctx["game_date"] == "" and ctx["start_time"] == "" and ctx["kickoff"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# preview_lines: the test-button data path                                     #
+# --------------------------------------------------------------------------- #
+
+class TestPreviewLines:
+    def test_default_template_has_no_errors(self):
+        errors, lines = naming.preview_lines(naming.DEFAULT_NAME_TEMPLATE)
+        assert errors == []
+        assert len(lines) == len(naming._PREVIEW_SAMPLES)
+
+    def test_default_renders_expected_samples(self):
+        _, lines = naming.preview_lines(naming.DEFAULT_NAME_TEMPLATE)
+        rendered = {label: name for label, name in lines}
+        assert rendered["Ranked vs unranked, favorite, college"] == (
+            "CBB ⭐★8.5 · Alabama (15) at St. John's · top-25 matchup"
+        )
+        assert rendered["Both ranked, college football"] == (
+            "CFB ★9.2 · Ohio State (5) at Penn State (1) · top-5 showdown"
+        )
+        # standings game: ranks suppressed, no inline parens
+        assert rendered["Standings race, soccer (ranks suppressed)"] == (
+            "EPL ★10.0 · Brentford at Manchester United · title race"
+        )
+        # pro game: every optional group collapses, no stray separators
+        assert rendered["Pro game, no ranks / no tagline / no favorite"] == (
+            "NFL ★7.2 · Buffalo Bills at Kansas City Chiefs"
+        )
+
+    def test_invalid_template_surfaces_errors(self):
+        errors, _ = naming.preview_lines("{bogus} {away_team}")
+        assert errors and any("bogus" in e for e in errors)
+
+
+# --------------------------------------------------------------------------- #
+# format_channel_name: default + custom template + truncation                  #
+# --------------------------------------------------------------------------- #
+
+class TestFormatChannelNameTemplate:
+    def test_custom_template_reshapes_name(self):
+        sig = GameSignals(rank_a=1, rank_b=5)
+        score = score_game(sig, Weights())
+        name = format_channel_name(
+            "CFB", sig, score, "Penn State", "Ohio State",
+            tagline="top-5 showdown",
+            template="{away_team} v {home_team}{ - tagline}",
+        )
+        assert name == "Ohio State v Penn State - top-5 showdown"
+
+    def test_custom_template_with_date(self):
+        sig = GameSignals(rank_a=None, rank_b=None)
+        score = score_game(sig, Weights())
+        dt = datetime(2026, 11, 14, 19, 0, tzinfo=timezone.utc)
+        name = format_channel_name(
+            "NFL", sig, score, "Chiefs", "Bills",
+            template="{game_date} {start_time} · {away_team} at {home_team}",
+            start_dt=dt, tz=timezone.utc,
+        )
+        assert name == "Sat Nov 14 7:00 PM · Bills at Chiefs"
+
+    def test_standings_source_suppresses_inline_rank(self):
+        sig = GameSignals(rank_a=3, rank_b=9)
+        score = score_game(sig, Weights())
+        name = format_channel_name(
+            "EPL", sig, score, "Manchester United", "Brentford", rank_source="standings",
+        )
+        assert "(3)" not in name and "(9)" not in name
+
+    def test_truncates_to_250(self):
+        sig = GameSignals(rank_a=1, rank_b=2)
+        score = score_game(sig, Weights())
+        name = format_channel_name("CFB", sig, score, "A" * 200, "B" * 200, tagline="x" * 200)
+        assert len(name) <= 250 and name.endswith("...")
+
+    def test_invalid_template_param_does_not_crash_here(self):
+        # format_channel_name renders whatever template it's given; the apply
+        # path validates+falls back. A no-token group degrades gracefully.
+        sig = GameSignals(rank_a=None, rank_b=None)
+        score = score_game(sig, Weights())
+        name = format_channel_name("NFL", sig, score, "Chiefs", "Bills", template="{nope} {away_team}")
+        assert "Bills" in name
+
+
+# --------------------------------------------------------------------------- #
+# Tagline prettifier (#98)                                                     #
+# --------------------------------------------------------------------------- #
+
+class TestTaglinePrettify:
+    def test_bracket_band_is_clean_no_race(self):
+        assert render_importance_tagline(["omaha_bound"]) == "Road to Omaha"
+        assert render_importance_tagline(["round_of_32"]) == "Round of 32"
+        assert render_importance_tagline(["elite_8"]) == "Elite Eight"
+        assert render_importance_tagline(["super_bowl"]) == "Super Bowl"
+
+    def test_no_raw_snake_case_leaks(self):
+        for label in STAGE_BANDS:
+            out = render_importance_tagline([label])
+            assert "_" not in out
+            assert not out.endswith(" race")
+
+    def test_standings_band_keeps_race_and_humanizes(self):
+        assert render_importance_tagline(["title"]) == "title race"
+        assert render_importance_tagline(["relegation"]) == "relegation race"
+        # snake_case standings label gets de-underscored but keeps "race"
+        assert render_importance_tagline(["playoff_bubble"]) == "playoff bubble race"
+
+    def test_empty_thresholds(self):
+        assert render_importance_tagline([]) == ""
+
+    def test_pick_tagline_routes_bracket_band_clean(self):
+        tag = pick_tagline(
+            score_breakdown={"importance": 5.0},
+            favorites_matched=[],
+            spread=None,
+            importance_thresholds=["omaha_bound"],
+            tournament_stage=None,
+            rank_a=None, rank_b=None,
+        )
+        assert tag == "Road to Omaha"
+
+    def test_tournament_stage_label(self):
+        assert tournament_stage_label("ROUND_OF_16") == "Round of 16"
+        assert tournament_stage_label("last_16") == "Round of 16"
+        assert tournament_stage_label(None) == ""
+        assert tournament_stage_label("NONSENSE") == ""

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1916,3 +1916,28 @@ class TestDedupSeriesGames:
         assert len(out_g) == 1
         # The one with a real start_time wins.
         assert out_g[0].start_time is not None
+
+
+class TestActionPreviewNames:
+    """The 'Test naming convention' action (#100) renders sample games against
+    the configured template so a user can eyeball the layout before applying.
+    Django-free: it only touches settings, naming.py, and the tz resolver."""
+
+    def test_default_template_previews_ok(self, plugin):
+        r = plugin._action_preview_names({"local_timezone": "UTC"})
+        assert r["status"] == "ok"
+        assert "DEFAULT template" in r["message"]
+        assert "Alabama (15) at St. John's" in r["message"]
+
+    def test_custom_template_is_used(self, plugin):
+        r = plugin._action_preview_names({"name_template": "{away_team} at {home_team}"})
+        assert r["status"] == "ok"
+        assert "your template" in r["message"]
+        assert "Alabama at St. John's" in r["message"]
+
+    def test_invalid_template_errors_and_falls_back_to_default(self, plugin):
+        r = plugin._action_preview_names({"name_template": "{bogus} {away_team}"})
+        assert r["status"] == "error"
+        assert "bogus" in r["message"]
+        # the DEFAULT is still previewed so the user sees working output
+        assert "Alabama (15) at St. John's" in r["message"]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -217,12 +217,17 @@ class TestScoreGameCloseness:
 
 
 class TestFormatChannelName:
-    def test_rank_pair_normalized_low_first(self):
-        sig = GameSignals(rank_a=9, rank_b=3)
+    def test_inline_ranks_attach_to_each_team(self):
+        # New default (#99): ranks render inline after the team they belong to,
+        # not as a compact "NvN" prefix. rank_a/team_a is HOME, rank_b/team_b
+        # is AWAY, and the matchup renders "away at home".
+        sig = GameSignals(rank_a=9, rank_b=3)  # home rank 9, away rank 3
         score = score_game(GameSignals(rank_a=9, rank_b=3), Weights())
-        name = format_channel_name("EPL", sig, score, "Manchester United", "Brentford FC")
-        # Should render "3v9" not "9v3"
-        assert " 3v9 " in name
+        name = format_channel_name("CFB", sig, score, "Penn State", "Ohio State")
+        assert "Ohio State (3) at Penn State (9)" in name
+        # the retired "NvN" prefix must be gone
+        assert "3v9" not in name
+        assert "9v3" not in name
 
     def test_truncates_to_250(self):
         sig = GameSignals(rank_a=1, rank_b=2)
@@ -238,7 +243,8 @@ class TestFormatChannelName:
         name = format_channel_name("EPL", sig, score, "Manchester United FC", "Brentford FC")
         # "FC" must NOT appear in the rendered matchup
         assert "FC" not in name
-        assert "Brentford at Manchester United" in name
+        # away (Brentford, rank_b=9) at home (Man United, rank_a=3), suffixes gone
+        assert "Brentford (9) at Manchester United (3)" in name
 
     def test_b_format_separator(self):
         sig = GameSignals(rank_a=3, rank_b=9)
@@ -259,10 +265,14 @@ class TestFormatChannelName:
         assert "⭐" in name
 
     def test_one_ranked(self):
-        sig = GameSignals(rank_a=5, rank_b=None)
+        # Only the ranked team gets an inline rank; the unranked opponent stays
+        # bare (no "vUR" marker, no empty parens) thanks to the {group} collapse.
+        sig = GameSignals(rank_a=5, rank_b=None)  # home Texas ranked, away Oklahoma not
         score = score_game(sig, Weights())
         name = format_channel_name("CFB", sig, score, "Texas", "Oklahoma")
-        assert "5vUR" in name
+        assert "Oklahoma at Texas (5)" in name
+        assert "vUR" not in name
+        assert "()" not in name
 
 
 class TestStripTeamSuffix:


### PR DESCRIPTION
Builds the three channel-name issues as one coherent change to the naming layer. #100 is the umbrella; #98 and #99 fold in as the `{tagline}`/`{tournament}` and `{rank_*}` facets.

## What changed

**#100 — customizable template (new `naming.py`)**
Sonarr/Radarr-style `{group}` convention: plain text is literal; a `{group}` holds one variable plus any glued literal characters, and the whole group collapses when the variable is blank (so an unranked team or a tagline-less game leaves no orphaned parens/separators). New `name_template` setting under a "Channel Naming" section, and a **"Test naming convention"** action (`preview_names`) that renders sample games with no DB writes, reports template errors, and lists every variable. Invalid templates fall back to the default and log, so a bad template never poisons live channel names.

**#99 — inline ranks**
Default now renders poll ranks inline after each team (`Ohio State (5) at Penn State (1)`), dropping the `NvN` prefix that couldn't say which team held which rank. Gated on `rank_source == "poll"`, so standings leagues (and rankless pro leagues) are unaffected.

**#98 — humanized taglines**
Bracket/event bands prettify to clean stage names with the wrong "race" suffix dropped (`omaha_bound` → "Road to Omaha", `round_of_32` → "Round of 32", `super_bowl` → "Super Bowl"). Season-long standings bands keep their "race" framing (title race, relegation race).

`format_channel_name` delegates to `naming.render_name`; tournament-stage labels were extracted to a module-level map reused by the `{tournament}` token.

## Design decisions (confirmed with @Jacob-Lasky)
- Engine: Sonarr/Radarr `{group}`-collapse convention (familiar to the self-hosted audience).
- Default: inline ranks, drop the `NvN` prefix.
- Taglines: clean stage names, no "race" for bracket/event bands.

## Tests
- New `tests/test_naming.py`: engine (collapse, validation, build_context rank-source gate, date/time, preview), #98 prettifier (incl. a `test_no_raw_snake_case_leaks` guard that fails on pre-change code), #99 inline ranks, custom templates, truncation, and a drift guard pinning `plugin.json`'s default to `naming.DEFAULT_NAME_TEMPLATE`.
- `TestActionPreviewNames` in `tests/test_plugin_helpers.py`: the new action incl. invalid-template fallback.
- Updated the 3 `format_channel_name` contract tests in `tests/test_scoring.py` to the new inline-rank shape.
- Full Django-free suite green (the only failures in a no-Django runner are pre-existing ORM-helper tests that also fail on `main`).

## Verification
Rendered output (the user-visible artifact), via the `preview_names` action on the default template:
```
CBB ⭐★8.5 · Alabama (15) at St. John's · top-25 matchup
CFB ★9.2 · Ohio State (5) at Penn State (1) · top-5 showdown
EPL ★10.0 · Brentford at Manchester United · title race   (standings: ranks suppressed)
NFL ★7.2 · Buffalo Bills at Kansas City Chiefs            (all optional groups collapse)
CWS ★9.0 · LSU at Tennessee · Road to Omaha
```
The pure logic is exhaustively unit-tested and the action handler is exercised end-to-end. Final in-Dispatcharr confirmation (loading the plugin, clicking **Test naming convention**, applying) is left to you, since I won't reach into the live instance.

Closes #98
Closes #99
Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)