### PR TITLE
Reclaim orphaned scheduler thread on reload (#110)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import threading
+import types
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -2719,8 +2721,45 @@ def _action_show_status(settings: Dict[str, Any]) -> Dict[str, Any]:
 
 # ---------- scheduler ----------
 
-_scheduler_thread: Optional[threading.Thread] = None
-_scheduler_stop = threading.Event()
+# Scheduler state (the running thread + its stop Event) lives in a registry
+# stashed in sys.modules under a synthetic key, NOT in module globals, so it
+# SURVIVES a plugin reload. #110: the loader's force_reload path (reload
+# endpoint / .reload_token / settings-save) unloads this module by file path and
+# re-imports it WITHOUT calling stop() — it only calls stop() on disable/delete.
+# Module globals reset on reload, so the new incarnation could never see the
+# thread the old one started, orphaning it (and its DB connection) every reload.
+# That re-leaks the exact thread #82's stop() was meant to reclaim. Keeping the
+# state in a reload-stable registry lets the new incarnation's __init__ find and
+# tear down the prior thread before starting its own. The synthetic module has
+# no __file__/__path__ under the plugin dir, so the loader's _unload_path_modules
+# leaves it in place across reloads.
+_SCHEDULER_REGISTRY_KEY = "_dispatcharr_ranked_matchups_scheduler_state"
+
+
+def _scheduler_registry():
+    reg = sys.modules.get(_SCHEDULER_REGISTRY_KEY)
+    if reg is None:
+        reg = types.ModuleType(_SCHEDULER_REGISTRY_KEY)
+        reg.thread = None
+        reg.stop_event = None
+        sys.modules[_SCHEDULER_REGISTRY_KEY] = reg
+    return reg
+
+
+def _stop_scheduler(thread, stop_event, reason: str) -> None:
+    """Signal a scheduler thread to exit and join it briefly. The loop polls
+    its own stop_event between work units, so setting it drops the loop out at
+    its next wake-up. Join with a short timeout because the loader's reload path
+    blocks on this and we don't want a thread stuck mid-pipeline to wedge it."""
+    if stop_event is not None:
+        stop_event.set()
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=5.0)
+        if thread.is_alive():
+            logger.warning(
+                "[ranked_matchups] scheduler thread did not exit within 5s of "
+                "%s; it will linger until process exit", reason,
+            )
 
 
 def _parse_scheduled_times(raw: str) -> List[Tuple[int, int]]:
@@ -2761,30 +2800,35 @@ def _next_fire_time(times: List[Tuple[int, int]], tz, now: Optional[datetime] = 
     return min(future) if future else None
 
 
-def _scheduler_loop(plugin_ref):
-    """Auto-refresh + apply at every time listed in scheduled_times."""
-    while not _scheduler_stop.is_set():
+def _scheduler_loop(plugin_ref, stop_event):
+    """Auto-refresh + apply at every time listed in scheduled_times.
+
+    stop_event is THIS thread's own Event, held in the reload-stable registry
+    (#110), not a module global: a later reload can stop this exact thread even
+    after the module that started it has been unloaded and its globals reset.
+    """
+    while not stop_event.is_set():
         try:
             settings = plugin_ref.get_current_settings()
             if not settings.get("auto_refresh_enabled", False):
-                _scheduler_stop.wait(timeout=300)
+                stop_event.wait(timeout=300)
                 continue
             tz = _resolve_tz(settings.get("local_timezone", "UTC"))
             times = _parse_scheduled_times(settings.get("scheduled_times", "0400"))
             if not times:
                 logger.warning("[ranked_matchups] no valid scheduled_times; idling 5m")
-                _scheduler_stop.wait(timeout=300)
+                stop_event.wait(timeout=300)
                 continue
             target = _next_fire_time(times, tz)
             if target is None:
-                _scheduler_stop.wait(timeout=300)
+                stop_event.wait(timeout=300)
                 continue
             sleep_s = (target - datetime.now(tz)).total_seconds()
             logger.info(
                 "[ranked_matchups] scheduler sleeping %.0fs until %s (next of %s)",
                 sleep_s, target.isoformat(), times,
             )
-            if _scheduler_stop.wait(timeout=sleep_s):
+            if stop_event.wait(timeout=sleep_s):
                 return
             logger.info("[ranked_matchups] scheduler firing auto_pipeline")
             # Delegates to the shared lock/inflight/subprocess path so the
@@ -2796,7 +2840,7 @@ def _scheduler_loop(plugin_ref):
             tasks.run_scheduled_pipeline(settings)
         except Exception:
             logger.exception("[ranked_matchups] scheduler loop crashed; sleeping 10m")
-            _scheduler_stop.wait(timeout=600)
+            stop_event.wait(timeout=600)
 
 
 _SCHEDULER_LOCK_KEY = f"plugins:{PLUGIN_KEY}:scheduler:lock"
@@ -2833,14 +2877,21 @@ class Plugin:
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than
         # relying on stale init-time settings.
-        global _scheduler_thread
-        if _scheduler_thread is None or not _scheduler_thread.is_alive():
-            _scheduler_stop.clear()
-            t = threading.Thread(target=_scheduler_loop, args=(self,), daemon=True,
-                                 name="ranked_matchups-scheduler")
-            t.start()
-            _scheduler_thread = t
-            logger.info("[ranked_matchups] scheduler thread started (pid=%s)", os.getpid())
+        reg = _scheduler_registry()
+        # #110: the loader reloads us without calling stop(), so a thread started
+        # by a PRIOR module incarnation is still running and is only reachable
+        # via the reload-stable registry. Reclaim and stop it here before
+        # starting our own, otherwise every reload leaks a thread + DB connection
+        # (the #82 leak, through the reload path #82's stop() never covered).
+        if reg.thread is not None and reg.thread.is_alive():
+            _stop_scheduler(reg.thread, reg.stop_event, "reload")
+        stop_event = threading.Event()
+        t = threading.Thread(target=_scheduler_loop, args=(self, stop_event), daemon=True,
+                             name="ranked_matchups-scheduler")
+        t.start()
+        reg.thread = t
+        reg.stop_event = stop_event
+        logger.info("[ranked_matchups] scheduler thread started (pid=%s)", os.getpid())
 
     def get_current_settings(self) -> Dict[str, Any]:
         try:
@@ -2853,35 +2904,22 @@ class Plugin:
         return {}
 
     def stop(self, context: Optional[Dict[str, Any]] = None) -> None:
-        """Tear down the scheduler thread when the loader disables /
-        reloads / deletes the plugin. The Dispatcharr plugin loader
-        contract calls this on every lifecycle change (Plugins.md). The
-        thread keeps polling settings from Postgres on a 5-min loop;
-        without this teardown each reload leaks one thread per uwsgi
-        worker, each holding a DB connection, until Postgres's
-        max_connections cap is hit and every API request 500s with
-        "FATAL: sorry, too many clients already" (#82).
+        """Tear down the scheduler thread when the loader disables / deletes the
+        plugin. The loader calls stop() on disable/delete (NOT on reload, see
+        #110), so the reload-orphan reclaim lives in __init__; this path handles
+        the explicit-teardown case. Without it the thread keeps polling Postgres
+        on a 5-min loop, leaking a DB connection per worker until max_connections
+        is hit and every API request 500s with "too many clients" (#82).
 
-        Signal-then-join: the scheduler loop polls
-        `_scheduler_stop.wait(timeout=...)` between work units, so
-        setting the event drops the loop out at its next wake-up.
-        Join with a short timeout because the loader's reload path
-        blocks on stop() and we don't want a stuck thread to wedge
-        the whole reload.
+        State is read from the reload-stable registry (#110), not module globals,
+        so stop() reclaims the live thread even if it was started by a different
+        module incarnation than the one this instance belongs to.
         """
         del context  # unused; conform to loader's stop(context) shape
-        _scheduler_stop.set()
-        global _scheduler_thread
-        t = _scheduler_thread
-        if t is not None and t.is_alive():
-            t.join(timeout=5.0)
-            if t.is_alive():
-                logger.warning(
-                    "[ranked_matchups] scheduler thread did not exit "
-                    "within 5s of stop signal; loader will proceed but "
-                    "the daemon thread will linger until process exit"
-                )
-        _scheduler_thread = None
+        reg = _scheduler_registry()
+        _stop_scheduler(reg.thread, reg.stop_event, "stop signal")
+        reg.thread = None
+        reg.stop_event = None
 
     def run(self, action: Optional[str] = None,
             params: Optional[Dict[str, Any]] = None,

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1783,134 +1783,125 @@ class TestBuildStandingsPostureLine:
         assert md_idx < st_idx < nar_idx
 
 
-class TestPluginStopTeardown:
-    """The Plugin class spawns a daemon scheduler thread in __init__.
-    Without a stop() teardown, plugin reloads leak one thread per
-    uwsgi worker per reload; each thread holds a Postgres connection
-    via its 5-min settings-polling loop. Over a day of reloads, the
-    embedded Postgres's `max_connections=200` cap is hit and every
-    API request 500s with "FATAL: sorry, too many clients already"
-    (#82, reproduced live in the running Dispatcharr container on
-    2026-05-26).
+class _StubThread:
+    """Controllable stand-in for a scheduler thread. join() simulates the loop
+    exiting once its stop_event is set, exactly as the real loop does."""
 
-    Plugin.stop() signals the stop event and joins the thread so each
-    reload sees the old thread cleanly exit before the new one starts.
+    def __init__(self, stop_event):
+        self._alive = True
+        self.join_calls = 0
+        self._stop_event = stop_event
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        self.join_calls += 1
+        if self._stop_event is not None and self._stop_event.is_set():
+            self._alive = False
+
+
+class TestPluginStopTeardown:
+    """The Plugin class spawns a daemon scheduler thread in __init__. Without
+    teardown, every reload leaks one thread per uwsgi worker, each holding a
+    Postgres connection via its 5-min settings-poll loop, until max_connections
+    is hit and the API 500s with "too many clients" (#82).
+
+    #110: the loader unloads + re-imports this module on reload WITHOUT calling
+    stop() (it only calls stop() on disable/delete). So the scheduler (thread +
+    its stop Event) lives in a reload-stable registry, and __init__ reclaims and
+    stops a prior incarnation's thread before starting its own. These tests
+    drive that registry-based lifecycle.
     """
 
-    def test_stop_signals_and_clears_thread(self, plugin):
-        # Use a stub thread so the test isn't gated on Django being
-        # available (the real _scheduler_loop hits PluginConfig.objects
-        # on the first iteration).
+    @pytest.fixture(autouse=True)
+    def _isolate_registry(self, plugin):
+        # Snapshot + restore the reload-stable registry around each test so the
+        # scheduler tests don't leak state into one another.
         import threading
+        reg = plugin._scheduler_registry()
+        saved_thread, saved_event = reg.thread, reg.stop_event
+        reg.thread, reg.stop_event = None, None
+        yield reg
+        # Make sure no real thread we started lingers.
+        if reg.stop_event is not None:
+            reg.stop_event.set()
+        reg.thread, reg.stop_event = saved_thread, saved_event
 
-        class StubThread:
-            def __init__(self):
-                self._alive = True
-                self.join_calls = 0
-            def is_alive(self):
-                return self._alive
-            def join(self, timeout=None):
-                self.join_calls += 1
-                # Simulate the loop responding to _scheduler_stop being
-                # set: as soon as the stop event is set, the thread
-                # exits. (In production the loop calls
-                # _scheduler_stop.wait() between work units.)
-                if plugin._scheduler_stop.is_set():
-                    self._alive = False
+    def test_stop_signals_and_clears_registry(self, plugin, _isolate_registry):
+        import threading
+        reg = _isolate_registry
+        ev = threading.Event()
+        stub = _StubThread(ev)
+        reg.thread, reg.stop_event = stub, ev
 
-        stub = StubThread()
-        # Save/restore the module-level globals around the test so we
-        # don't disturb other tests that exercise the scheduler.
-        saved_thread = plugin._scheduler_thread
-        saved_stop_set = plugin._scheduler_stop.is_set()
-        try:
-            plugin._scheduler_thread = stub
-            plugin._scheduler_stop.clear()
-            inst = plugin.Plugin.__new__(plugin.Plugin)  # skip __init__'s thread spawn
+        inst = plugin.Plugin.__new__(plugin.Plugin)  # skip __init__'s thread spawn
+        inst.stop()
 
-            inst.stop()
+        assert ev.is_set()
+        assert stub.join_calls == 1
+        assert not stub.is_alive()
+        assert reg.thread is None and reg.stop_event is None
 
-            # Event was set, join was called, thread exited, module
-            # global was cleared.
-            assert plugin._scheduler_stop.is_set()
-            assert stub.join_calls == 1
-            assert not stub.is_alive()
-            assert plugin._scheduler_thread is None
-        finally:
-            plugin._scheduler_thread = saved_thread
-            if saved_stop_set:
-                plugin._scheduler_stop.set()
-            else:
-                plugin._scheduler_stop.clear()
-
-    def test_stop_is_safe_when_thread_already_dead(self, plugin):
-        # Defensive: stop() called twice in a row (e.g., loader unload
-        # races with disable signal) must not raise on the second call
-        # even though the thread is already gone.
-        saved_thread = plugin._scheduler_thread
-        saved_stop_set = plugin._scheduler_stop.is_set()
-        try:
-            plugin._scheduler_thread = None
-            plugin._scheduler_stop.clear()
-            inst = plugin.Plugin.__new__(plugin.Plugin)
-            inst.stop()  # no-op path: thread is None
-            inst.stop()  # repeated: still no-op
-            assert plugin._scheduler_thread is None
-        finally:
-            plugin._scheduler_thread = saved_thread
-            if saved_stop_set:
-                plugin._scheduler_stop.set()
-            else:
-                plugin._scheduler_stop.clear()
-
-    def test_stop_accepts_context_argument(self, plugin):
-        # The Dispatcharr loader contract is `stop(self, context)`.
-        # Plugins.md confirms: the loader passes the context dict on
-        # every lifecycle stop. The signature must accept it without
-        # complaint.
+    def test_stop_is_safe_when_no_thread(self, plugin, _isolate_registry):
+        # Defensive: stop() called with an empty registry (or twice) must not
+        # raise (loader unload can race a disable signal).
         inst = plugin.Plugin.__new__(plugin.Plugin)
-        # No-context call AND with-context call both work.
+        inst.stop()
+        inst.stop()
+        assert _isolate_registry.thread is None
+
+    def test_stop_accepts_context_argument(self, plugin, _isolate_registry):
+        # Loader contract is stop(self, context); it passes a dict on lifecycle
+        # stops. The signature must accept it (and None, and nothing).
+        inst = plugin.Plugin.__new__(plugin.Plugin)
         inst.stop()
         inst.stop({"settings": {}})
         inst.stop(None)
 
-    def test_subsequent_init_after_stop_creates_fresh_thread(self, plugin, monkeypatch):
-        # After stop(), a new Plugin() must be able to spawn a fresh
-        # scheduler thread. This is the reload cycle: loader calls
-        # stop() then re-instantiates Plugin().
+    def test_init_spawns_thread_into_registry(self, plugin, monkeypatch, _isolate_registry):
         import threading
-
         spawned = []
-        real_thread = threading.Thread
 
-        class TrackingThread(real_thread):
+        class TrackingThread(threading.Thread):
             def __init__(self, *a, **kw):
                 spawned.append(kw.get("name") or "<unnamed>")
                 super().__init__(*a, **kw)
-            def start(self):
-                # Don't actually start: we don't want a live thread
-                # touching DB / FD in tests.
+            def start(self):  # don't run a live thread in tests
                 pass
 
         monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
-        saved_thread = plugin._scheduler_thread
-        try:
-            plugin._scheduler_thread = None
-            plugin._scheduler_stop.clear()
-            # First instantiation: spawns scheduler thread.
-            inst1 = plugin.Plugin()
-            assert len(spawned) == 1
-            assert spawned[0] == "ranked_matchups-scheduler"
+        plugin.Plugin()
+        assert spawned == ["ranked_matchups-scheduler"]
+        assert _isolate_registry.thread is not None
+        assert _isolate_registry.stop_event is not None
 
-            # Now stop + re-instantiate (the reload path).
-            inst1.stop()
-            inst2 = plugin.Plugin()
+    def test_reload_init_reclaims_and_stops_orphan(self, plugin, monkeypatch, _isolate_registry):
+        # THE #110 fix: the loader reloads WITHOUT calling stop(), so a thread
+        # from the prior module incarnation is still running, reachable only via
+        # the reload-stable registry. A fresh Plugin() (the reload's new
+        # instance) must stop that orphan before starting its own thread.
+        import threading
+        reg = _isolate_registry
+        orphan_event = threading.Event()
+        orphan = _StubThread(orphan_event)
+        reg.thread, reg.stop_event = orphan, orphan_event
 
-            # Second spawn happened: no skipped instantiation.
-            assert len(spawned) == 2
-        finally:
-            plugin._scheduler_thread = saved_thread
-            plugin._scheduler_stop.clear()
+        class TrackingThread(threading.Thread):
+            def start(self):  # don't run a live thread in tests
+                pass
+
+        monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
+        plugin.Plugin()  # the reloaded incarnation
+
+        # Orphan was signaled, joined, and exited; registry now holds a NEW
+        # thread + event, not the orphan.
+        assert orphan_event.is_set()
+        assert orphan.join_calls >= 1
+        assert not orphan.is_alive()
+        assert reg.thread is not orphan
+        assert isinstance(reg.thread, TrackingThread)
+        assert reg.stop_event is not orphan_event
 
 
 class TestDedupSeriesGames:


### PR DESCRIPTION
## Problem

The Dispatcharr loader calls a plugin's `stop()` only on disable/delete (`loader.py` `stop_plugin`/`stop_all_plugins`). The **force_reload** path (reload endpoint, `.reload_token`, settings-save) unloads the module by file path and re-imports it **without** `stop()`. The scheduler thread + stop Event lived in module globals, which reset on reload, so the new incarnation could never see or stop the thread the old one started. Every reload orphaned a scheduler thread holding a Postgres connection via its 5-min poll loop — the #82 leak, re-opened through the reload path #82's `stop()` never covered. Live this accumulated until the plugin HTTP endpoints wedged (surfaced while shipping #108/#112).

## Fix

Move the scheduler state into a **reload-stable registry** stashed in `sys.modules` under a synthetic key (`_dispatcharr_ranked_matchups_scheduler_state`). A `types.ModuleType` has no `__file__`/`__path__` under the plugin dir, so the loader's `_unload_path_modules` leaves it in place across reloads.

- `__init__` reclaims and stops any thread a prior incarnation left running (reachable only via the registry) before starting its own. This is where the reload-orphan gets cleaned up, since the loader won't call `stop()`.
- The loop carries its own stop Event (passed in, held in the registry), so a later incarnation can stop it even after the starting module's globals are gone.
- `stop()` reads the same registry (still handles the disable/delete path).
- Shared `_stop_scheduler(thread, event, reason)` helper for signal-then-join (5s bounded, so a thread stuck mid-pipeline can't wedge the reload).

The underlying loader gap (no `stop()` on reload) is upstream Dispatcharr; this is the plugin-side self-defense.

## Tests

`TestPluginStopTeardown` rewritten for the registry lifecycle, including the core case: a fresh `Plugin()` (the reload's new instance) reclaims and stops a prior orphan, leaving a single fresh thread. Full suite **3156 passed**.

## Verification plan

Off-by-default-irrelevant (lifecycle code). After deploy + restart, the definitive check is a live **reload** (`POST /reload/`): pre-fix it wedged/leaked; post-fix it should complete fast, leave exactly one scheduler thread, and not grow the DB connection count. That makes future plugin updates hot-reloadable instead of restart-only.