### PR TITLE
Widen stream pool: stack same-fixture fallback streams (off by default) (#108)

### DIFF
--- a/matcher.py
+++ b/matcher.py
@@ -303,20 +303,50 @@ MATCHER_SYSTEM_PROMPT = (
 )
 
 
+def _stack_fallback_ids(
+    primary_id: int, cands: List[ChannelCandidate]
+) -> List[int]:
+    """Primary id first, then every other candidate id, deduped in order.
+
+    Used by the #108 widen path to stack same-fixture provider variants as
+    fallback streams behind the chosen primary. A single channel can appear in
+    `cands` more than once (multiple ProgramData rows), so dedupe.
+    """
+    out = [primary_id]
+    seen = {primary_id}
+    for c in cands:
+        if c.channel_id not in seen:
+            out.append(c.channel_id)
+            seen.add(c.channel_id)
+    return out
+
+
 def match_games_to_channels(
     scored_games: List[Tuple[Any, Any, Any]],  # (GameRow, GameSignals, GameScore)
     epg_lookup,  # callable: GameRow -> List[ChannelCandidate]
     api_key: str,
     model: str,
+    widen: bool = False,
 ) -> List[MatchResult]:
     """Resolve each game to a Dispatcharr channel.
 
     epg_lookup: callable that, given a GameRow, returns candidate channels
     broadcasting around that time. Caller (plugin.py) provides this with a
     closure over Dispatcharr's ORM.
+
+    widen (#108): when True, the LLM-disambiguated tier stacks the non-chosen
+    candidates as fallback streams behind the primary, INSTEAD of discarding
+    them. Off by default. Only the both-team candidate set (the `filtered`
+    tier-2 matches the LLM picks among) is stacked: a candidate that names just
+    one team is a different-game risk, so the zero-both-team `wider` path is
+    never widened even when `widen` is True. The tier-1 regex_strict path
+    already stacks every channel-name variant and is unaffected by this flag.
     """
     results: List[MatchResult] = [MatchResult(game_index=i) for i in range(len(scored_games))]
-    ambiguous: List[Tuple[int, Any, List[ChannelCandidate]]] = []
+    # Each entry: (game_index, game, candidates, both_team). `both_team` is True
+    # only when every candidate named BOTH teams (tier-2 multi-match), which is
+    # the precondition for #108 widening.
+    ambiguous: List[Tuple[int, Any, List[ChannelCandidate], bool]] = []
 
     for i, (game, _signals, _score) in enumerate(scored_games):
         candidates = epg_lookup(game)
@@ -333,13 +363,12 @@ def match_games_to_channels(
             results[i].channel_id = primary.channel_id
             results[i].channel_name = primary.channel_name
             results[i].program_title = primary.program_title
-            # De-dupe channel_ids while preserving order (a single channel
-            # can have multiple ProgramData rows that pass the filter).
-            seen_ids = set()
-            for c in strict:
-                if c.channel_id not in seen_ids:
-                    results[i].channel_ids.append(c.channel_id)
-                    seen_ids.add(c.channel_id)
+            # De-dupe channel_ids while preserving order (a single channel can
+            # have multiple ProgramData rows that pass the filter). Tier-1
+            # always stacks every channel-name variant: this is the original
+            # multi-stream path the #108 widen flag generalizes to lower tiers,
+            # so it shares the same stacking helper.
+            results[i].channel_ids = _stack_fallback_ids(primary.channel_id, strict)
             results[i].method = "regex_strict"
             continue
 
@@ -363,15 +392,19 @@ def match_games_to_channels(
             # mentions a team keyword, so the count is naturally small.
             wider = _strip_preview_titles(candidates)
             if wider:
-                ambiguous.append((i, game, wider))
+                # both_team=False: these matched only a team keyword, not both
+                # teams, so they are NOT eligible for #108 fallback stacking.
+                ambiguous.append((i, game, wider, False))
         else:
             # Multiple regex matches survived preview stripping: Claude resolves.
-            ambiguous.append((i, game, filtered))
+            # both_team=True: every candidate named both teams, so the
+            # non-chosen ones are same-fixture variants safe to stack (#108).
+            ambiguous.append((i, game, filtered, True))
 
     if ambiguous and api_key:
         # One batch Claude call.
         payload = []
-        for idx, game, cands in ambiguous:
+        for idx, game, cands, _both in ambiguous:
             payload.append({
                 "game_id": str(idx),
                 "sport": game.sport_label,
@@ -389,7 +422,7 @@ def match_games_to_channels(
             })
         user = "Match each game to its broadcasting channel from the candidates. JSON only.\n\n" + json.dumps(payload, ensure_ascii=False)
         parsed = _post_claude(api_key, model, MATCHER_SYSTEM_PROMPT, user) or {}
-        for idx, game, cands in ambiguous:
+        for idx, game, cands, both_team in ambiguous:
             picked = parsed.get(str(idx))
             if picked is None:
                 results[idx].note = f"LLM no match among {len(cands)} candidates"
@@ -406,17 +439,28 @@ def match_games_to_channels(
             results[idx].channel_id = chosen.channel_id
             results[idx].channel_name = chosen.channel_name
             results[idx].program_title = chosen.program_title
-            results[idx].channel_ids = [chosen.channel_id]
+            # #108: stack the other both-team variants as fallback streams when
+            # widen is on; otherwise keep the historical single-channel result.
+            if widen and both_team:
+                results[idx].channel_ids = _stack_fallback_ids(chosen.channel_id, cands)
+            else:
+                results[idx].channel_ids = [chosen.channel_id]
             results[idx].method = "llm"
     elif ambiguous:
         # No API key: best-effort: pick first candidate to surface SOMETHING.
-        for idx, _game, cands in ambiguous:
+        for idx, _game, cands, both_team in ambiguous:
             if cands:
                 c = cands[0]
                 results[idx].channel_id = c.channel_id
                 results[idx].channel_name = c.channel_name
                 results[idx].program_title = c.program_title
-                results[idx].channel_ids = [c.channel_id]
+                # #108: same widen rule as the LLM path. Without an API key we
+                # cannot disambiguate, so the first candidate is primary and the
+                # rest stack only when they all name both teams.
+                if widen and both_team:
+                    results[idx].channel_ids = _stack_fallback_ids(c.channel_id, cands)
+                else:
+                    results[idx].channel_ids = [c.channel_id]
                 results[idx].method = "fallback_first"
                 results[idx].note = "no api key; first candidate"
 

--- a/plugin.json
+++ b/plugin.json
@@ -521,6 +521,13 @@
       "help_text": "Replace each virtual channel's logo with TheSportsDB's pre-rendered 960x540 matchup graphic (both team crests + league wordmark + region backdrop). Resolved by team-name pair + date; cached per fixture for 14 days. Falls back to the matched source channel's logo when SportsDB has no thumbnail (offseason, untracked sport, field events like F1/golf/UFC/tennis). Configure key under 'API Keys'."
     },
     {
+      "id": "widen_stream_pool",
+      "type": "boolean",
+      "label": "Widen stream pool (extra fallback streams)",
+      "default": false,
+      "help_text": "When a game airs on several provider channels that all name both teams, the matcher normally keeps just the one it judges best and discards the rest. Turn this on to also stack those other same-fixture channels as lower-priority fallback streams, so if the primary upstream goes down (e.g. a provider 503) the channel fails over instead of going dark. Only channels naming BOTH teams are stacked, never single-team-keyword guesses. Off by default: it trades tighter curation for resilience, and cannot help games your providers do not carry at all."
+    },
+    {
       "id": "_section_schedule",
       "type": "info",
       "label": "Auto-Refresh",

--- a/plugin.py
+++ b/plugin.py
@@ -1116,7 +1116,11 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     epg_lookup = _build_epg_lookup()
     api_key = _resolve_key(settings, "anthropic_api_key", ANTHROPIC_KEY_PATH)
     model = settings.get("model", "claude-haiku-4-5")
-    matches = match_games_to_channels(scored, epg_lookup, api_key, model)
+    # #108: off-by-default. When on, the matcher stacks same-fixture provider
+    # variants as fallback streams so a single upstream 503 doesn't dark out
+    # the matchup channel.
+    widen = bool(settings.get("widen_stream_pool", False))
+    matches = match_games_to_channels(scored, epg_lookup, api_key, model, widen=widen)
 
     # 5. Build cache payload (transparent: every signal + breakdown stored)
     games_payload = []

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -12,6 +12,7 @@ from dispatcharr_ranked_matchups.matcher import (
     _regex_filter_channel_name,
     _strip_preview_titles,
     _team_keywords,
+    match_games_to_channels,
 )
 
 
@@ -333,3 +334,142 @@ class TestMatcherPromptIncludesForeignLanguageHints:
     def test_prompt_mentions_french_journee(self):
         from dispatcharr_ranked_matchups.matcher import MATCHER_SYSTEM_PROMPT
         assert "journee" in MATCHER_SYSTEM_PROMPT
+
+
+class _Game:
+    """Minimal stand-in for a GameRow: only the attrs the matcher reads."""
+
+    def __init__(self, home, away, sport_label="NCAAF"):
+        self.home = home
+        self.away = away
+        self.sport_label = sport_label
+        self.start_time = datetime(2026, 4, 27, tzinfo=timezone.utc)
+
+
+def _cand(channel_id, channel_name, program_title):
+    return ChannelCandidate(
+        channel_id=channel_id,
+        channel_name=channel_name,
+        program_title=program_title,
+        program_start=datetime(2026, 4, 27, tzinfo=timezone.utc),
+        program_end=datetime(2026, 4, 27, 4, tzinfo=timezone.utc),
+    )
+
+
+class TestWidenStreamPool:
+    """#108: an off-by-default `widen` flag stacks the non-chosen same-fixture
+    candidates as fallback streams instead of discarding them.
+
+    Scoping rule: only candidates that name BOTH teams (the `filtered` set the
+    LLM disambiguates) get stacked. Single-team-keyword candidates (the
+    zero-both-team `wider` path) are NOT stacked, because failing over to a
+    stream that only mentions one team risks landing on a different game.
+    """
+
+    def _multi_both_team_setup(self, monkeypatch):
+        # Both candidates name BOTH teams in the TITLE but neither in the
+        # CHANNEL NAME, so tier-1 (regex_strict on channel name) misses and the
+        # game falls to the LLM disambiguation path with filtered len == 2.
+        cands = [
+            _cand(100, "ESPN", "Penn State at Ohio State"),
+            _cand(101, "FOX", "Penn State vs Ohio State"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        # LLM picks channel 100 as the primary broadcast.
+        monkeypatch.setattr(
+            "dispatcharr_ranked_matchups.matcher._post_claude",
+            lambda *a, **k: {"0": 100},
+        )
+        return games, lambda g: cands
+
+    def test_llm_single_id_when_widen_off(self, monkeypatch):
+        games, lookup = self._multi_both_team_setup(monkeypatch)
+        results = match_games_to_channels(games, lookup, api_key="x", model="m")
+        assert results[0].method == "llm"
+        assert results[0].channel_id == 100
+        assert results[0].channel_ids == [100]
+
+    def test_llm_stacks_both_team_candidates_when_widen_on(self, monkeypatch):
+        games, lookup = self._multi_both_team_setup(monkeypatch)
+        results = match_games_to_channels(
+            games, lookup, api_key="x", model="m", widen=True
+        )
+        assert results[0].method == "llm"
+        # Primary stays the LLM's pick; the other both-team variant is stacked
+        # after it as a fallback stream source.
+        assert results[0].channel_id == 100
+        assert results[0].channel_ids == [100, 101]
+
+    def test_widen_does_not_stack_single_team_candidates(self, monkeypatch):
+        # No candidate names BOTH teams (filtered == 0). The LLM still picks one
+        # from the wider single-team-keyword pool, but widening must NOT stack
+        # the others: they could be a different game featuring one of the teams.
+        cands = [
+            _cand(200, "ESPN", "Penn State football tonight"),
+            _cand(201, "BTN", "Ohio State pregame coverage"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        monkeypatch.setattr(
+            "dispatcharr_ranked_matchups.matcher._post_claude",
+            lambda *a, **k: {"0": 200},
+        )
+        results = match_games_to_channels(
+            games, lambda g: cands, api_key="x", model="m", widen=True
+        )
+        assert results[0].channel_id == 200
+        assert results[0].channel_ids == [200]
+
+    def test_regex_strict_stacks_regardless_of_widen(self, monkeypatch):
+        # Tier-1 channel-name both-team matches already stack all variants; the
+        # widen flag must not change that established behavior (widen off here).
+        cands = [
+            _cand(300, "EPL01: Penn State 20:00 Ohio State", "Live"),
+            _cand(301, "AU: Penn State v Ohio State", "Live"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(
+            games, lambda g: cands, api_key="x", model="m"
+        )
+        assert results[0].method == "regex_strict"
+        assert results[0].channel_ids == [300, 301]
+
+    def test_regex_strict_dedupes_repeated_channel(self):
+        # A single channel with two ProgramData rows both passing the filter
+        # must appear once. Exercises the shared stacking helper's dedupe.
+        cands = [
+            _cand(300, "EPL01: Penn State v Ohio State", "First half"),
+            _cand(300, "EPL01: Penn State v Ohio State", "Second half"),
+            _cand(301, "AU: Penn State v Ohio State", "Live"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(
+            games, lambda g: cands, api_key="x", model="m"
+        )
+        assert results[0].channel_ids == [300, 301]
+
+    def test_fallback_first_stacks_both_team_when_widen_on(self):
+        # No API key -> fallback_first. With widen on and every candidate
+        # naming both teams, stack the rest behind the first as fallbacks.
+        cands = [
+            _cand(400, "ESPN", "Penn State at Ohio State"),
+            _cand(401, "FOX", "Penn State vs Ohio State"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(
+            games, lambda g: cands, api_key="", model="m", widen=True
+        )
+        assert results[0].method == "fallback_first"
+        assert results[0].channel_id == 400
+        assert results[0].channel_ids == [400, 401]
+
+    def test_fallback_first_single_id_when_widen_off(self):
+        cands = [
+            _cand(400, "ESPN", "Penn State at Ohio State"),
+            _cand(401, "FOX", "Penn State vs Ohio State"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(
+            games, lambda g: cands, api_key="", model="m"
+        )
+        assert results[0].method == "fallback_first"
+        assert results[0].channel_ids == [400]


### PR DESCRIPTION
## What

Adds an off-by-default `widen_stream_pool` setting. When on, the matcher stacks the non-chosen same-fixture provider channels as lower-priority fallback streams behind the primary pick, for the LLM and no-API-key (`fallback_first`) tiers. Previously those tiers kept only the single best channel and discarded the rest, so many matchup channels carried one stream (some zero) and a single upstream 503 darked them out with no failover.

Closes #108

## Scope / safety

- Only candidates naming **both** teams (the tier-2 `filtered` set the LLM disambiguates among) are stacked. The zero-both-team `wider` path is never widened, even with the flag on, because a single-team-keyword stream risks failing over to a different game.
- Tier-1 `regex_strict` (which always stacked channel-name variants) is unaffected, and now shares the new `_stack_fallback_ids` helper, removing a duplicated dedupe-preserving-order loop.
- Off by default: trades tighter curation for resilience. Cannot help games a provider does not carry at all (those stay unmatched).
- The apply phase already pools and quality-ranks all `channel_ids`, so no apply change was needed.

## Tests

`tests/test_matcher.py`: widen on/off across the `llm`, `fallback_first`, and `regex_strict` tiers, the deliberate no-stack on the single-team path, and dedupe of a repeated channel. **Full suite: 3140 passed** (`python:3.11-slim`).

## Live verification (container 0.26.0, Dispatcharr on Tower)

- **Deploy**: matcher.py / plugin.py / plugin.json copied to the live plugin folder, confirmed **byte-identical** to the branch for all three.
- **Setting renders**: the loader parses `widen_stream_pool` into the served fields (`type: boolean`, `default: false`, help text intact) — confirmed via the plugin loader.
- **Real-data integration**: ran the deployed `match_games_to_channels` (widen off vs on) over the real EPG (`_build_epg_lookup`) and real Claude for the current 25-game slate. The widen path runs cleanly, accepts the flag, and produces **zero regressions** (no game's stream count drops). Today's fixtures contain no multi-distinct-both-team-title game, so widen correctly no-ops on them; the positive stacking case is covered by the deterministic unit tests.
- **Note**: the HTTP `/api/plugins/plugins/` and `/reload/` endpoints on the long-running worker hang (pre-existing; DB at 55/200 connections, hub otherwise healthy, fresh-process discovery completes in 0.6s). The new field/code will be picked up on the next worker re-discovery or a container restart. Flagged to the maintainer.