### PR TITLE
Keep scheduler reload-reclaim non-blocking under gevent (#110 follow-up)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2746,14 +2746,23 @@ def _scheduler_registry():
     return reg
 
 
-def _stop_scheduler(thread, stop_event, reason: str) -> None:
-    """Signal a scheduler thread to exit and join it briefly. The loop polls
-    its own stop_event between work units, so setting it drops the loop out at
-    its next wake-up. Join with a short timeout because the loader's reload path
-    blocks on this and we don't want a thread stuck mid-pipeline to wedge it."""
+def _stop_scheduler(thread, stop_event, reason: str, *, join: bool = True) -> None:
+    """Signal a scheduler thread to exit. The loop polls its own stop_event
+    between work units, so setting it drops the loop out at its next wake-up
+    (immediate: set() wakes a thread waiting on the Event).
+
+    join controls whether we then block to confirm exit:
+      - join=True (disable/delete via stop()): block briefly; teardown is not
+        on a latency-sensitive path and confirming exit is tidy.
+      - join=False (reload via __init__): DO NOT block. __init__ runs inside a
+        gevent request greenlet during discovery; a blocking join there stalls
+        the worker's whole hub (every greenlet shares one OS thread). The orphan
+        exits on its own once signaled, and __init__ repoints the registry at
+        the replacement immediately after, so the signaled orphan is unreachable
+        and harmless while it unwinds. Keeps the hot reload path non-blocking."""
     if stop_event is not None:
         stop_event.set()
-    if thread is not None and thread.is_alive():
+    if join and thread is not None and thread.is_alive():
         thread.join(timeout=5.0)
         if thread.is_alive():
             logger.warning(
@@ -2884,7 +2893,7 @@ class Plugin:
         # starting our own, otherwise every reload leaks a thread + DB connection
         # (the #82 leak, through the reload path #82's stop() never covered).
         if reg.thread is not None and reg.thread.is_alive():
-            _stop_scheduler(reg.thread, reg.stop_event, "reload")
+            _stop_scheduler(reg.thread, reg.stop_event, "reload", join=False)
         stop_event = threading.Event()
         t = threading.Thread(target=_scheduler_loop, args=(self, stop_event), daemon=True,
                              name="ranked_matchups-scheduler")

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1876,11 +1876,14 @@ class TestPluginStopTeardown:
         assert _isolate_registry.thread is not None
         assert _isolate_registry.stop_event is not None
 
-    def test_reload_init_reclaims_and_stops_orphan(self, plugin, monkeypatch, _isolate_registry):
+    def test_reload_init_reclaims_orphan_without_blocking(self, plugin, monkeypatch, _isolate_registry):
         # THE #110 fix: the loader reloads WITHOUT calling stop(), so a thread
         # from the prior module incarnation is still running, reachable only via
         # the reload-stable registry. A fresh Plugin() (the reload's new
-        # instance) must stop that orphan before starting its own thread.
+        # instance) must SIGNAL that orphan to exit and repoint the registry at
+        # its own thread. The reload path must NOT block-join (it runs in a
+        # gevent request greenlet during discovery); the orphan self-exits on
+        # the signal, so join is not called here.
         import threading
         reg = _isolate_registry
         orphan_event = threading.Event()
@@ -1894,14 +1897,26 @@ class TestPluginStopTeardown:
         monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
         plugin.Plugin()  # the reloaded incarnation
 
-        # Orphan was signaled, joined, and exited; registry now holds a NEW
-        # thread + event, not the orphan.
+        # Orphan was signaled (it will exit on its next wake), NOT join-blocked,
+        # and the registry now holds a NEW thread + event, not the orphan.
         assert orphan_event.is_set()
-        assert orphan.join_calls >= 1
-        assert not orphan.is_alive()
+        assert orphan.join_calls == 0  # reload path must not block on join
         assert reg.thread is not orphan
         assert isinstance(reg.thread, TrackingThread)
         assert reg.stop_event is not orphan_event
+
+    def test_stop_still_joins_on_teardown(self, plugin, _isolate_registry):
+        # The disable/delete path (stop()) is not latency-sensitive and SHOULD
+        # block-join to confirm the thread exited.
+        import threading
+        reg = _isolate_registry
+        ev = threading.Event()
+        stub = _StubThread(ev)
+        reg.thread, reg.stop_event = stub, ev
+        plugin.Plugin.__new__(plugin.Plugin).stop()
+        assert ev.is_set()
+        assert stub.join_calls == 1
+        assert not stub.is_alive()
 
 
 class TestDedupSeriesGames:


### PR DESCRIPTION
Follow-up to #110/#114. The reclaim join ran inside `Plugin.__init__`, i.e. in a gevent request greenlet during discovery; a blocking join there stalls the worker hub (all greenlets share one OS thread) and contributes to transient reload wedges under pressure. Make the reload path signal-only (`_stop_scheduler(..., join=False)`): set the orphan's stop Event and return; the orphan self-exits on its next wake and the registry is repointed immediately. `stop()` (disable/delete) keeps join=True. Leak fix unchanged (connections still plateau). Full suite 3157 passed. Refs #110