### PR TITLE
Fall back to league/tournament badge before the channel logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
   "Elite Eight", and so on, with the incorrect "race" suffix dropped for
   bracket and championship-event bands. Season-long standings bands keep their
   "race" framing (title race, relegation race).
+- **Logo fallback now prefers a league/tournament badge** over the provider
+  channel logo (#102). When no team-vs-team matchup thumbnail exists, the
+  channel gets the league's badge from TheSportsDB (tournament badge first when
+  a competition id is mapped, then the sport/league badge), keyed by
+  `sport_prefix` and cached once per league. The source-channel logo is now the
+  last resort. Unmapped sports still fall back to the channel logo.
 
 ## [1.0.0] — 2026-05-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ downstream is sport-agnostic.
 | `sources/nba.py` | ESPN unofficial API (stats.nba.com is WAF-blocked from most homelab egress). `NbaRegularSource` uses raw win count. `NbaPlayoffSource` is a BestOfNSeriesSource with uniform SERIES_LENGTH=7 (R1 / CSF / CF / FINALS). Stage routing comes from parsing the ESPN headline ("East 1st Round - Game 3" etc.) — the only place ESPN exposes the playoff round. All-Star Tournament games (which ESPN tags `season.type=2` but `competition.type.abbreviation=ALLSTAR`) are filtered out so the regular-season team list stays at 30. |
 | `sources/mls.py` | ESPN unofficial API for the schedule + The Odds API (`soccer_usa_mls`) for closeness. Intentionally thin: `MlsSource` does NOT inherit `PointsBasedSportSource` and `supports_importance=False`. MLS surfaces with favorite + closeness signals only; standings-based importance and the mixed-format MLS Cup bracket (best-of-3 R1 + single-leg subsequent rounds) are tracked in #30. Team-name fuzzy matching reuses `_util.TEAM_SUFFIX_TOKENS` — never add "united" to that list (it's a substantive body word for Atlanta United / D.C. United / Minnesota United). |
 | `sources/soccer.py` | Football-Data.org for fixtures+standings, The Odds API for spreads. League position used as rank. `SoccerSource` is league-shaped (PL, ELC); `KnockoutSoccerSource` is bracket-shaped (UCL) — multi-inherits from `AggregateLegSource` (bracket state machine) + `SoccerSource` (FD.org fetch / strengths) with the MRO `K → AggregateLegSource → BracketSportSource → SoccerSource → SportSource`. Routed by `LEAGUE_CONTEXTS[fd_code].format`. |
-| `logos.py` | TheSportsDB matchup-thumbnail resolver. Looks up the curated game via `searchevents.php` (team-name pair, date-tolerance ±2 days, sport-hint disambiguation), downloads the 960x540 graphic to `/data/logos/ranked_matchups_<sha1>.jpg`, and registers a `Logo` row pointing at it. Persistent per-marker cache (`sportsdb_thumb_cache.json`, 14d positive TTL / 1d negative TTL) means apply only HTTP-probes each fixture once. Field-event sources (`away=="Field"`) and dry_run short-circuit the lookup. Stale-file sweep at the end of each apply prunes JPGs whose marker isn't in the live set. |
+| `logos.py` | TheSportsDB matchup-thumbnail resolver. Looks up the curated game via `searchevents.php` (team-name pair, date-tolerance ±2 days, sport-hint disambiguation), downloads the 960x540 graphic to `/data/logos/ranked_matchups_<sha1>.jpg`, and registers a `Logo` row pointing at it. Persistent per-marker cache (`sportsdb_thumb_cache.json`, 14d positive TTL / 1d negative TTL) means apply only HTTP-probes each fixture once. Field-event sources (`away=="Field"`) and dry_run short-circuit the lookup. Stale-file sweep at the end of each apply prunes JPGs whose marker isn't in the live set. Also resolves the league/tournament BADGE fallback (#102): `SPORTSDB_LEAGUE_IDS` (`sport_prefix` -> verified league id), `league_id_for`, `resolve_league_badge_url` (`lookupleague.php` -> `strBadge`), cached as `ranked_matchups_badge_<id>.png` (distinct prefix the sweep skips). |
 
 State (gitignored, lives in `<plugin_dir>/`):
 - `cache.json` — last refresh result (curated game list with score breakdowns)
@@ -242,8 +242,10 @@ docker logs --since 5m dispatcharr 2>&1 | grep ranked_matchups | tail -30
 - Per-matchup channel logos from TheSportsDB (`logos.py`): each virtual
   channel gets a pre-rendered 960x540 graphic showing both team crests +
   league badge, replacing the inherited source-channel logo. Free public
-  test tier (`api_key="3"`) is the default; falls back to source-channel
-  logo for offseason / untracked-league / field-event fixtures.
+  test tier (`api_key="3"`) is the default. Fallback order (#102): matchup
+  thumbnail -> league/tournament badge (`SPORTSDB_LEAGUE_IDS`, cached once
+  per league) -> source-channel logo (last resort). So an offseason /
+  no-thumbnail / untracked fixture shows the sport badge, not the provider logo.
 
 **Known limitations & open work:** tracked as GitHub issues so they don't
 drift. Quick map (most user-facing first):

--- a/logos.py
+++ b/logos.py
@@ -94,6 +94,43 @@ _SPORT_HINT: dict[str, str] = {
     "BSA": "Brazilian",
 }
 
+# Plugin sport_prefix -> TheSportsDB league id, used to fetch a league/sport
+# BADGE as the per-game logo fallback when no team-vs-team matchup thumbnail
+# exists (issue #102). A provider channel's own logo ("ESPN") is the least
+# useful image for a curated matchup, so we prefer the league badge first.
+#
+# Every id below was verified against lookupleague.php at build time (the
+# endpoint returns strBadge). Cup prefixes (UCL/WC/EURO) map to the competition
+# itself, so their badge IS the tournament badge. Prefixes deliberately left
+# unmapped (e.g. niche NCAA sub-sports whose SportsDB league could not be
+# confirmed) fall through to the source-channel logo rather than risk showing
+# a wrong-sport badge.
+SPORTSDB_LEAGUE_IDS: dict[str, int] = {
+    "CFB": 4479,            # NCAA Division 1 (American Football)
+    "CBB": 4607,            # NCAA Division I Basketball Mens
+    "NFL": 4391, "NHL": 4380, "MLB": 4424, "NBA": 4387, "WNBA": 4516,
+    "MLS": 4346, "NWSL": 4521, "LigaMX": 4350,
+    "EPL": 4328, "EFL": 4329, "UCL": 4480, "BL1": 4331,
+    "LaLiga": 4335, "SerieA": 4332, "Ligue1": 4334,
+    "WC": 4429, "EURO": 4502,
+    "Eredivisie": 4337, "PrimeiraLiga": 4344, "BSA": 4351,
+}
+
+# Optional tournament-specific override, consulted FIRST when a game carries a
+# `tournament_stage`, so a league source's postseason can show the competition
+# badge rather than the regular-season league badge (the "tournament -> sport
+# -> channel" order chosen for #102). Empty by default: cup SOURCES already map
+# their tournament badge directly via SPORTSDB_LEAGUE_IDS, so this only matters
+# for a league source that also runs a distinct postseason with its own
+# SportsDB league id. Add entries as those ids are confirmed.
+SPORTSDB_TOURNAMENT_LEAGUE_IDS: dict[str, int] = {}
+
+_LEAGUE_URL = "https://www.thesportsdb.com/api/v1/json/{key}/lookupleague.php?id={id}"
+
+# League badges are shared across all of a league's games (a small, finite set),
+# so they use a distinct filename prefix that the per-game marker sweep skips.
+BADGE_FILENAME_PREFIX = LOGO_FILENAME_PREFIX + "badge_"
+
 
 def _strip_trailing_qualifier(name: str) -> str:
     """Strip trailing FC/AFC/CF/SC/FK/AC qualifiers iteratively.
@@ -124,6 +161,45 @@ def marker_to_filename(marker: str) -> str:
     """
     digest = hashlib.sha1(marker.encode("utf-8")).hexdigest()[:16]
     return f"{LOGO_FILENAME_PREFIX}{digest}.jpg"
+
+
+def badge_filename(league_id: int) -> str:
+    """Stable filename for a cached league badge. Uses BADGE_FILENAME_PREFIX so
+    the per-game marker sweep leaves it alone (badges are shared, not per-game)."""
+    return f"{BADGE_FILENAME_PREFIX}{int(league_id)}.png"
+
+
+def league_id_for(
+    sport_prefix: Optional[str], tournament_stage: Optional[str] = None,
+) -> Optional[int]:
+    """Pick the SportsDB league id for a game's fallback badge.
+
+    Tournament override first (when the game is in a tournament AND a distinct
+    competition id is mapped), then the sport's league id, else None (the caller
+    falls back to the source-channel logo). Implements the #102 order
+    tournament -> sport -> channel.
+    """
+    if not sport_prefix:
+        return None
+    if tournament_stage and sport_prefix in SPORTSDB_TOURNAMENT_LEAGUE_IDS:
+        return SPORTSDB_TOURNAMENT_LEAGUE_IDS[sport_prefix]
+    return SPORTSDB_LEAGUE_IDS.get(sport_prefix)
+
+
+def resolve_league_badge_url(league_id: int, api_key: str = "3") -> Optional[str]:
+    """Return a league's badge image URL via SportsDB lookupleague.php, or None.
+
+    `api_key`: "3" is SportsDB's free test tier (same as resolve_thumb_url)."""
+    url = _LEAGUE_URL.format(
+        key=urllib.parse.quote(api_key or "3"), id=int(league_id),
+    )
+    payload = _http_get_json(url)
+    if not payload:
+        return None
+    leagues = payload.get("leagues") or []
+    if not leagues:
+        return None
+    return leagues[0].get("strBadge") or None
 
 
 def _date_in_tolerance(event_date_str: str, expected_dt: datetime) -> bool:
@@ -329,6 +405,10 @@ def sweep_stale_logo_files(live_markers: set[str], logo_dir: str = LOGO_DIR) -> 
         return 0
     for name in entries:
         if not name.startswith(LOGO_FILENAME_PREFIX):
+            continue
+        # League badges (BADGE_FILENAME_PREFIX) are shared across games, not
+        # keyed by a live marker; never sweep them here.
+        if name.startswith(BADGE_FILENAME_PREFIX):
             continue
         if name in live_filenames:
             continue

--- a/plugin.py
+++ b/plugin.py
@@ -1933,6 +1933,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     sportsdb_api_key = SPORTSDB_DEFAULT_KEY
     thumb_cache: Optional[matchup_logos.ThumbCache] = None
     matchup_logos_used = 0
+    matchup_logos_badge = 0
     matchup_logos_fallback = 0
     if matchup_logos_enabled and not dry_run:
         sportsdb_api_key = (
@@ -1941,26 +1942,69 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         )
         thumb_cache = matchup_logos.ThumbCache(SPORTSDB_THUMB_CACHE_PATH)
 
+    def _resolve_league_badge_id(game: Dict[str, Any]) -> Optional[int]:
+        """Resolve a cached league/tournament badge Logo id for this game, or
+        None when the sport_prefix is unmapped or the badge can't be fetched.
+
+        Badges are shared per league: one file per league id, reused across all
+        that league's games, and skipped by the per-game sweep. The local file
+        IS the cache (no badge re-fetch once downloaded). Only reached on the
+        matchup-thumb miss path, which already requires logos-enabled + not
+        dry_run, so the HTTP here is appropriately gated.
+        """
+        league_id = matchup_logos.league_id_for(
+            game.get("sport_prefix"), game.get("tournament_stage"),
+        )
+        if league_id is None:
+            return None
+        badge_path = os.path.join(
+            matchup_logos.LOGO_DIR, matchup_logos.badge_filename(league_id),
+        )
+        if not os.path.exists(badge_path):
+            badge_url = matchup_logos.resolve_league_badge_url(league_id, sportsdb_api_key)
+            if not badge_url:
+                return None
+            try:
+                os.makedirs(matchup_logos.LOGO_DIR, exist_ok=True)
+            except OSError as e:
+                logger.warning("[ranked_matchups] cannot mkdir %s: %s", matchup_logos.LOGO_DIR, e)
+                return None
+            if not matchup_logos.download_thumb(badge_url, badge_path):
+                return None
+        from apps.channels.models import Logo
+        logo_obj, _ = Logo.objects.get_or_create(
+            url=badge_path,
+            defaults={"name": f"League badge: {game.get('sport_prefix','?')}"},
+        )
+        return logo_obj.id
+
     def _resolve_matchup_logo_id(
         game: Dict[str, Any], marker: str, source,
-    ) -> Tuple[Optional[int], bool]:
-        """Returns (logo_id, hit_via_sportsdb).
+    ) -> Tuple[Optional[int], str]:
+        """Returns (logo_id, outcome) where outcome is one of "matchup", "badge",
+        or "channel" so the caller can tally each per apply.
 
-        Tries SportsDB lookup → local download → Logo.get_or_create. Falls back
-        to source.logo_id (current v0 behavior) on any miss; the bool tells the
-        caller which path was taken so it can update the per-apply counters
-        without recomputing the fallback id. Dry_run and feature-disabled
-        paths short-circuit to the fallback before any HTTP.
+        Resolution order (issue #102): team-vs-team matchup thumbnail → league /
+        tournament badge → source-channel logo. The provider channel logo is the
+        last resort, not the first fallback. Dry_run and feature-disabled paths
+        short-circuit to the channel logo before any HTTP.
         """
-        fallback_id = source.logo_id if source else None
+        channel_logo = source.logo_id if source else None
         if not matchup_logos_enabled or dry_run or thumb_cache is None:
-            return fallback_id, False
+            return channel_logo, "channel"
+
+        def _badge_or_channel() -> Tuple[Optional[int], str]:
+            badge_id = _resolve_league_badge_id(game)
+            if badge_id is not None:
+                return badge_id, "badge"
+            return channel_logo, "channel"
+
         fresh, cached_url = thumb_cache.get(marker)
         thumb_url = cached_url
         if not fresh:
             start_dt = parse_iso_utc(game.get("start_time_utc"))
             if start_dt is None:
-                return fallback_id, False
+                return _badge_or_channel()
             thumb_url = matchup_logos.resolve_thumb_url(
                 home=game.get("home", ""),
                 away=game.get("away", ""),
@@ -1970,26 +2014,26 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             )
             thumb_cache.put(marker, thumb_url)
         if not thumb_url:
-            return fallback_id, False
+            return _badge_or_channel()
         # Ensure /data/logos/ exists (Dispatcharr creates it lazily on first
         # upload via the UI; we might race a fresh install).
         try:
             os.makedirs(matchup_logos.LOGO_DIR, exist_ok=True)
         except OSError as e:
             logger.warning("[ranked_matchups] cannot mkdir %s: %s", matchup_logos.LOGO_DIR, e)
-            return fallback_id, False
+            return _badge_or_channel()
         local_path = os.path.join(
             matchup_logos.LOGO_DIR, matchup_logos.marker_to_filename(marker),
         )
         if not os.path.exists(local_path):
             if not matchup_logos.download_thumb(thumb_url, local_path):
-                return fallback_id, False
+                return _badge_or_channel()
         from apps.channels.models import Logo
         logo_obj, _ = Logo.objects.get_or_create(
             url=local_path,
             defaults={"name": f"Top Matchup: {game.get('home','?')} vs {game.get('away','?')}"},
         )
-        return logo_obj.id, True
+        return logo_obj.id, "matchup"
 
     with transaction.atomic():
         # Phase 0: park existing virtual channels in a high temporary number
@@ -2123,10 +2167,12 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             source_streams = [sid for _, _, sid in stream_pool]
             existing = existing_virtuals.get(marker)
 
-            resolved_logo_id, used_sportsdb = _resolve_matchup_logo_id(g, marker, source)
+            resolved_logo_id, logo_outcome = _resolve_matchup_logo_id(g, marker, source)
             if matchup_logos_enabled and not dry_run:
-                if used_sportsdb:
+                if logo_outcome == "matchup":
                     matchup_logos_used += 1
+                elif logo_outcome == "badge":
+                    matchup_logos_badge += 1
                 else:
                     matchup_logos_fallback += 1
 
@@ -2330,7 +2376,8 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     logo_msg = ""
     if matchup_logos_enabled and not dry_run:
         logo_msg = (
-            f" Matchup logos: {matchup_logos_used} resolved via SportsDB, "
+            f" Matchup logos: {matchup_logos_used} matchup thumbnails, "
+            f"{matchup_logos_badge} league/tournament badges, "
             f"{matchup_logos_fallback} fell back to source-channel logo, "
             f"{stale_logo_files_swept} stale file(s) swept."
         )

--- a/tests/test_logos.py
+++ b/tests/test_logos.py
@@ -409,3 +409,75 @@ class TestDownloadThumb:
 
     def test_empty_url_returns_false(self, tmp_path):
         assert logos.download_thumb("", str(tmp_path / "out.jpg")) is False
+
+
+# ---------- league/tournament badge fallback (issue #102) ----------
+
+class TestLeagueIdFor:
+    def test_sport_league_id(self):
+        assert logos.league_id_for("EPL") == 4328
+        assert logos.league_id_for("CFB") == 4479      # NCAA football, NOT basketball
+        assert logos.league_id_for("CBB") == 4607      # NCAA men's basketball
+
+    def test_unmapped_prefix_is_none(self):
+        # Niche NCAA sub-sports are intentionally unmapped -> channel-logo fallback.
+        assert logos.league_id_for("NCAAWS") is None
+        assert logos.league_id_for("MADEUP") is None
+        assert logos.league_id_for(None) is None
+
+    def test_tournament_override_when_stage_set(self, monkeypatch):
+        monkeypatch.setitem(logos.SPORTSDB_TOURNAMENT_LEAGUE_IDS, "CBB", 9999)
+        # tournament_stage set + prefix in override -> tournament id wins
+        assert logos.league_id_for("CBB", "FINAL") == 9999
+        # no tournament_stage -> falls back to the sport league id
+        assert logos.league_id_for("CBB", None) == 4607
+
+    def test_every_mapped_id_is_int_and_known_prefix(self):
+        for prefix, lid in logos.SPORTSDB_LEAGUE_IDS.items():
+            assert isinstance(lid, int)
+            # every badge-mapped prefix is a real sport hint prefix
+            assert prefix in logos._SPORT_HINT
+
+
+class TestBadgeFilename:
+    def test_format_and_prefix(self):
+        fn = logos.badge_filename(4328)
+        assert fn == "ranked_matchups_badge_4328.png"
+        assert fn.startswith(logos.BADGE_FILENAME_PREFIX)
+
+    def test_distinct_from_per_game_filename(self):
+        # A badge file must never collide with a per-game marker file.
+        assert logos.badge_filename(4328) != logos.marker_to_filename("ranked_matchups:EPL:x")
+
+
+class TestResolveLeagueBadgeUrl:
+    def test_returns_badge_url(self, monkeypatch):
+        payload = {"leagues": [{"strLeague": "English Premier League",
+                                "strBadge": "https://example.test/epl.png"}]}
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen(payload))
+        assert logos.resolve_league_badge_url(4328, "3") == "https://example.test/epl.png"
+
+    def test_no_leagues_returns_none(self, monkeypatch):
+        monkeypatch.setattr(logos.urllib.request, "urlopen", _fake_urlopen({"leagues": None}))
+        assert logos.resolve_league_badge_url(4328, "3") is None
+
+    def test_missing_badge_field_returns_none(self, monkeypatch):
+        monkeypatch.setattr(logos.urllib.request, "urlopen",
+                            _fake_urlopen({"leagues": [{"strLeague": "X"}]}))
+        assert logos.resolve_league_badge_url(4328, "3") is None
+
+
+class TestSweepKeepsBadges:
+    def test_badge_file_survives_marker_sweep(self, tmp_path):
+        live_marker = "ranked_matchups:EPL:live"
+        # one live per-game file, one stale per-game file, one badge file
+        live_file = tmp_path / logos.marker_to_filename(live_marker)
+        stale_file = tmp_path / logos.marker_to_filename("ranked_matchups:EPL:stale")
+        badge_file = tmp_path / logos.badge_filename(4328)
+        for f in (live_file, stale_file, badge_file):
+            f.write_bytes(b"x")
+        removed = logos.sweep_stale_logo_files({live_marker}, logo_dir=str(tmp_path))
+        assert removed == 1               # only the stale per-game file
+        assert live_file.exists()
+        assert badge_file.exists()        # badge is never swept
+        assert not stale_file.exists()


### PR DESCRIPTION
Closes #102.

When no team-vs-team matchup thumbnail can be found, the virtual channel previously inherited the provider channel's logo ("ESPN") — the least useful image for a curated matchup. Now it falls back to the league/tournament **badge** first.

## Resolution order (new)
`matchup thumbnail -> league/tournament badge -> source-channel logo (last resort)`

## How
- `SPORTSDB_LEAGUE_IDS`: `sport_prefix -> TheSportsDB league id`. **Every id was verified against the live `lookupleague.php` endpoint** (which returns `strBadge`) during the build. Cup prefixes (UCL/WC/EURO) map to the competition itself, so their badge already IS the tournament badge.
- `league_id_for(prefix, tournament_stage)`: tournament override first (via `SPORTSDB_TOURNAMENT_LEAGUE_IDS`, currently empty — the documented seam for a league source's distinct postseason), then the sport league id, else `None`.
- `resolve_league_badge_url` reuses the existing `_http_get_json`; the badge is downloaded with the existing `download_thumb` and cached as `ranked_matchups_badge_<id>.png` — **one file per league, shared across all its games**, with a distinct filename prefix the per-game marker sweep skips.
- Unmapped sports (e.g. niche NCAA sub-sports whose SportsDB league couldn't be confirmed on the free key) fall through to the channel logo rather than risk a wrong-sport badge. Notably CFB maps to NCAA *football* (4479), not the NCAA *basketball* league a naive name-match would pick.
- The apply summary now reports matchup vs badge vs channel-logo counts.

## Design decisions (confirmed with @Jacob-Lasky)
- Icon source: TheSportsDB league badges (reuses existing API + cache infra).
- Order: tournament -> sport -> channel.

## Tests
New tests in `tests/test_logos.py`: `league_id_for` (sport / unmapped / tournament-override / map-integrity incl. a guard that CFB is football not basketball), `badge_filename`, `resolve_league_badge_url` (mocked, 3 cases), and a sweep test proving badge files survive the per-game marker sweep. Full suite: 3104 passed (the only failures in a Django-less runner are pre-existing ORM-helper tests that also fail on `main`).

## Live verification
`lookupleague.php` returns a real `strBadge` URL for every mapped id (e.g. EPL 4328 -> `https://r2.thesportsdb.com/images/media/league/badge/gasy9d1`, CFB 4479 = "NCAA Division 1" [American Football]). Whether Dispatcharr renders the badge on the channel is in-Dispatcharr, for you to confirm after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)