### PR TITLE
Run matchups pipeline in a subprocess to unfreeze gevent workers (0.26.0)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/_pipeline_runner.py
+++ b/_pipeline_runner.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""Subprocess entry point for ranked_matchups heavy pipeline actions.
+
+DO NOT run the pipeline (refresh / apply / auto_pipeline) inline in the uwsgi
+worker. Dispatcharr 0.26.0 runs uwsgi under gevent (gevent-early-monkey-patch).
+The scoring step (simulation.py) is a pure-Python Monte Carlo that holds the
+GIL for its entire run, so executing it in the worker -- even in a daemon
+thread -- freezes every greenlet on that worker: login and live streams hang
+until the scoring finishes. A gevent threadpool does NOT help (pure-Python
+never yields the GIL), and a Celery @shared_task is rejected as "unregistered
+task" on this build (see tasks.py header). So tasks.run_pipeline_subprocess
+forks THIS script: a fresh interpreter that never imports the gevent
+monkey-patch and runs the scoring at full speed in its own GIL, fully isolated
+from the worker that serves requests.
+
+Protocol:
+    python _pipeline_runner.py   < {"action": "<name>", "settings": {...}}  on stdin
+The action's result dict is written to stdout as a single sentinel-prefixed
+line (see tasks._RESULT_SENTINEL). ALL logging goes to stderr so a stray
+print during django.setup() can never corrupt the result line.
+"""
+import json
+import logging
+import os
+import sys
+
+# stderr-only logging: stdout is reserved for the one sentinel result line.
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stderr,
+    format="%(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("ranked_matchups.runner")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        log.exception("could not parse stdin payload")
+        return 2
+    action = payload.get("action")
+    settings = payload.get("settings") or {}
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dispatcharr.settings")
+    import django
+
+    django.setup()
+
+    # Resolve the plugin package by its folder name (== importable package
+    # name in the deployed container) and add the plugins root to sys.path,
+    # matching how Dispatcharr's loader registers it. Done AFTER django.setup()
+    # because plugin.py imports Django models at module load.
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    plugins_root = os.path.dirname(pkg_dir)
+    if plugins_root not in sys.path:
+        sys.path.insert(0, plugins_root)
+    pkg_name = os.path.basename(pkg_dir)
+
+    plugin = __import__(f"{pkg_name}.plugin", fromlist=["plugin"])
+    tasks = __import__(f"{pkg_name}.tasks", fromlist=["tasks"])
+
+    # Only the GIL-holding actions run out of process. auto_pipeline chains
+    # refresh + apply internally (transitioning the inflight phase the parent
+    # published); standalone apply stays inline in the worker because it's
+    # I/O-bound DB work that yields to the gevent hub. Action names come from
+    # tasks so the caller/runner contract has one source of truth.
+    actions = {
+        tasks.ACTION_REFRESH: plugin._action_refresh,
+        tasks.ACTION_AUTO_PIPELINE: plugin._action_auto_pipeline_sync,
+    }
+    fn = actions.get(action)
+    if fn is None:
+        log.error("unknown action %r", action)
+        result = {"status": "error", "message": f"unknown action {action!r}"}
+    else:
+        try:
+            result = fn(settings)
+        except Exception as e:  # noqa: BLE001 - report, don't crash silently
+            log.exception("action %s crashed", action)
+            result = {"status": "error", "message": f"{action} crashed: {e}"}
+
+    # Single intentional stdout write: the sentinel-prefixed result line.
+    sys.stdout.write(tasks._RESULT_SENTINEL + json.dumps(result) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/plugin.py
+++ b/plugin.py
@@ -2410,25 +2410,26 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
 # ---------- auto pipeline ----------
 
 def _action_auto_pipeline_sync(settings: Dict[str, Any]) -> Dict[str, Any]:
-    """Synchronous in-process auto_pipeline (refresh then apply).
+    """Synchronous auto_pipeline body (refresh then apply).
 
-    DO NOT call this from the HTTP `Plugin.run("auto_pipeline", ...)`
-    dispatch -- the action runs ~40s end-to-end on a populated install
-    and the browser / axios client drops the response well before that,
-    producing a false "failed to run plugin action" toast (#84). The HTTP
-    dispatch goes through `_action_auto_pipeline_async` which queues a
-    Celery task that calls this function inside a Celery worker.
+    DO NOT call this inline in a uwsgi worker (neither from the HTTP
+    `Plugin.run` dispatch NOR from the scheduler loop). The refresh step
+    runs a pure-Python Monte Carlo that holds the GIL, and uwsgi runs
+    under gevent on 0.26.0, so running it in-worker freezes the hub and
+    hangs login + live streams (prod outage 2026-06-10). It is meant to
+    execute inside `_pipeline_runner.py` (a subprocess with no gevent
+    patch). Both entry points reach it the same way -- via
+    `tasks.run_pipeline_subprocess("auto_pipeline", settings)`:
+      - HTTP `Plugin.run("auto_pipeline")` -> `_action_auto_pipeline_async`
+        -> daemon thread -> run_pipeline_subprocess (returns a queued
+        envelope immediately so the browser doesn't time out, #84).
+      - `_scheduler_loop` -> run_pipeline_subprocess.
 
-    The scheduler (`_scheduler_loop`) DOES call this directly: scheduler
-    runs already happen out-of-request, the Redis lock prevents racing
-    a thread-driven HTTP run, and keeping the sync path means crash
-    semantics stay simple (a hung action is visible in the worker
-    process, not orphaned in a thread).
-
-    The caller is responsible for setting and clearing the inflight Redis
-    key (Celery task and scheduler do this around the call). This helper
-    only transitions the phase between refresh and apply so both entry
-    points get the same fine-grained progress in show_status."""
+    The CALLER (the daemon thread / scheduler, in the worker process) owns
+    the inflight Redis key and the scheduler lock around the subprocess.
+    This body only transitions the inflight phase between refresh and
+    apply so both entry points get the same fine-grained show_status
+    progress -- the child writes that phase update to the same Redis key."""
     r1 = _action_refresh(settings)
     if r1.get("status") != "ok":
         return r1
@@ -2644,27 +2645,14 @@ def _scheduler_loop(plugin_ref):
             )
             if _scheduler_stop.wait(timeout=sleep_s):
                 return
-            if not _try_acquire_scheduler_lock():
-                logger.info("[ranked_matchups] another worker holds the lock; skipping")
-                continue
-            try:
-                logger.info("[ranked_matchups] scheduler firing auto_pipeline")
-                # Publish inflight to the same Redis key the Celery tasks use
-                # so the UI's show_status surfaces scheduled runs identically
-                # to HTTP-queued runs. The task_id slot gets "scheduler-<pid>"
-                # so it's distinguishable from a Celery UUID.
-                tasks._set_inflight(
-                    "scheduled_auto_pipeline",
-                    f"scheduler-{os.getpid()}",
-                    "refresh",
-                )
-                try:
-                    result = _action_auto_pipeline_sync(settings)
-                    logger.info("[ranked_matchups] auto_pipeline: %s", result.get("message"))
-                finally:
-                    tasks._clear_inflight()
-            finally:
-                _release_scheduler_lock()
+            logger.info("[ranked_matchups] scheduler firing auto_pipeline")
+            # Delegates to the shared lock/inflight/subprocess path so the
+            # scheduler runs the work OUT OF PROCESS (the Monte Carlo scoring
+            # holds the GIL and would freeze this gevent worker's hub if run
+            # inline) and can't drift out of sync with the HTTP launchers.
+            # run_scheduled_pipeline acquires the cross-worker lock itself and
+            # no-ops if another worker holds it. See tasks.py header.
+            tasks.run_scheduled_pipeline(settings)
         except Exception:
             logger.exception("[ranked_matchups] scheduler loop crashed; sleeping 10m")
             _scheduler_stop.wait(timeout=600)
@@ -2699,7 +2687,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.1.0"
+    version = "1.2.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tasks.py
+++ b/tasks.py
@@ -1,49 +1,70 @@
-"""Background-thread runner for ranked_matchups long-running actions.
+"""Background runner for ranked_matchups long-running actions.
 
-These exist because Dispatcharr's HTTP layer drops the response when a
-synchronous plugin action runs longer than the client's fetch timeout
-(typically 30s for browsers, 60s for axios). Auto pipeline is ~40s
-end-to-end on a populated install and reliably exceeds those defaults;
-the Plugins page surfaces the dropped response as "failed to run plugin
-action" even though the server-side work completed. See issue #84.
+Two problems shape this module, and the fix for each is load-bearing:
 
-DO NOT switch this to Celery without first fixing Dispatcharr core.
-The natural path is `@shared_task` + dispatch via `.delay()`, but
+1. HTTP RESPONSE TIMEOUT (#84). Dispatcharr's HTTP layer drops the
+   response when a synchronous plugin action runs longer than the
+   client's fetch timeout (~30s browsers, 60s axios). Auto pipeline is
+   ~40s end-to-end on a populated install, so the Plugins page shows
+   "failed to run plugin action" even though the work completed. The
+   HTTP entry points therefore return a queued envelope immediately and
+   run the work in a daemon thread that publishes progress to a Redis
+   inflight key (show_status reads it).
+
+2. GEVENT HUB FREEZE (the actual reason the work runs OUT OF PROCESS).
+   DO NOT run the pipeline inline in the uwsgi worker -- not directly,
+   and NOT in a daemon thread. Dispatcharr 0.26.0 runs uwsgi under gevent
+   (gevent-early-monkey-patch = true). The scoring step (simulation.py)
+   is a pure-Python Monte Carlo that holds the GIL for its entire run, so
+   executing it anywhere in the worker process freezes every greenlet on
+   that worker: login and live streams hang until it finishes (observed
+   in prod 2026-06-10, a multi-restart outage). A gevent threadpool does
+   NOT help -- pure-Python never yields the GIL. So the daemon thread no
+   longer runs the work itself; it SUPERVISES a subprocess
+   (run_pipeline_subprocess -> _pipeline_runner.py), a fresh interpreter
+   that never imports the gevent monkey-patch and runs the scoring at
+   full speed in its own GIL. The supervising thread only blocks on the
+   child (gevent-cooperative wait), so the hub stays free.
+
+DO NOT switch this to a Celery @shared_task without first fixing
+Dispatcharr core. The natural path is `@shared_task` + `.delay()`, but
 Dispatcharr's celery.py wires plugin discovery to the `worker_ready`
 signal which fires AFTER the worker's consumer has called
 `update_strategies()` and frozen the per-task strategy registry
-(celery/worker/consumer/consumer.py:635). Plugins that register tasks
-in `worker_ready` show up in `inspect.registered()` (which reads
-`app.tasks`) but are rejected by the consumer as "unregistered task"
-(KeyError in `strategies[name]` at consumer.py:668). Empirically
-verified 2026-05-26 on Dispatcharr 0.25.1. The upstream fix is either
-(a) move the discover_plugins call to `worker_init` instead of
-`worker_ready`, or (b) drop `'celery'` from
-`apps/plugins/apps.py::_no_discovery_cmds` so PluginsConfig.ready()
-runs plugin discovery before Celery's consumer initializes. Until
-one of those lands, daemon threads inside the uwsgi worker process
-are the only viable async path.
+(celery/worker/consumer/consumer.py:635). Plugins that register tasks in
+`worker_ready` show up in `inspect.registered()` but are rejected by the
+consumer as "unregistered task" (KeyError in `strategies[name]` at
+consumer.py:668). Empirically verified 2026-05-26 on 0.25.1 and
+RE-VERIFIED 2026-06-10 on 0.26.0: `'celery'` is still in
+`apps/plugins/apps.py::_no_discovery_cmds` AND discovery is still on
+`worker_ready`, so neither upstream fix has landed. The upstream fix is
+either (a) move discover_plugins to `worker_init`, or (b) drop `'celery'`
+from `_no_discovery_cmds` so PluginsConfig.ready() discovers plugins
+before Celery's consumer initializes. If that lands, the subprocess can
+be replaced by a shared_task in the `dvr` worker (which is --pool=threads
+in a separate process, so the GIL freeze never reaches the uwsgi hub).
 
-Trade-offs of the daemon-thread approach:
+Trade-offs of the daemon-thread-supervises-subprocess approach:
+  + Hub stays responsive: the CPU-bound scoring is in another process.
   + No Celery dependency, no broker round-trip, no worker_ready race.
-  + Lives in the uwsgi worker that handles the request -- consistent
-    with the scheduler's existing in-process model.
-  + Redis-backed scheduler lock already gates cross-worker mutex, so
-    the "thread per uwsgi worker, no shared state" concern is moot.
-  - Worker restart kills the in-flight thread. The 30-min Redis lock
-    TTL auto-clears so a follow-up click can succeed.
-  - State is in the worker, not in a broker. show_status reads the
-    same Redis inflight key the thread writes, so the UI still sees
-    progress even from a different worker.
+  + Redis-backed scheduler lock still gates cross-worker mutex.
+  - Worker restart kills the supervising thread (the child is reaped by
+    the OS). The 30-min Redis lock TTL auto-clears so a retry succeeds.
+  - ~1-2s django.setup() cost per run in the child. Acceptable for a
+    6-hourly + manual action; the win is no frozen worker.
 """
 from __future__ import annotations
 
 import json
 import logging
 import os
+import shutil
+import subprocess
+import sys
 import threading
 import uuid
 from datetime import datetime, timezone
+from functools import partial
 from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.tasks")
@@ -61,6 +82,28 @@ _INFLIGHT_KEY = f"plugins:{PLUGIN_KEY}:inflight"
 # want show_status to stop claiming work is in progress; the lock itself
 # also auto-releases at this point so a new run can start.
 _INFLIGHT_TTL_SECONDS = 30 * 60
+
+# Sentinel prefixing the single stdout line the subprocess emits with its
+# JSON result. Reserving a marker (rather than parsing all of stdout) means a
+# stray print during the child's django.setup() can't corrupt the result.
+# _pipeline_runner.py imports this constant so there is one source of truth.
+_RESULT_SENTINEL = "__RM_PIPELINE_RESULT__ "
+
+# Hard ceiling on a single pipeline run. Kept just under the 30-min scheduler
+# lock TTL so a hung child can't outlive the lock and wedge the next run; on
+# timeout we return an error and the lock auto-releases.
+_SUBPROCESS_TIMEOUT_SECONDS = 25 * 60
+
+# Action selectors for the subprocess boundary -- the contract between
+# run_pipeline_subprocess callers and _pipeline_runner.py's dispatch map.
+# Defined once here and imported by the runner so a rename can't silently
+# drift into an "unknown action" at runtime. Values match the manifest action
+# ids. apply is NOT here: plugin.run("apply") and the auto_pipeline body call
+# _action_apply directly, and apply is I/O-bound DB work that yields to the
+# gevent hub (only the Monte Carlo scoring in refresh holds the GIL), so it
+# does not need a subprocess.
+ACTION_REFRESH = "refresh"
+ACTION_AUTO_PIPELINE = "auto_pipeline"
 
 
 def _redis():
@@ -171,6 +214,98 @@ def _new_task_id() -> str:
     return str(uuid.uuid4())
 
 
+def _python_executable() -> str:
+    """Resolve the real Python interpreter to fork.
+
+    DO NOT use sys.executable here: uWSGI embeds Python, so inside a worker
+    sys.executable is the uwsgi BINARY, not an interpreter. Running it against
+    a .py script makes uwsgi try to load the script as a config
+    ("unable to load configuration from ...") and the child exits rc=1.
+    The venv interpreter lives at sys.prefix/bin/python (verified
+    /dispatcharrpy/bin/python on the 0.26.0 image); fall back to PATH only if
+    that's somehow absent."""
+    candidate = os.path.join(sys.prefix, "bin", "python")
+    if os.path.exists(candidate):
+        return candidate
+    exe = sys.executable or ""
+    if exe and "uwsgi" not in os.path.basename(exe):
+        return exe
+    return shutil.which("python3") or shutil.which("python") or "python3"
+
+
+def run_pipeline_subprocess(action: str, settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a heavy pipeline action ('refresh' / 'apply' / 'auto_pipeline') in
+    a SEPARATE PROCESS and return its result dict.
+
+    This is the gevent-safety boundary (see module header): the scoring is a
+    pure-Python Monte Carlo that holds the GIL, so it MUST NOT run in the uwsgi
+    worker -- doing so freezes the gevent hub and hangs login + streams. We
+    fork `_pipeline_runner.py` (a fresh interpreter with no gevent patch),
+    feed it the action + settings as JSON on stdin, and read its result back
+    from the sentinel line on stdout. Because the parent process is
+    gevent-monkey-patched, `subprocess.run` yields the calling greenlet while
+    the child runs, so the hub keeps serving requests.
+
+    NEVER raises: the caller is a daemon thread / scheduler loop whose escape
+    would crash a uwsgi worker. Any failure (non-zero exit, timeout,
+    unparseable output) is logged and returned as an error dict."""
+    runner = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_pipeline_runner.py")
+    payload = json.dumps({"action": action, "settings": settings})
+    # The forked plain interpreter's sys.path[0] is the plugin dir, so /app
+    # (where the `dispatcharr` Django project lives) is NOT importable and
+    # django.setup() dies with "No module named 'dispatcharr'". The uwsgi
+    # worker we're running in CAN import it, so forward our sys.path to the
+    # child via PYTHONPATH. (The child inherits our cwd by default, which is
+    # the worker's /app, so we don't pass cwd explicitly.)
+    env = os.environ.copy()
+    forwarded = os.pathsep.join(p for p in sys.path if p)
+    env["PYTHONPATH"] = (
+        forwarded + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    )
+    try:
+        proc = subprocess.run(
+            [_python_executable(), runner],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "[ranked_matchups] pipeline subprocess action=%s timed out after %ss",
+            action, _SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        return {"status": "error", "message": "pipeline subprocess timed out"}
+    except Exception as e:  # noqa: BLE001 - never let this escape the thread
+        logger.exception("[ranked_matchups] pipeline subprocess action=%s crashed", action)
+        return {"status": "error", "message": f"pipeline subprocess error: {e}"}
+
+    # The child routes all its logging to stderr; surface it under our logger
+    # so scheduled-run diagnostics land where they always did.
+    if proc.stderr:
+        for line in proc.stderr.splitlines():
+            logger.info("[ranked_matchups.subproc] %s", line)
+
+    if proc.returncode != 0:
+        logger.error(
+            "[ranked_matchups] pipeline subprocess action=%s exited rc=%s",
+            action, proc.returncode,
+        )
+        return {"status": "error", "message": f"pipeline subprocess failed (rc={proc.returncode})"}
+
+    for line in proc.stdout.splitlines():
+        if line.startswith(_RESULT_SENTINEL):
+            try:
+                return json.loads(line[len(_RESULT_SENTINEL):])
+            except json.JSONDecodeError:
+                break
+    logger.error(
+        "[ranked_matchups] pipeline subprocess action=%s: no parseable result line", action,
+    )
+    return {"status": "error", "message": "pipeline subprocess produced no result"}
+
+
 def run_auto_pipeline_background(settings: Dict[str, Any]) -> str:
     """Spawn a daemon thread that runs refresh + apply in the
     background. Returns the task id (a fresh UUID) the caller can
@@ -178,13 +313,13 @@ def run_auto_pipeline_background(settings: Dict[str, Any]) -> str:
 
     DO NOT block on the thread; the whole point is to return to the
     HTTP client immediately. The thread publishes progress to the
-    inflight Redis key which show_status reads."""
-    from .plugin import _action_auto_pipeline_sync
-
+    inflight Redis key which show_status reads. The thread does NOT run
+    the scoring itself -- it supervises a subprocess (see module header
+    on the gevent freeze); the cooperative wait keeps the hub free."""
     task_id = _new_task_id()
     t = threading.Thread(
         target=_run_under_lock,
-        args=("auto_pipeline", task_id, _action_auto_pipeline_sync, settings),
+        args=("auto_pipeline", task_id, partial(run_pipeline_subprocess, ACTION_AUTO_PIPELINE), settings),
         name=f"ranked_matchups-auto_pipeline-{task_id[:8]}",
         daemon=True,
     )
@@ -194,15 +329,31 @@ def run_auto_pipeline_background(settings: Dict[str, Any]) -> str:
 
 def run_refresh_background(settings: Dict[str, Any]) -> str:
     """Spawn a daemon thread that runs refresh only. Same contract as
-    run_auto_pipeline_background."""
-    from .plugin import _action_refresh
-
+    run_auto_pipeline_background (work runs in a supervised subprocess)."""
     task_id = _new_task_id()
     t = threading.Thread(
         target=_run_under_lock,
-        args=("refresh", task_id, _action_refresh, settings),
+        args=("refresh", task_id, partial(run_pipeline_subprocess, ACTION_REFRESH), settings),
         name=f"ranked_matchups-refresh-{task_id[:8]}",
         daemon=True,
     )
     t.start()
     return task_id
+
+
+def run_scheduled_pipeline(settings: Dict[str, Any]) -> None:
+    """Scheduler entry point for the auto-refresh tick.
+
+    Runs the auto_pipeline through the SAME lock/inflight/subprocess path the
+    HTTP launchers use (`_run_under_lock` -> supervised subprocess), so the
+    scheduler can't drift back into running the Monte Carlo in-process and
+    re-freezing the gevent hub. Blocks until the child completes; that's fine
+    because the scheduler runs in its own loop thread, not a request worker.
+    The kind/task_id mark this as a scheduled run so show_status can tell it
+    apart from an HTTP-queued one."""
+    _run_under_lock(
+        "scheduled_auto_pipeline",
+        f"scheduler-{os.getpid()}",
+        partial(run_pipeline_subprocess, ACTION_AUTO_PIPELINE),
+        settings,
+    )

--- a/tests/test_subprocess_pipeline.py
+++ b/tests/test_subprocess_pipeline.py
@@ -1,0 +1,190 @@
+"""Tests for the subprocess isolation of the heavy pipeline (gevent fix).
+
+The scoring is pure-Python Monte Carlo that holds the GIL; running it in
+the gevent uwsgi worker froze the hub and hung login + live streams
+(prod outage 2026-06-10). run_pipeline_subprocess forks a fresh
+interpreter so the work runs in its own GIL. These tests pin:
+  - the subprocess command shape, stdin payload, and sentinel parsing;
+  - that every failure mode (non-zero exit, timeout, no result line)
+    returns an error dict and NEVER raises (the caller is a daemon
+    thread whose escape crashes a worker);
+  - that the HTTP launchers route their supervised target through the
+    subprocess for the right action.
+
+The child interpreter itself (_pipeline_runner.py) needs Django and is
+exercised live against the running container during deploy, not here."""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+def _load_tasks_module():
+    if f"{PKG_NAME}.tasks" in sys.modules:
+        return sys.modules[f"{PKG_NAME}.tasks"]
+    spec = importlib.util.spec_from_file_location(
+        f"{PKG_NAME}.tasks", os.path.join(REPO_ROOT, "tasks.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{PKG_NAME}.tasks"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def tasks_mod():
+    return _load_tasks_module()
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    """Stand-in for subprocess.CompletedProcess (only the attrs we read)."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestRunPipelineSubprocess:
+    def test_happy_path_returns_parsed_result(self, tasks_mod):
+        result = {"status": "ok", "message": "refresh: 12 | apply: 12"}
+        stdout = "some django.setup() noise\n" + tasks_mod._RESULT_SENTINEL + json.dumps(result) + "\n"
+        with patch.object(tasks_mod, "_python_executable", return_value="/venv/bin/python"):
+            with patch.object(tasks_mod.subprocess, "run", return_value=_completed(0, stdout)) as run:
+                out = tasks_mod.run_pipeline_subprocess("auto_pipeline", {"max_games": 5})
+        assert out == result
+        # Command shape: the resolved interpreter + the runner in the package dir.
+        (cmd,), kwargs = run.call_args
+        assert cmd[0] == "/venv/bin/python"
+        assert cmd[1].endswith("_pipeline_runner.py")
+        # Action + settings handed off as JSON on stdin.
+        assert json.loads(kwargs["input"]) == {"action": "auto_pipeline", "settings": {"max_games": 5}}
+        # Bounded so a hung child can't outlive the scheduler lock.
+        assert kwargs["timeout"] == tasks_mod._SUBPROCESS_TIMEOUT_SECONDS
+        # Parent sys.path forwarded so the child can import `dispatcharr`.
+        assert "PYTHONPATH" in kwargs["env"]
+        assert any(p and p in kwargs["env"]["PYTHONPATH"] for p in sys.path)
+
+    def test_python_executable_never_returns_uwsgi_binary(self, tasks_mod):
+        # The whole bug: under uWSGI sys.executable is the uwsgi binary, which
+        # makes the child try to parse the script as a uwsgi config (rc=1).
+        with patch.object(tasks_mod.sys, "executable", "/dispatcharrpy/bin/uwsgi"):
+            # sys.prefix/bin/python exists in the test env, so we get that...
+            exe = tasks_mod._python_executable()
+            assert "uwsgi" not in os.path.basename(exe)
+            # ...and with no venv python present, we must still avoid uwsgi.
+            with patch.object(tasks_mod.os.path, "exists", return_value=False):
+                with patch.object(tasks_mod.shutil, "which", return_value="/usr/bin/python3"):
+                    assert tasks_mod._python_executable() == "/usr/bin/python3"
+
+    def test_sentinel_ignores_leading_stdout_noise(self, tasks_mod):
+        # A stray print before the sentinel must not corrupt the result.
+        result = {"status": "ok"}
+        stdout = "WARNING blah\nDEBUG something\n" + tasks_mod._RESULT_SENTINEL + json.dumps(result)
+        with patch.object(tasks_mod.subprocess, "run", return_value=_completed(0, stdout)):
+            out = tasks_mod.run_pipeline_subprocess("refresh", {})
+        assert out == result
+
+    def test_nonzero_exit_returns_error_dict(self, tasks_mod):
+        with patch.object(tasks_mod.subprocess, "run", return_value=_completed(1, "", "boom")):
+            out = tasks_mod.run_pipeline_subprocess("refresh", {})
+        assert out["status"] == "error"
+        assert "rc=1" in out["message"]
+
+    def test_timeout_returns_error_dict(self, tasks_mod):
+        with patch.object(
+            tasks_mod.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1),
+        ):
+            out = tasks_mod.run_pipeline_subprocess("auto_pipeline", {})
+        assert out["status"] == "error"
+        assert "timed out" in out["message"]
+
+    def test_no_sentinel_line_returns_error_dict(self, tasks_mod):
+        # Child exited 0 but emitted nothing parseable -- treat as failure,
+        # do NOT pretend success.
+        with patch.object(tasks_mod.subprocess, "run", return_value=_completed(0, "just logs\n")):
+            out = tasks_mod.run_pipeline_subprocess("refresh", {})
+        assert out["status"] == "error"
+        assert "no result" in out["message"]
+
+    def test_unexpected_exception_never_escapes(self, tasks_mod):
+        # The caller is a daemon thread; an escape crashes a uwsgi worker.
+        with patch.object(tasks_mod.subprocess, "run", side_effect=OSError("fork failed")):
+            out = tasks_mod.run_pipeline_subprocess("refresh", {})
+        assert out["status"] == "error"
+
+
+class TestLaunchersRouteThroughSubprocess:
+    """The HTTP launchers must hand _run_under_lock a target that runs the
+    work in the subprocess for the correct action -- NOT the in-process
+    action function (which would freeze the gevent hub)."""
+
+    def _run_and_capture(self, tasks_mod, launcher, settings):
+        """Patch run_pipeline_subprocess BEFORE the launcher runs so the
+        target partial binds the mock (partial captures the function at
+        build time, so patching after the fact would be a no-op), then
+        capture the args handed to threading.Thread."""
+        captured = {}
+
+        def capture_thread(*args, **kwargs):
+            captured["args"] = kwargs.get("args")
+            captured["daemon"] = kwargs.get("daemon")
+            return MagicMock()
+
+        rps = MagicMock(return_value={"status": "ok"})
+        with patch.object(tasks_mod, "run_pipeline_subprocess", rps):
+            with patch.object(tasks_mod.threading, "Thread", side_effect=capture_thread):
+                launcher(settings)
+            kind, _task_id, target, passed_settings = captured["args"]
+            target_result = target(settings)
+        return captured, rps, kind, passed_settings, target_result
+
+    def test_auto_pipeline_target_routes_to_subprocess(self, tasks_mod):
+        settings = {"max_games": 9}
+        captured, rps, kind, passed_settings, target_result = self._run_and_capture(
+            tasks_mod, tasks_mod.run_auto_pipeline_background, settings
+        )
+        assert kind == "auto_pipeline"
+        assert passed_settings == settings
+        assert captured["daemon"] is True
+        assert target_result == {"status": "ok"}
+        rps.assert_called_once_with(tasks_mod.ACTION_AUTO_PIPELINE, settings)
+
+    def test_refresh_target_routes_to_subprocess(self, tasks_mod):
+        settings = {"enable_epl": True}
+        _captured, rps, kind, passed_settings, _result = self._run_and_capture(
+            tasks_mod, tasks_mod.run_refresh_background, settings
+        )
+        assert kind == "refresh"
+        assert passed_settings == settings
+        rps.assert_called_once_with(tasks_mod.ACTION_REFRESH, settings)
+
+    def test_scheduled_pipeline_routes_through_lock_and_subprocess(self, tasks_mod):
+        # The scheduler tick is the ORIGINAL outage path. Guard that it runs
+        # under the cross-worker lock AND out of process -- i.e. it must NOT
+        # call the in-process _action_auto_pipeline_sync directly.
+        settings = {"max_games": 3}
+        with patch.object(tasks_mod, "run_pipeline_subprocess", return_value={"status": "ok"}) as rps:
+            with patch.object(tasks_mod, "_run_under_lock") as rul:
+                tasks_mod.run_scheduled_pipeline(settings)
+            (kind, task_id, target, passed_settings), _ = rul.call_args
+            # Distinguishable scheduled-run identity for show_status.
+            assert kind == "scheduled_auto_pipeline"
+            assert task_id.startswith("scheduler-")
+            assert passed_settings == settings
+            # The supervised target must run the auto_pipeline in the subprocess.
+            target(settings)
+        rps.assert_called_once_with(tasks_mod.ACTION_AUTO_PIPELINE, settings)
+
+    def test_action_constants_match_manifest_ids(self, tasks_mod):
+        # The subprocess action selectors must equal the wire/manifest action
+        # ids the UI and plugin.run dispatch on, or a scheduled/HTTP run would
+        # hand the runner a name it doesn't know.
+        assert tasks_mod.ACTION_REFRESH == "refresh"
+        assert tasks_mod.ACTION_AUTO_PIPELINE == "auto_pipeline"


### PR DESCRIPTION
## Problem

Dispatcharr 0.26.0 moved uwsgi to **gevent** (`gevent-early-monkey-patch`). The refresh scoring (`simulation.py`) is a pure-Python Monte Carlo that holds the GIL for its whole run. Running it in an in-worker daemon thread froze the gevent hub: **login hung and live streams went unresponsive** for the duration of every refresh (scheduled or manual). This caused a multi-restart prod outage on 2026-06-10.

Why not the obvious alternatives:
- **gevent threadpool**: doesn't help. Pure-Python never yields the GIL, so the hub still stalls.
- **Celery `@shared_task`**: still not registrable on 0.26.0. Plugin discovery runs on `worker_ready`, after the consumer freezes its task-strategy registry, so `.delay()` is rejected as "unregistered task". Re-verified on 0.26.0 (`'celery'` still in `_no_discovery_cmds`, discovery still on `worker_ready`).

## Fix

Run the heavy pipeline in a **separate interpreter** (`_pipeline_runner.py`). The supervising daemon thread / scheduler only blocks on the child via a gevent-cooperative `subprocess` wait, so the hub stays free.

- `tasks.run_pipeline_subprocess`: forks the venv python (**not** `sys.executable` — that's the uwsgi binary under embed), forwards `sys.path` via `PYTHONPATH` so the child can import `dispatcharr`, and parses the result off a sentinel stdout line (immune to stray `django.setup()` prints).
- `run_scheduled_pipeline`: the scheduler now shares the same lock/inflight/subprocess path as the HTTP launchers, removing a duplicated lock+inflight block.
- Action names (`refresh`, `auto_pipeline`) are shared constants across the caller/runner process boundary.
- Removed stale docstrings claiming a Celery-worker path. Bumped `1.1.0` -> `1.2.0`.

## Live verification (running 0.26.0 container)

- Full refresh ran ~40s entirely in the subprocess: `refresh task ... complete: status=ok`, `cache.json` advanced, 19 games written.
- **Hub stayed responsive throughout**: index held at ~2ms and auth sub-second across a ~2.5 min run (before the fix, the same run produced 10s auth timeouts and dead streams).
- Subprocess stderr is surfaced under the plugin logger; scheduler loads clean, no `ImportError`/`unknown action`.

## Tests

`3133 passed`. New `tests/test_subprocess_pipeline.py` covers: command shape + stdin payload + sentinel parse, every failure mode returns an error dict and never raises (timeout, non-zero exit, no result line, unexpected exception), the venv-python resolver never returns the uwsgi binary, the HTTP launchers + scheduler all route through the subprocess for the right action, and the action constants match the manifest ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)