### PR TITLE
Treat foreign-language audio-feed labels as non-English (#113)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -254,15 +254,36 @@ _SPANISH_COUNTRY_HINTS = (
     " UCRANIA ", " ESCOCIA ", " GALES ", " IRLANDA ", " CHEQUIA ",
 )
 
+# A foreign-language audio label (e.g. "Czech Feed", "Korean Commentary"): the
+# team names are spelled in English but the COMMENTARY is foreign, so the
+# English-team-name check would wrongly rank it English. #113: surfaced live on
+# a WC channel where "TSN+ Czech Feed" / "Korean Feed" sorted ahead of the
+# plain English FIFA feed. "English" is intentionally absent from the language
+# list. Matched as "<lang> <feed-noun>" so a team like "Czechia" (no feed noun)
+# never trips it.
+_FOREIGN_FEED_LANGUAGES = (
+    "SPANISH", "FRENCH", "GERMAN", "ITALIAN", "PORTUGUESE", "CZECH", "KOREAN",
+    "JAPANESE", "ARABIC", "DUTCH", "POLISH", "RUSSIAN", "TURKISH", "GREEK",
+    "DANISH", "SWEDISH", "NORWEGIAN", "CROATIAN", "SERBIAN", "CHINESE",
+)
+_FOREIGN_FEED_NOUNS = ("FEED", "COMMENTARY", "AUDIO", "COMMS")
+_FOREIGN_FEED_MARKERS = tuple(
+    f"{lang} {noun}" for lang in _FOREIGN_FEED_LANGUAGES for noun in _FOREIGN_FEED_NOUNS
+)
+
 
 def _has_foreign_language_marker(name: str) -> bool:
     """True when a stream name carries a reliable non-English signal: an
-    accented Latin letter, a foreign-language broadcaster, or a Spanish country
-    spelling. Best-effort (#111); stays silent on ambiguous names so they land
-    in the unknown middle tier rather than being mislabeled."""
+    accented Latin letter, a foreign-language broadcaster, a Spanish country
+    spelling, or a foreign-language audio-feed label ("Czech Feed"). Best-effort
+    (#111/#113); stays silent on ambiguous names so they land in the unknown
+    middle tier rather than being mislabeled."""
     if any(c in _FOREIGN_ACCENT_CHARS for c in name):
         return True
-    padded = f" {name.upper()} "
+    upper = name.upper()
+    if any(marker in upper for marker in _FOREIGN_FEED_MARKERS):
+        return True
+    padded = f" {upper} "
     if any(tok in padded for tok in _FOREIGN_PROVIDER_TOKENS):
         return True
     if any(tok in padded for tok in _SPANISH_COUNTRY_HINTS):

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -2117,6 +2117,29 @@ class TestStreamLanguageRank:
         n = "US (Peacock 061) |  Arabia Saudí v. Uruguay (2026-06-15 17:00:00)"
         assert plugin._stream_language_rank(n, "Saudi Arabia", "Uruguay") == plugin._LANG_RANK_NON_ENGLISH
 
+    def test_foreign_audio_feed_label_is_non_english(self, plugin):
+        # Regression (#113, caught live): the audio is Czech/Korean even though
+        # the team names are spelled in English, so the "<lang> Feed" label must
+        # demote it below the plain English feed.
+        czech = "TSN+ 11 : Czech Feed: FIFA World Cup 2026: Korea Republic vs. Czechia"
+        korean = "TSN+ 12 : Korean Feed: FIFA World Cup 2026: Korea Republic vs. Czechia"
+        assert plugin._stream_language_rank(czech, "South Korea", "Czechia") == plugin._LANG_RANK_NON_ENGLISH
+        assert plugin._stream_language_rank(korean, "South Korea", "Czechia") == plugin._LANG_RANK_NON_ENGLISH
+
+    def test_plain_english_feed_outranks_foreign_audio_feed(self, plugin):
+        # The plain English FIFA feed (no "<lang> Feed" label) must sort ahead.
+        czech = plugin._stream_language_rank(
+            "TSN+ 11 : Czech Feed: ... Korea Republic vs. Czechia", "South Korea", "Czechia")
+        english = plugin._stream_language_rank(
+            "FIFA World Cup 2026 05: Korea Republic 03:00 Czechia", "South Korea", "Czechia")
+        assert english < czech  # English (0) before non-English (2)
+
+    def test_team_name_alone_does_not_trip_feed_marker(self, plugin):
+        # "Czechia" contains "CZECH" but no feed noun follows, so a plain feed
+        # naming the team must NOT be mislabeled foreign.
+        n = "FIFA World Cup 2026 05: Korea Republic 03:00 Czechia"
+        assert plugin._stream_language_rank(n, "South Korea", "Czechia") == plugin._LANG_RANK_ENGLISH
+
     def test_english_provider_with_single_team_is_english(self, plugin):
         # Only one team named, but "BBC" is an English provider marker.
         n = "WC2026: BBC Scotland"


### PR DESCRIPTION
## What

Follow-up fix to #112, surfaced the moment widen+English-first ordering went live. On a WC channel the streams ordered:

```
[0] TSN+ 11 : Czech Feed: ... Korea Republic vs. Czechia
[1] TSN+ 12 : Korean Feed: ... Korea Republic vs. Czechia
[2] FIFA World Cup 2026 05: Korea Republic 03:00 Czechia
[3] FIFA World Cup 2026 06: [4K] ...
```

The "Czech Feed" / "Korean Feed" are foreign-**audio** feeds that spell the team names in English, so `_stream_language_rank`'s both-English-names check ranked them English (0) and sorted them ahead of the actual English FIFA feed.

## Fix

`_has_foreign_language_marker` now also matches a foreign-language audio label: `<foreign-language> <feed-noun>` where feed-noun is FEED / COMMENTARY / AUDIO / COMMS. "English" is deliberately excluded from the language list, and a feed noun must follow the language, so a team name like "Czechia" (contains "CZECH", no feed noun) never trips it.

## Tests

3 new tests (foreign feed -> non-English, English feed outranks it, team-name-alone guard). Full suite **3155 passed**. Verified against the exact live stream names that exposed the gap.

## Activation

Off by default behavior unchanged; only affects ordering when `widen_stream_pool` is on (currently enabled on the live box). Needs deploy + `docker restart` + a refresh/apply to re-order existing channels (reload unsafe until #110).