### PR TITLE
Stable day-chronological channel numbers (no client TVG-ID setup) (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+### Changed
+
+- **Stable, day-chronological channel numbers (#119).** Virtual channel numbers
+  are now a pure function of each game's kickoff day plus a per-game hash, so a
+  given game keeps the same number for its whole life instead of being renumbered
+  by ★ rank on every refresh. This makes the EPG bind correctly under
+  Dispatcharr's **default** `tvg_id_source=channel_number` with no client setup,
+  fixing the name↔guide mismatch from #117 at the source rather than via a
+  required client setting. Earlier-day games still get lower numbers, so today's
+  games sort first; within a day, order is stable-but-arbitrary (by hash) rather
+  than by ★ score. The prior "set TVG-ID Source = TVG-ID" requirement (banner +
+  README step 5) is removed; that mode still works but is no longer needed.
+
 ### Added
 
 - **Tuning recipes in SCORING.md** plus an in-settings link to them. The

--- a/README.md
+++ b/README.md
@@ -163,22 +163,19 @@ form will collect everything needed to scope it.
 
 4. Run **Refresh + apply now** to populate.
 
-5. **Point your client at the right URLs (required).** On the Channels page,
-   use the **M3U** and **EPG** buttons to generate URLs, and on BOTH set
-   **TVG-ID Source = TVG-ID** (not the default *Channel Number*). Then load
-   those URLs in TiviMate / Plex / your client.
+5. **Load the M3U and EPG URLs in your client.** On the Channels page, use the
+   **M3U** and **EPG** buttons to generate URLs and load them in TiviMate /
+   Plex / your client. No special TVG-ID setting is required: the guide binds
+   correctly under Dispatcharr's default *Channel Number* source.
 
-   > **Why this matters.** These channels are renumbered by ★ score on every
-   > refresh, so a given channel *number* maps to a different game over time.
-   > With the default `tvg_id_source=channel_number`, your client binds the
-   > guide to channels by that volatile number, and because Dispatcharr caches
-   > the EPG separately from the playlist, a post-refresh renumber pairs the
-   > new channel's name with the previous cycle's program for that number
-   > (e.g. an "Ole Miss at North Carolina" channel showing the "Iran vs New
-   > Zealand" guide entry). The plugin already writes a stable per-game
-   > `tvg_id`, so `TVG-ID Source = TVG-ID` binds name and guide by that stable
-   > id and is immune to the reshuffle. Both the M3U and EPG URLs must use the
-   > same source.
+   > **Why no setup is needed.** Each game's channel *number* is now stable for
+   > the life of that game (it's derived from the kickoff date plus a per-game
+   > hash, not from its ★ rank), and earlier-day games get lower numbers so
+   > today's games still sort first. Because the number no longer moves when the
+   > slate re-ranks, binding the guide by channel number stays correct even
+   > though Dispatcharr caches the EPG separately from the playlist. (Setting
+   > **TVG-ID Source = TVG-ID** on both URLs also works and binds by the stable
+   > per-game `tvg_id` instead, but it is no longer required.)
 
 ## Pipeline
 

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/_util.py
+++ b/_util.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import math
 import random
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 
 
@@ -34,6 +34,57 @@ def stable_hash_int(s: str) -> int:
     uniqueness and is identical across processes / restarts."""
     digest = hashlib.md5(s.encode("utf-8")).hexdigest()
     return int(digest[:16], 16)
+
+
+# Fixed anchor for stable_channel_number's day offset. DO NOT change this date:
+# every virtual channel's number is measured in days from this origin, so moving
+# it shifts EVERY channel number by the same delta in one apply (a one-time mass
+# renumber). It only needs to sit on or before the earliest kickoff the plugin
+# will ever schedule; the plugin fetches upcoming games, so any date safely in
+# the past works and 2024-01-01 leaves comfortable headroom.
+CHANNEL_NUMBER_ORIGIN = date(2024, 1, 1)
+
+# Decimal places channel numbers are rounded to. Single source of truth: the
+# fraction-bucket count, the rounding below, and plugin.py's collision nudge all
+# derive from it, so the hash-fraction granularity always matches the rounding
+# grid. 9 keeps same-day collisions astronomically unlikely (birthday bound over
+# a realistic slate of <~100 games is ~1e-5) while staying within float
+# precision when added to a 4-6 digit integer base.
+CHANNEL_NUMBER_DECIMALS = 9
+
+# Stable hash buckets for the fractional part: one per rounding step, so every
+# distinct bucket survives the round() below as a distinct number.
+_CHANNEL_NUMBER_FRAC_BUCKETS = 10 ** CHANNEL_NUMBER_DECIMALS
+
+
+def stable_channel_number(
+    virtual_base: int, start_utc: datetime, marker: str, tz
+) -> float:
+    """Stable, day-chronological channel number for a virtual game channel.
+
+    PURE FUNCTION of the game's immutable kickoff and its `marker`: the SAME
+    game always maps to the SAME number regardless of how the slate is ranked
+    or which other games are present. That stability is the whole point.
+    Dispatcharr's default output mode (``tvg_id_source=channel_number``) binds
+    the EPG to a channel BY its channel number, so a volatile number pairs the
+    wrong programme with a channel after a re-rank (see #117). A stable number
+    makes the default mode bind correctly with no client configuration.
+
+      integer part = virtual_base + days-from-origin (in the user's local tz)
+      fraction     = stable hash of marker in [0, 1)
+
+    The day offset makes earlier-kickoff days sort first (today's games lead the
+    list, preserving the prior behaviour's intent), while the hash fraction
+    gives each same-day game a distinct, stable slot. Within a day the order is
+    stable-but-arbitrary (by hash), not by kickoff time; see #119 for the
+    trade-off (chronological-within-day would force much larger channel
+    numbers). Earlier kickoffs in absolute time still get strictly lower
+    numbers across days.
+    """
+    local_date = start_utc.astimezone(tz).date()
+    day_offset = max(0, (local_date - CHANNEL_NUMBER_ORIGIN).days)
+    frac = (stable_hash_int(marker) % _CHANNEL_NUMBER_FRAC_BUCKETS) / _CHANNEL_NUMBER_FRAC_BUCKETS
+    return round(virtual_base + day_offset + frac, CHANNEL_NUMBER_DECIMALS)
 
 
 def extract_game_number_after_marker(headline: str, marker: str) -> Optional[int]:

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.2.0",
-  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. IMPORTANT: generate your M3U and EPG URLs with TVG-ID Source = TVG-ID (not the default Channel Number) on both, or your client will pair a channel's name with another game's guide.",
+  "version": "1.3.0",
+  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Works with Dispatcharr's default M3U/EPG output settings; no special TVG-ID Source is required.",
   "author": "Jake (with Claude)",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",
@@ -10,8 +10,8 @@
     {
       "id": "_section_client_setup",
       "type": "info",
-      "label": "⚠ Client setup: set TVG-ID Source = TVG-ID",
-      "description": "When you generate your M3U and EPG URLs (Channels page → M3U / EPG buttons), set TVG-ID Source to 'TVG-ID' on BOTH (not the default 'Channel Number'). These channels re-rank by score every refresh, so their numbers change; binding the guide by channel number makes your client show one game's name over another game's program (e.g. an 'Ole Miss' channel showing the 'Iran vs New Zealand' guide). TVG-ID binds by a stable per-game id and is shuffle-proof."
+      "label": "Guide binding: no client setup needed",
+      "description": "Load the M3U and EPG URLs as-is; the guide binds correctly under Dispatcharr's default TVG-ID Source = Channel Number. Each game's channel number is stable for the life of the game (derived from its kickoff day plus a per-game hash, not from its ★ rank), and earlier-day games get lower numbers so today's games sort first. Setting TVG-ID Source = TVG-ID on both URLs also works but is not required."
     },
     {
       "id": "_section_sources",

--- a/plugin.py
+++ b/plugin.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import sys
 import threading
@@ -43,6 +44,7 @@ except ImportError:  # py < 3.9 fallback (won't hit on Dispatcharr's Python 3.13
     ZoneInfo = None  # type: ignore
 
 from ._util import (
+    CHANNEL_NUMBER_DECIMALS,
     group_advance_text,
     group_phase_text,
     group_results_lines,
@@ -51,6 +53,7 @@ from ._util import (
     series_phase_text,
     series_record_text,
     series_result_lines,
+    stable_channel_number,
     stable_hash_int,
 )
 
@@ -1471,12 +1474,65 @@ def _resolve_virtual_base(settings: Dict[str, Any], highest_non_virtual: float) 
     return candidate if candidate > 1 else _AUTO_BASE_FALLBACK
 
 
-def _resolve_park_base(target_base: int, num_games: int) -> int:
+def _resolve_park_base(max_target_number: float) -> int:
     """Pick a parking range that's guaranteed past every target number we'll
     write. Parking + writing happens in one transaction within our own group,
     so we only need to clear our own target range; +1000 slack keeps the
-    parking range comfortably out of any plausible target_base growth."""
-    return target_base + max(num_games, 0) + 1000
+    parking range comfortably out of the highest target we're about to assign.
+
+    `max_target_number` is the largest channel number this apply will write
+    (the channel numbers are now day-offset based, so the ceiling is driven by
+    how far ahead the slate reaches, NOT by the game count). Callers pass the
+    target base itself when the slate is empty so the result stays sane."""
+    return int(math.floor(max_target_number)) + 1000
+
+
+def _assign_channel_numbers(
+    games: List[Dict[str, Any]], virtual_base: int, tz
+) -> Dict[str, float]:
+    """Map each game's marker to its stable channel number for this apply.
+
+    Numbers come from `stable_channel_number` (a pure function of kickoff +
+    marker), so a given game keeps the same number across applies regardless of
+    how the slate is ranked. That stability is what lets Dispatcharr's default
+    ``tvg_id_source=channel_number`` bind the EPG correctly (#119).
+
+    Two DIFFERENT games can only land on the same rounded number if they share
+    a local day AND a hash bucket (~1e-5 odds on a realistic slate). That would
+    violate the unique ``(channel_group, channel_number)`` constraint, so we
+    resolve it deterministically: walk the games in (number, marker) order and
+    nudge any exact duplicate up by a hair. This perturbs ONLY the colliding
+    game, never the rest, so every other game keeps its pure stable number and
+    the resolution is reproducible across applies."""
+    pairs: List[Tuple[str, float]] = []
+    for g in games:
+        start_dt = parse_iso_utc(g.get("start_time_utc"))
+        if start_dt is None:
+            continue
+        marker = _build_marker_key(g)
+        pairs.append((marker, stable_channel_number(virtual_base, start_dt, marker, tz)))
+
+    pairs.sort(key=lambda mn: (mn[1], mn[0]))
+    assigned: Dict[str, float] = {}
+    used: set = set()
+    collisions = 0
+    # Smallest increment that survives the shared rounding grid: one step nudges
+    # an exact duplicate onto the next free slot without crossing into the next
+    # day band (which is 1.0 away).
+    nudge = 10 ** -CHANNEL_NUMBER_DECIMALS
+    for marker, number in pairs:
+        while number in used:
+            number = round(number + nudge, CHANNEL_NUMBER_DECIMALS)
+            collisions += 1
+        used.add(number)
+        assigned[marker] = number
+    if collisions:
+        logger.warning(
+            "[ranked_matchups] resolved %d channel-number collision(s) by nudging; "
+            "widen _CHANNEL_NUMBER_FRAC_BUCKETS in _util.py if this recurs",
+            collisions,
+        )
+    return assigned
 
 
 def _build_signals_score_from_payload(g: Dict[str, Any]):
@@ -2063,12 +2119,18 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         .aggregate(m=_Max("channel_number"))["m"] or 0
     )
     virtual_base = _resolve_virtual_base(settings, highest_other)
-    park_base = _resolve_park_base(virtual_base, len(games))
+    # Stable per-game channel numbers (marker -> number). Computed once up front
+    # so collision resolution sees the whole slate and so park_base can be set
+    # above the true ceiling (day-offset based, not game-count based).
+    chnum_by_marker = _assign_channel_numbers(games, virtual_base, apply_tz)
+    max_target = max(chnum_by_marker.values(), default=float(virtual_base))
+    park_base = _resolve_park_base(max_target)
     logger.info(
-        "[ranked_matchups] virtual_base=%d (highest_other=%s, setting=%r), park_base=%d",
+        "[ranked_matchups] virtual_base=%d (highest_other=%s, setting=%r), "
+        "max_target=%.3f, park_base=%d",
         virtual_base, highest_other,
         settings.get("virtual_channel_base", DEFAULT_VIRTUAL_CHANNEL_BASE),
-        park_base,
+        max_target, park_base,
     )
 
     created = 0
@@ -2228,7 +2290,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             for ch in existing_virtuals.values():
                 ch.save(update_fields=["channel_number"])
 
-        for cache_idx, g in enumerate(games):
+        for g in games:
             # channel_ids is the full list of matched provider channels (e.g.
             # multiple regional/quality variants of the same fixture). Falls
             # back to the single-channel `channel_id` key for cache entries
@@ -2254,26 +2316,6 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 else:
                     skipped_unmatched += 1
                     continue
-
-            # Target channel number = base + cache index. Today's games are at
-            # the front of the cache, so they get the lowest numbers (TiviMate
-            # and other IPTV clients sort by channel number → today's games
-            # appear first in the user's Top Matchups group).
-            #
-            # DO NOT make the EPG↔channel binding depend on this number, and DO
-            # NOT try to stabilize it per game to "fix" a guide mismatch. This
-            # number is INTENTIONALLY volatile: it re-ranks by ★ score every
-            # refresh, so a given number maps to a different game across applies.
-            # The stable per-game identity is `marker`, written to BOTH
-            # Channel.tvg_id and ProgramData.tvg_id below. Clients MUST generate
-            # their M3U and EPG URLs with tvg_id_source=tvg_id so the guide binds
-            # by that stable marker. Dispatcharr's default tvg_id_source=
-            # channel_number binds by THIS number instead, and because it caches
-            # the EPG XML separately from the M3U, a post-refresh renumber pairs
-            # the new channel's name with the prior cycle's guide entry for that
-            # number (e.g. "Ole Miss at North Carolina" name over an "Iran vs
-            # New Zealand" program). Root-caused 2026-06-12.
-            target_chnum = float(virtual_base + cache_idx)
 
             marker = _build_marker_key(g)
             seen_markers.add(marker)
@@ -2301,6 +2343,15 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             if start_dt is None:
                 logger.warning("[ranked_matchups] bad start_time_utc on %s", marker)
                 continue
+
+            # Stable, day-chronological channel number for this game. Keyed by
+            # marker (not slate position) so it never moves across applies, which
+            # is what makes Dispatcharr's DEFAULT tvg_id_source=channel_number
+            # bind the EPG correctly with no client setup (#119). Earlier-day
+            # kickoffs still sort first. _assign_channel_numbers computed the
+            # whole map up front; marker is guaranteed present here because that
+            # map skips exactly the same bad-start_time rows we just skipped.
+            target_chnum = chnum_by_marker[marker]
 
             new_name = format_channel_name(
                 g["sport_prefix"], signals, score, g["home"], g["away"],
@@ -2923,7 +2974,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.2.0"
+    version = "1.3.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -8,6 +8,7 @@ __init__.py."""
 import importlib.util
 import os
 import sys
+from datetime import timezone
 
 import pytest
 
@@ -503,26 +504,84 @@ class TestResolveVirtualBase:
 
 
 class TestResolvParkBase:
-    def test_park_above_target_range(self, plugin):
-        # park must be past base + N (the highest target we'll write).
-        base = 9000
-        n_games = 25
-        park = plugin._resolve_park_base(base, n_games)
-        assert park > base + n_games
+    def test_park_above_max_target(self, plugin):
+        # park must be past the highest target number we'll write this apply.
+        max_target = 9742.512345
+        park = plugin._resolve_park_base(max_target)
+        assert park > max_target
 
-    def test_dynamic_with_huge_n(self, plugin):
-        # Even with a giant cache, park stays past targets.
-        assert plugin._resolve_park_base(100, 5000) > 100 + 5000
+    def test_park_above_fractional_ceiling(self, plugin):
+        # The ceiling is a fractional float (day_offset + hash frac); park must
+        # clear its integer ceiling, not just its floor.
+        assert plugin._resolve_park_base(9000.999) > 9001
 
-    def test_zero_games(self, plugin):
-        # Empty cache shouldn't crash; we still want a sane park base.
-        park = plugin._resolve_park_base(9000, 0)
-        assert park > 9000
+    def test_empty_slate_uses_base(self, plugin):
+        # Empty cache passes the bare virtual_base; result stays sane and above.
+        assert plugin._resolve_park_base(9000.0) > 9000
 
-    def test_negative_games_clamped(self, plugin):
-        # Defensive: never compute a park base below the target base.
-        park = plugin._resolve_park_base(9000, -10)
-        assert park > 9000
+
+class TestAssignChannelNumbers:
+    """Stable per-game channel numbering (#119). The map must be position-
+    independent (the #117/#119 fix) and collision-free."""
+
+    @staticmethod
+    def _game(marker_id, start_iso, sport="cfb"):
+        # Minimal cache-shaped row: _assign_channel_numbers only reads
+        # start_time_utc + whatever _build_marker_key needs (sport_prefix +
+        # extra.cfbd_id here gives a deterministic marker).
+        return {
+            "sport_prefix": sport,
+            "start_time_utc": start_iso,
+            "extra": {"cfbd_id": marker_id},
+        }
+
+    def test_same_game_keeps_number_when_slate_reordered(self, plugin):
+        # THE regression: under the old `virtual_base + cache_idx` scheme a
+        # game's number changed when the slate re-ranked. Now reordering the
+        # input list must not change any game's assigned number.
+        games = [
+            self._game(1, "2026-06-13T16:00:00Z"),
+            self._game(2, "2026-06-13T20:00:00Z"),
+            self._game(3, "2026-06-14T18:00:00Z"),
+        ]
+        a = plugin._assign_channel_numbers(games, 1000, timezone.utc)
+        b = plugin._assign_channel_numbers(list(reversed(games)), 1000, timezone.utc)
+        assert a == b
+        assert len(a) == 3
+
+    def test_all_numbers_unique(self, plugin):
+        games = [
+            self._game(i, f"2026-06-{13 + (i % 5)}T{12 + (i % 8):02d}:00:00Z")
+            for i in range(60)
+        ]
+        assigned = plugin._assign_channel_numbers(games, 5000, timezone.utc)
+        assert len(assigned) == 60
+        assert len(set(assigned.values())) == 60
+
+    def test_skips_bad_start_time(self, plugin):
+        games = [
+            self._game(1, "2026-06-13T16:00:00Z"),
+            self._game(2, "not-a-date"),
+            self._game(3, None),
+        ]
+        assigned = plugin._assign_channel_numbers(games, 1000, timezone.utc)
+        markers = set(assigned.keys())
+        assert plugin._build_marker_key(games[0]) in markers
+        assert plugin._build_marker_key(games[1]) not in markers
+        assert plugin._build_marker_key(games[2]) not in markers
+
+    def test_collisions_resolved_to_unique_values(self, plugin, monkeypatch):
+        # Force every game onto the SAME raw number; the resolver must still
+        # hand back all-distinct numbers (nudge path) and stay deterministic.
+        monkeypatch.setattr(plugin, "stable_channel_number",
+                            lambda base, start, marker, tz: 1000.0)
+        games = [self._game(i, "2026-06-13T16:00:00Z") for i in range(5)]
+        assigned = plugin._assign_channel_numbers(games, 1000, timezone.utc)
+        assert len(assigned) == 5
+        assert len(set(assigned.values())) == 5
+        # Deterministic across calls.
+        again = plugin._assign_channel_numbers(games, 1000, timezone.utc)
+        assert assigned == again
 
 
 class TestBuildSourcesToggles:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,10 @@
 """Tests for _util.parse_iso_utc, stable_hash_int, extract_game_number_after_marker,
 and the playoff-series rendering helpers."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from dispatcharr_ranked_matchups._util import (
+    CHANNEL_NUMBER_ORIGIN,
     extract_game_number_after_marker,
     group_advance_text,
     group_phase_text,
@@ -13,6 +14,7 @@ from dispatcharr_ranked_matchups._util import (
     series_phase_text,
     series_record_text,
     series_result_lines,
+    stable_channel_number,
     stable_hash_int,
 )
 
@@ -301,3 +303,86 @@ class TestGroupAdvanceText:
     def test_missing_returns_empty(self):
         assert group_advance_text(_group_stage(advance="")) == ""
         assert group_advance_text(None) == ""
+
+
+# ---------- stable channel numbering (#119) ----------
+
+# A fixed-offset tz stands in for a real zoneinfo zone: enough to exercise the
+# local-date boundary logic without depending on the tz database in CI.
+_ET = timezone(timedelta(hours=-5))
+
+
+def _utc(y, mo, d, h=18, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=timezone.utc)
+
+
+class TestStableChannelNumber:
+    def test_deterministic(self):
+        # Same inputs → same number, every time. This is the property the whole
+        # feature rests on: a game's number must not move across applies.
+        a = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
+        b = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
+        assert a == b
+
+    def test_independent_of_other_games(self):
+        # The number is a pure function of THIS game; the old scheme keyed off
+        # slate position (virtual_base + cache_idx), so a re-rank moved it. The
+        # number must depend only on (base, kickoff, marker, tz).
+        n = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:42", _ET)
+        # Computing it before/after any number of other games changes nothing.
+        for other in ("m:cfb:1", "m:soc:fd_9", "m:nhl:7"):
+            stable_channel_number(1000, _utc(2026, 6, 13), other, _ET)
+        assert stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:42", _ET) == n
+
+    def test_earlier_day_sorts_first(self):
+        # Today's games must get lower numbers than tomorrow's, regardless of
+        # which marker hashes higher.
+        today = stable_channel_number(1000, _utc(2026, 6, 13), "zzz", _ET)
+        tomorrow = stable_channel_number(1000, _utc(2026, 6, 14), "aaa", _ET)
+        assert today < tomorrow
+
+    def test_within_day_band(self):
+        # A same-day game lands in [base + day_offset, base + day_offset + 1):
+        # the integer part encodes the day, the fraction the per-game slot.
+        day_offset = (_utc(2026, 6, 13).astimezone(_ET).date() - CHANNEL_NUMBER_ORIGIN).days
+        n = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
+        assert 1000 + day_offset <= n < 1000 + day_offset + 1
+
+    def test_same_day_distinct_per_marker(self):
+        # Two different games on the same day get different numbers (distinct
+        # hash fractions) so they never collide on the unique constraint.
+        a = stable_channel_number(1000, _utc(2026, 6, 13, 12), "m:cfb:1", _ET)
+        b = stable_channel_number(1000, _utc(2026, 6, 13, 20), "m:cfb:2", _ET)
+        assert a != b
+
+    def test_pre_origin_clamps_to_zero_offset(self):
+        # A kickoff before the fixed origin must not produce a number below the
+        # base (which could collide with the user's real channels). Clamped.
+        n = stable_channel_number(1000, _utc(2020, 1, 1), "m:cfb:1", _ET)
+        assert 1000 <= n < 1001
+
+    def test_local_timezone_decides_the_day(self):
+        # A kickoff at 02:00 UTC on the 14th is still the EVENING of the 13th in
+        # ET (-5). The day offset must use the LOCAL date so "today" matches the
+        # user's calendar, not UTC's.
+        early_utc = _utc(2026, 6, 14, 2, 0)  # = 2026-06-13 21:00 ET
+        n_et = stable_channel_number(1000, early_utc, "m:cfb:1", _ET)
+        n_utc = stable_channel_number(1000, early_utc, "m:cfb:1", timezone.utc)
+        et_off = (early_utc.astimezone(_ET).date() - CHANNEL_NUMBER_ORIGIN).days
+        utc_off = (early_utc.date() - CHANNEL_NUMBER_ORIGIN).days
+        assert utc_off == et_off + 1
+        assert int(n_et) == 1000 + et_off
+        assert int(n_utc) == 1000 + utc_off
+
+    def test_unique_across_realistic_slate(self):
+        # 120 games spread over 10 days: every number must be distinct after
+        # rounding (the value clients bind on), so no two channels ever share a
+        # (group, channel_number).
+        numbers = []
+        for day in range(10):
+            for i in range(12):
+                start = _utc(2026, 6, 1 + day, 12 + (i % 8))
+                numbers.append(
+                    stable_channel_number(5000, start, f"m:cfb:{day}_{i}", _ET)
+                )
+        assert len(numbers) == len(set(numbers))


### PR DESCRIPTION
## What

Make each virtual channel's number a **stable, day-chronological** value so the EPG binds correctly under Dispatcharr's **default** `tvg_id_source=channel_number` — no client configuration required. This fixes the #117 name/guide mismatch at the source instead of via a mandatory client setting.

## Why

Numbers were `virtual_base + cache_idx`, re-ranked by ★ score every apply, so a given number mapped to a different game across refreshes. Under default output mode the EPG binds by channel number, and because Dispatcharr caches the EPG separately from the M3U, a post-refresh renumber paired the wrong programme with a channel (an "Ole Miss" channel showing the "Iran vs New Zealand" guide). The prior fix (#117) pushed a required `TVG-ID Source = TVG-ID` setting onto every consumer.

## How

`number = virtual_base + days-from-fixed-origin (local tz) + stable-hash(marker) fraction`

- Pure function of the game, so a game keeps its number for life → default-mode binding is stable.
- Earlier-day kickoffs get lower numbers → today's games still sort first.
- Within a day, order is stable-but-arbitrary (by hash) rather than by ★ score (the trade-off chosen in #119; chronological-within-day would force much larger channel numbers).
- `_assign_channel_numbers` builds the map up front and resolves the ~1e-5 same-day+same-bucket collision deterministically so the unique `(group, channel_number)` constraint can't trip.
- `_resolve_park_base` now bounds by the real (day-offset-driven) max target, not the game count.
- `CHANNEL_NUMBER_ORIGIN` / `CHANNEL_NUMBER_DECIMALS` are the single source for origin + rounding/bucket/nudge precision.
- Removed the now-obsolete "set TVG-ID Source = TVG-ID" banner (`plugin.json`), description clause, and README step 5; that mode still works but is no longer required. Bumped 1.2.0 → 1.3.0.

## Tests

Full suite **3194 passed** in `python:3.11-slim`. New coverage:
- `stable_channel_number`: determinism, position-independence, earlier-day-sorts-first, within-day band, distinct-per-marker, pre-origin clamp, local-tz day boundary, uniqueness across a 120-game slate.
- `_assign_channel_numbers`: **reorder-stability** (the regression — old `virtual_base + cache_idx` was position-dependent), all-unique, skip-bad-start, deterministic collision resolution.
- `_resolve_park_base`: new single-arg signature.

## Live verification (production container, 25 World Cup channels)

Ran `apply` (cache order) → snapshot `{number → game}` → **shuffled the slate** → `apply` → snapshot again → restore.

```
virtual channels: 25
all numbers unique: True
fractional numbers: 25/25 (stable hash fraction present)
number range: 7155.525864773 .. 7161.977686242
mapping identical across shuffle (binding shuffle-proof): True
drifted numbers (should be empty): 0
VERDICT: PASS
```

The `{channel_number → game}` mapping is **identical before and after a re-order**, so a client that fetches the EPG and M3U at different times (the #117 trigger) binds the same game at every number. The old scheme would have drifted all 25.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)