### PR TITLE
Kickoff-time integer channel numbers (Xtream Codes chronological sort) (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ### Changed
 
-- **Stable, day-chronological channel numbers (#119).** Virtual channel numbers
-  are now a pure function of each game's kickoff day plus a per-game hash, so a
-  given game keeps the same number for its whole life instead of being renumbered
-  by ★ rank on every refresh. This makes the EPG bind correctly under
-  Dispatcharr's **default** `tvg_id_source=channel_number` with no client setup,
-  fixing the name↔guide mismatch from #117 at the source rather than via a
-  required client setting. Earlier-day games still get lower numbers, so today's
-  games sort first; within a day, order is stable-but-arbitrary (by hash) rather
-  than by ★ score. The prior "set TVG-ID Source = TVG-ID" requirement (banner +
-  README step 5) is removed; that mode still works but is no longer needed.
+- **Stable, kickoff-time channel numbers (#121, supersedes #119).** Virtual
+  channel numbers are a pure function of each game's start time:
+  `virtual_base + minutes-since-a-fixed-origin × slots + a small per-game hash
+  tiebreak`, as an **integer**. The list therefore sorts strictly by day then
+  start time (live/upcoming first, no ★-score ordering), and every game keeps
+  the same number for its whole life — finished games drop off and new games
+  slot into their time-position without any existing number moving. Because the
+  number is stable, the guide binds to the right game with no client setup in
+  **both** the default M3U/EPG output and the **Xtream Codes API** (both bind by
+  the integer channel number), fixing the #117 name↔guide mismatch at the source.
+  Replaces #119's day-offset-plus-hash-fraction scheme, whose *fractional*
+  numbers were floored and collision-bumped by the Xtream Codes layer (XC
+  requires integer channel numbers), scrambling the order. The "set TVG-ID
+  Source = TVG-ID" requirement remains removed. Numbers are large (time-encoded)
+  by design; that is the cost of stable, integer, chronological numbering.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -163,19 +163,24 @@ form will collect everything needed to scope it.
 
 4. Run **Refresh + apply now** to populate.
 
-5. **Load the M3U and EPG URLs in your client.** On the Channels page, use the
-   **M3U** and **EPG** buttons to generate URLs and load them in TiviMate /
-   Plex / your client. No special TVG-ID setting is required: the guide binds
-   correctly under Dispatcharr's default *Channel Number* source.
+5. **Load the M3U/EPG URLs (or connect via Xtream Codes) in your client.** On
+   the Channels page, use the **M3U** and **EPG** buttons (or point your client
+   at the Xtream Codes API). No special TVG-ID setting is required, in either
+   the default M3U/EPG output or the Xtream Codes API.
 
-   > **Why no setup is needed.** Each game's channel *number* is now stable for
-   > the life of that game (it's derived from the kickoff date plus a per-game
-   > hash, not from its ★ rank), and earlier-day games get lower numbers so
-   > today's games still sort first. Because the number no longer moves when the
-   > slate re-ranks, binding the guide by channel number stays correct even
-   > though Dispatcharr caches the EPG separately from the playlist. (Setting
-   > **TVG-ID Source = TVG-ID** on both URLs also works and binds by the stable
-   > per-game `tvg_id` instead, but it is no longer required.)
+   > **Why it sorts soonest-first and the guide stays correct.** Each channel's
+   > *number* is derived from its kickoff time: `virtual_base + minutes-since-a-
+   > fixed-origin × slots + a small per-game tiebreak`. So the list sorts
+   > strictly by day then start time (live/upcoming games first), and — crucially
+   > — every game keeps the **same number for its whole life**. Finished games
+   > drop off and new games slot into their time-position on their own, which
+   > looks like "renumbering every refresh" but no existing game's number ever
+   > moves. Because the number is stable, the guide binds to the right game even
+   > though clients cache the EPG separately from the channel list, in both the
+   > default output and the Xtream Codes API (both bind by the integer channel
+   > number). The numbers are large (time-encoded) by design; that is what keeps
+   > them stable and integer-clean (Xtream Codes requires integer channel
+   > numbers and floors fractional ones, which would scramble the order).
 
 ## Pipeline
 

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/_util.py
+++ b/_util.py
@@ -36,55 +36,61 @@ def stable_hash_int(s: str) -> int:
     return int(digest[:16], 16)
 
 
-# Fixed anchor for stable_channel_number's day offset. DO NOT change this date:
-# every virtual channel's number is measured in days from this origin, so moving
-# it shifts EVERY channel number by the same delta in one apply (a one-time mass
-# renumber). It only needs to sit on or before the earliest kickoff the plugin
-# will ever schedule; the plugin fetches upcoming games, so any date safely in
-# the past works and 2024-01-01 leaves comfortable headroom.
-CHANNEL_NUMBER_ORIGIN = date(2024, 1, 1)
+# Fixed anchor for stable_channel_number. DO NOT change this date: every virtual
+# channel's number is measured in minutes from this origin, so moving it shifts
+# EVERY channel number by the same delta in one apply (a one-time mass renumber).
+# It only needs to sit on or before the earliest kickoff the plugin will ever
+# schedule; the plugin fetches upcoming games, so any date in the recent past
+# works. 2026-01-01 keeps the resulting numbers ~7 digits rather than ~8.
+CHANNEL_NUMBER_ORIGIN = date(2026, 1, 1)
 
-# Decimal places channel numbers are rounded to. Single source of truth: the
-# fraction-bucket count, the rounding below, and plugin.py's collision nudge all
-# derive from it, so the hash-fraction granularity always matches the rounding
-# grid. 9 keeps same-day collisions astronomically unlikely (birthday bound over
-# a realistic slate of <~100 games is ~1e-5) while staying within float
-# precision when added to a 4-6 digit integer base.
-CHANNEL_NUMBER_DECIMALS = 9
-
-# Stable hash buckets for the fractional part: one per rounding step, so every
-# distinct bucket survives the round() below as a distinct number.
-_CHANNEL_NUMBER_FRAC_BUCKETS = 10 ** CHANNEL_NUMBER_DECIMALS
+# Tiebreak slots reserved per kickoff minute. The channel number is
+# minutes-since-origin * this + (stable hash % this), so two games at the SAME
+# minute get distinct, stable numbers as long as their hashes differ mod this.
+# 16 keeps numbers compact while making same-minute hash collisions uncommon
+# (~6% per simultaneous pair); the rare residual is resolved by the deterministic
+# nudge in plugin._assign_channel_numbers. Because the value is < the per-minute
+# stride, it never reorders games across minute boundaries.
+CHANNEL_NUMBER_TIEBREAK_SLOTS = 16
 
 
 def stable_channel_number(
     virtual_base: int, start_utc: datetime, marker: str, tz
-) -> float:
-    """Stable, day-chronological channel number for a virtual game channel.
+) -> int:
+    """Stable, chronological channel number for a virtual game channel.
 
-    PURE FUNCTION of the game's immutable kickoff and its `marker`: the SAME
-    game always maps to the SAME number regardless of how the slate is ranked
-    or which other games are present. That stability is the whole point.
-    Dispatcharr's default output mode (``tvg_id_source=channel_number``) binds
-    the EPG to a channel BY its channel number, so a volatile number pairs the
-    wrong programme with a channel after a re-rank (see #117). A stable number
-    makes the default mode bind correctly with no client configuration.
+    PURE FUNCTION of the game's immutable kickoff time and its `marker`: the
+    SAME game always maps to the SAME integer for its whole life, regardless of
+    how the slate is ranked or which other games are present. That stability is
+    the whole point. Both Dispatcharr's default M3U/XMLTV output AND the Xtream
+    Codes API bind the EPG to a channel BY its (integer) channel number, so a
+    number that MOVES pairs the wrong programme with a channel after the slate
+    changes (see #117). A number derived from kickoff time never moves, so the
+    guide binds correctly with no client configuration, in either output mode.
 
-      integer part = virtual_base + days-from-origin (in the user's local tz)
-      fraction     = stable hash of marker in [0, 1)
+      number = virtual_base
+             + minutes-since-origin (in the user's local tz) * TIEBREAK_SLOTS
+             + (stable hash of marker) % TIEBREAK_SLOTS
 
-    The day offset makes earlier-kickoff days sort first (today's games lead the
-    list, preserving the prior behaviour's intent), while the hash fraction
-    gives each same-day game a distinct, stable slot. Within a day the order is
-    stable-but-arbitrary (by hash), not by kickoff time; see #119 for the
-    trade-off (chronological-within-day would force much larger channel
-    numbers). Earlier kickoffs in absolute time still get strictly lower
-    numbers across days.
+    The number increases monotonically with kickoff time, so the channel list
+    sorts strictly by day then start time (today's/soonest games first) — which
+    is exactly the "renumber every refresh, by start time" behaviour, achieved
+    WITHOUT any game's number ever changing: finished games drop off and new
+    games slot into their time-position on their own. The per-minute tiebreak
+    gives simultaneous kickoffs distinct, stable slots. Integer throughout, so
+    the Xtream Codes integer-channel-number requirement is satisfied natively
+    (no flooring/rounding by the XC layer, which is what scrambled the prior
+    fractional scheme).
     """
-    local_date = start_utc.astimezone(tz).date()
-    day_offset = max(0, (local_date - CHANNEL_NUMBER_ORIGIN).days)
-    frac = (stable_hash_int(marker) % _CHANNEL_NUMBER_FRAC_BUCKETS) / _CHANNEL_NUMBER_FRAC_BUCKETS
-    return round(virtual_base + day_offset + frac, CHANNEL_NUMBER_DECIMALS)
+    local = start_utc.astimezone(tz)
+    day_offset = max(0, (local.date() - CHANNEL_NUMBER_ORIGIN).days)
+    minutes_since_origin = day_offset * 1440 + local.hour * 60 + local.minute
+    slots = CHANNEL_NUMBER_TIEBREAK_SLOTS
+    return (
+        virtual_base
+        + minutes_since_origin * slots
+        + (stable_hash_int(marker) % slots)
+    )
 
 
 def extract_game_number_after_marker(headline: str, marker: str) -> Optional[int]:

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.3.0",
-  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Works with Dispatcharr's default M3U/EPG output settings; no special TVG-ID Source is required.",
+  "version": "1.4.0",
+  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",
@@ -10,8 +10,8 @@
     {
       "id": "_section_client_setup",
       "type": "info",
-      "label": "Guide binding: no client setup needed",
-      "description": "Load the M3U and EPG URLs as-is; the guide binds correctly under Dispatcharr's default TVG-ID Source = Channel Number. Each game's channel number is stable for the life of the game (derived from its kickoff day plus a per-game hash, not from its ★ rank), and earlier-day games get lower numbers so today's games sort first. Setting TVG-ID Source = TVG-ID on both URLs also works but is not required."
+      "label": "Guide binding & sorting: no client setup needed",
+      "description": "Load the M3U/EPG URLs (or connect via Xtream Codes) as-is; no special TVG-ID Source is required. Each channel's number is derived from its kickoff time, so the list sorts strictly by day then start time (soonest games first) and every game keeps the same number for its whole life. Because the number never moves, the guide binds to the right game in both the default output and the Xtream Codes API. Channel numbers are large (time-encoded, e.g. 235000+) by design; that is what keeps them stable and integer-clean for Xtream Codes."
     },
     {
       "id": "_section_sources",

--- a/plugin.py
+++ b/plugin.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import os
 import sys
 import threading
@@ -44,7 +43,6 @@ except ImportError:  # py < 3.9 fallback (won't hit on Dispatcharr's Python 3.13
     ZoneInfo = None  # type: ignore
 
 from ._util import (
-    CHANNEL_NUMBER_DECIMALS,
     group_advance_text,
     group_phase_text,
     group_results_lines,
@@ -1474,37 +1472,39 @@ def _resolve_virtual_base(settings: Dict[str, Any], highest_non_virtual: float) 
     return candidate if candidate > 1 else _AUTO_BASE_FALLBACK
 
 
-def _resolve_park_base(max_target_number: float) -> int:
+def _resolve_park_base(max_target_number: int) -> int:
     """Pick a parking range that's guaranteed past every target number we'll
     write. Parking + writing happens in one transaction within our own group,
     so we only need to clear our own target range; +1000 slack keeps the
     parking range comfortably out of the highest target we're about to assign.
 
     `max_target_number` is the largest channel number this apply will write
-    (the channel numbers are now day-offset based, so the ceiling is driven by
-    how far ahead the slate reaches, NOT by the game count). Callers pass the
-    target base itself when the slate is empty so the result stays sane."""
-    return int(math.floor(max_target_number)) + 1000
+    (channel numbers are kickoff-time based, so the ceiling is driven by how far
+    ahead the slate reaches, NOT by the game count). Callers pass the target
+    base itself when the slate is empty so the result stays sane."""
+    return int(max_target_number) + 1000
 
 
 def _assign_channel_numbers(
     games: List[Dict[str, Any]], virtual_base: int, tz
-) -> Dict[str, float]:
+) -> Dict[str, int]:
     """Map each game's marker to its stable channel number for this apply.
 
-    Numbers come from `stable_channel_number` (a pure function of kickoff +
-    marker), so a given game keeps the same number across applies regardless of
-    how the slate is ranked. That stability is what lets Dispatcharr's default
-    ``tvg_id_source=channel_number`` bind the EPG correctly (#119).
+    Numbers come from `stable_channel_number` (a pure function of kickoff time +
+    marker), so a given game keeps the same integer for its whole life
+    regardless of how the slate is ranked or which other games are present. That
+    stability is what lets both the default M3U/XMLTV output and the Xtream Codes
+    API bind the EPG correctly with no client setting (#121), while the numbers
+    still increase with kickoff time so the list sorts soonest-first.
 
-    Two DIFFERENT games can only land on the same rounded number if they share
-    a local day AND a hash bucket (~1e-5 odds on a realistic slate). That would
-    violate the unique ``(channel_group, channel_number)`` constraint, so we
-    resolve it deterministically: walk the games in (number, marker) order and
-    nudge any exact duplicate up by a hair. This perturbs ONLY the colliding
-    game, never the rest, so every other game keeps its pure stable number and
-    the resolution is reproducible across applies."""
-    pairs: List[Tuple[str, float]] = []
+    Two DIFFERENT games can only land on the same number if they share a kickoff
+    minute AND a hash slot (uncommon; see CHANNEL_NUMBER_TIEBREAK_SLOTS). That
+    would violate the unique ``(channel_group, channel_number)`` constraint, so
+    we resolve it deterministically: walk the games in (number, marker) order and
+    bump any exact duplicate to the next free integer. This perturbs ONLY a
+    colliding same-minute game, never games at other minutes, and is reproducible
+    across applies."""
+    pairs: List[Tuple[str, int]] = []
     for g in games:
         start_dt = parse_iso_utc(g.get("start_time_utc"))
         if start_dt is None:
@@ -1513,23 +1513,19 @@ def _assign_channel_numbers(
         pairs.append((marker, stable_channel_number(virtual_base, start_dt, marker, tz)))
 
     pairs.sort(key=lambda mn: (mn[1], mn[0]))
-    assigned: Dict[str, float] = {}
+    assigned: Dict[str, int] = {}
     used: set = set()
     collisions = 0
-    # Smallest increment that survives the shared rounding grid: one step nudges
-    # an exact duplicate onto the next free slot without crossing into the next
-    # day band (which is 1.0 away).
-    nudge = 10 ** -CHANNEL_NUMBER_DECIMALS
     for marker, number in pairs:
         while number in used:
-            number = round(number + nudge, CHANNEL_NUMBER_DECIMALS)
+            number += 1
             collisions += 1
         used.add(number)
         assigned[marker] = number
     if collisions:
         logger.warning(
-            "[ranked_matchups] resolved %d channel-number collision(s) by nudging; "
-            "widen _CHANNEL_NUMBER_FRAC_BUCKETS in _util.py if this recurs",
+            "[ranked_matchups] resolved %d channel-number collision(s) by +1 nudge; "
+            "raise CHANNEL_NUMBER_TIEBREAK_SLOTS in _util.py if this recurs",
             collisions,
         )
     return assigned
@@ -2121,13 +2117,14 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     virtual_base = _resolve_virtual_base(settings, highest_other)
     # Stable per-game channel numbers (marker -> number). Computed once up front
     # so collision resolution sees the whole slate and so park_base can be set
-    # above the true ceiling (day-offset based, not game-count based).
+    # above the true ceiling (kickoff-time based, so driven by how far ahead the
+    # slate reaches, not by the game count).
     chnum_by_marker = _assign_channel_numbers(games, virtual_base, apply_tz)
-    max_target = max(chnum_by_marker.values(), default=float(virtual_base))
+    max_target = max(chnum_by_marker.values(), default=virtual_base)
     park_base = _resolve_park_base(max_target)
     logger.info(
         "[ranked_matchups] virtual_base=%d (highest_other=%s, setting=%r), "
-        "max_target=%.3f, park_base=%d",
+        "max_target=%d, park_base=%d",
         virtual_base, highest_other,
         settings.get("virtual_channel_base", DEFAULT_VIRTUAL_CHANNEL_BASE),
         max_target, park_base,
@@ -2344,13 +2341,14 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 logger.warning("[ranked_matchups] bad start_time_utc on %s", marker)
                 continue
 
-            # Stable, day-chronological channel number for this game. Keyed by
-            # marker (not slate position) so it never moves across applies, which
-            # is what makes Dispatcharr's DEFAULT tvg_id_source=channel_number
-            # bind the EPG correctly with no client setup (#119). Earlier-day
-            # kickoffs still sort first. _assign_channel_numbers computed the
-            # whole map up front; marker is guaranteed present here because that
-            # map skips exactly the same bad-start_time rows we just skipped.
+            # Stable, kickoff-time-based channel number for this game. Keyed by
+            # marker (not slate position) so it never moves across applies, yet
+            # it increases with start time so the list still sorts soonest-first.
+            # Being a stable integer is what makes BOTH the default M3U/XMLTV
+            # output and the Xtream Codes API bind the EPG correctly with no
+            # client setup (#121). _assign_channel_numbers computed the whole map
+            # up front; marker is guaranteed present here because that map skips
+            # exactly the same bad-start_time rows we just skipped.
             target_chnum = chnum_by_marker[marker]
 
             new_name = format_channel_name(
@@ -2974,7 +2972,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.3.0"
+    version = "1.4.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -506,23 +506,18 @@ class TestResolveVirtualBase:
 class TestResolvParkBase:
     def test_park_above_max_target(self, plugin):
         # park must be past the highest target number we'll write this apply.
-        max_target = 9742.512345
+        max_target = 3767040
         park = plugin._resolve_park_base(max_target)
         assert park > max_target
 
-    def test_park_above_fractional_ceiling(self, plugin):
-        # The ceiling is a fractional float (day_offset + hash frac); park must
-        # clear its integer ceiling, not just its floor.
-        assert plugin._resolve_park_base(9000.999) > 9001
-
     def test_empty_slate_uses_base(self, plugin):
         # Empty cache passes the bare virtual_base; result stays sane and above.
-        assert plugin._resolve_park_base(9000.0) > 9000
+        assert plugin._resolve_park_base(9000) > 9000
 
 
 class TestAssignChannelNumbers:
-    """Stable per-game channel numbering (#119). The map must be position-
-    independent (the #117/#119 fix) and collision-free."""
+    """Stable kickoff-time channel numbering (#121). The map must be position-
+    independent (the #117 fix) and collision-free."""
 
     @staticmethod
     def _game(marker_id, start_iso, sport="cfb"):
@@ -574,11 +569,13 @@ class TestAssignChannelNumbers:
         # Force every game onto the SAME raw number; the resolver must still
         # hand back all-distinct numbers (nudge path) and stay deterministic.
         monkeypatch.setattr(plugin, "stable_channel_number",
-                            lambda base, start, marker, tz: 1000.0)
+                            lambda base, start, marker, tz: 1000)
         games = [self._game(i, "2026-06-13T16:00:00Z") for i in range(5)]
         assigned = plugin._assign_channel_numbers(games, 1000, timezone.utc)
         assert len(assigned) == 5
         assert len(set(assigned.values())) == 5
+        # Integer +1 nudge produces a contiguous block from the collided value.
+        assert sorted(assigned.values()) == [1000, 1001, 1002, 1003, 1004]
         # Deterministic across calls.
         again = plugin._assign_channel_numbers(games, 1000, timezone.utc)
         assert assigned == again

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 from dispatcharr_ranked_matchups._util import (
     CHANNEL_NUMBER_ORIGIN,
+    CHANNEL_NUMBER_TIEBREAK_SLOTS,
     extract_game_number_after_marker,
     group_advance_text,
     group_phase_text,
@@ -305,10 +306,10 @@ class TestGroupAdvanceText:
         assert group_advance_text(None) == ""
 
 
-# ---------- stable channel numbering (#119) ----------
+# ---------- stable kickoff-time channel numbering (#121) ----------
 
 # A fixed-offset tz stands in for a real zoneinfo zone: enough to exercise the
-# local-date boundary logic without depending on the tz database in CI.
+# local-date/time boundary logic without depending on the tz database in CI.
 _ET = timezone(timedelta(hours=-5))
 
 
@@ -317,71 +318,84 @@ def _utc(y, mo, d, h=18, mi=0):
 
 
 class TestStableChannelNumber:
+    def test_returns_int(self):
+        # Xtream Codes requires integer channel numbers; a float gets floored and
+        # collision-bumped by the XC layer, scrambling order. Must be int.
+        n = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
+        assert isinstance(n, int)
+
     def test_deterministic(self):
-        # Same inputs → same number, every time. This is the property the whole
-        # feature rests on: a game's number must not move across applies.
+        # Same inputs → same number, every time. The whole feature rests on this:
+        # a game's number must not move across applies.
         a = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
         b = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
         assert a == b
 
     def test_independent_of_other_games(self):
-        # The number is a pure function of THIS game; the old scheme keyed off
-        # slate position (virtual_base + cache_idx), so a re-rank moved it. The
-        # number must depend only on (base, kickoff, marker, tz).
+        # Pure function of THIS game; the old scheme keyed off slate position
+        # (virtual_base + cache_idx) so a re-rank moved it. Must depend only on
+        # (base, kickoff, marker, tz).
         n = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:42", _ET)
-        # Computing it before/after any number of other games changes nothing.
         for other in ("m:cfb:1", "m:soc:fd_9", "m:nhl:7"):
             stable_channel_number(1000, _utc(2026, 6, 13), other, _ET)
         assert stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:42", _ET) == n
 
-    def test_earlier_day_sorts_first(self):
-        # Today's games must get lower numbers than tomorrow's, regardless of
-        # which marker hashes higher.
-        today = stable_channel_number(1000, _utc(2026, 6, 13), "zzz", _ET)
-        tomorrow = stable_channel_number(1000, _utc(2026, 6, 14), "aaa", _ET)
+    def test_earlier_kickoff_sorts_first_across_days(self):
+        # Today's games get lower numbers than tomorrow's, regardless of hash.
+        today = stable_channel_number(1000, _utc(2026, 6, 13, 23), "zzz", _ET)
+        tomorrow = stable_channel_number(1000, _utc(2026, 6, 15, 1), "aaa", _ET)
         assert today < tomorrow
 
-    def test_within_day_band(self):
-        # A same-day game lands in [base + day_offset, base + day_offset + 1):
-        # the integer part encodes the day, the fraction the per-game slot.
-        day_offset = (_utc(2026, 6, 13).astimezone(_ET).date() - CHANNEL_NUMBER_ORIGIN).days
-        n = stable_channel_number(1000, _utc(2026, 6, 13), "m:cfb:1", _ET)
-        assert 1000 + day_offset <= n < 1000 + day_offset + 1
+    def test_earlier_kickoff_sorts_first_within_day(self):
+        # The key #121 fix vs the prior hash-within-day scheme: WITHIN a day the
+        # number must increase with start time (noon < afternoon < evening),
+        # independent of marker hash.
+        noon = stable_channel_number(1000, _utc(2026, 6, 13, 16), "zzzz", _ET)   # 12:00 ET
+        eve = stable_channel_number(1000, _utc(2026, 6, 13, 23), "aaaa", _ET)    # 19:00 ET
+        assert noon < eve
 
-    def test_same_day_distinct_per_marker(self):
-        # Two different games on the same day get different numbers (distinct
-        # hash fractions) so they never collide on the unique constraint.
-        a = stable_channel_number(1000, _utc(2026, 6, 13, 12), "m:cfb:1", _ET)
-        b = stable_channel_number(1000, _utc(2026, 6, 13, 20), "m:cfb:2", _ET)
+    def test_same_minute_distinct_via_tiebreak(self):
+        # Two games at the SAME kickoff minute get distinct numbers (different
+        # hash slots) so they don't collide on the unique constraint, and both
+        # stay just above the minute's base.
+        a = stable_channel_number(1000, _utc(2026, 6, 13, 18), "m:cfb:1", _ET)
+        b = stable_channel_number(1000, _utc(2026, 6, 13, 18), "m:cfb:2", _ET)
         assert a != b
+        # Both sit within one minute-stride of each other (same minute bucket).
+        assert abs(a - b) < CHANNEL_NUMBER_TIEBREAK_SLOTS
 
-    def test_pre_origin_clamps_to_zero_offset(self):
+    def test_pre_origin_clamps_to_base_minute_zero(self):
         # A kickoff before the fixed origin must not produce a number below the
-        # base (which could collide with the user's real channels). Clamped.
-        n = stable_channel_number(1000, _utc(2020, 1, 1), "m:cfb:1", _ET)
-        assert 1000 <= n < 1001
+        # base (which could collide with the user's real channels). Clamped to
+        # day_offset 0, so number is base + minute_of_day*slots + tiebreak.
+        n = stable_channel_number(1000, _utc(2020, 1, 1, 5), "m:cfb:1", _ET)
+        # 2020-01-01 05:00 UTC = 2020-01-01 00:00 ET → minute_of_day 0.
+        assert 1000 <= n < 1000 + CHANNEL_NUMBER_TIEBREAK_SLOTS
 
-    def test_local_timezone_decides_the_day(self):
-        # A kickoff at 02:00 UTC on the 14th is still the EVENING of the 13th in
-        # ET (-5). The day offset must use the LOCAL date so "today" matches the
-        # user's calendar, not UTC's.
-        early_utc = _utc(2026, 6, 14, 2, 0)  # = 2026-06-13 21:00 ET
+    def test_local_timezone_decides_day_and_time(self):
+        # 02:00 UTC on the 14th is 21:00 ET on the 13th. The local date+time
+        # drive the number so "today" and ordering match the user's clock. Same
+        # marker → same tiebreak, so the gap is exactly the minutes difference
+        # times the tiebreak stride.
+        early_utc = _utc(2026, 6, 14, 2, 0)
+        slots = CHANNEL_NUMBER_TIEBREAK_SLOTS
         n_et = stable_channel_number(1000, early_utc, "m:cfb:1", _ET)
         n_utc = stable_channel_number(1000, early_utc, "m:cfb:1", timezone.utc)
-        et_off = (early_utc.astimezone(_ET).date() - CHANNEL_NUMBER_ORIGIN).days
-        utc_off = (early_utc.date() - CHANNEL_NUMBER_ORIGIN).days
-        assert utc_off == et_off + 1
-        assert int(n_et) == 1000 + et_off
-        assert int(n_utc) == 1000 + utc_off
+
+        def mins(dt):
+            return (dt.date() - CHANNEL_NUMBER_ORIGIN).days * 1440 + dt.hour * 60 + dt.minute
+        et_min = mins(early_utc.astimezone(_ET))
+        utc_min = mins(early_utc.astimezone(timezone.utc))
+        assert n_utc - n_et == (utc_min - et_min) * slots
+        assert n_utc > n_et  # UTC interpretation is later in wall-clock-from-origin
 
     def test_unique_across_realistic_slate(self):
-        # 120 games spread over 10 days: every number must be distinct after
-        # rounding (the value clients bind on), so no two channels ever share a
-        # (group, channel_number).
+        # 120 games over 10 days at staggered times: every number distinct, so no
+        # two channels share a (group, channel_number).
         numbers = []
         for day in range(10):
             for i in range(12):
-                start = _utc(2026, 6, 1 + day, 12 + (i % 8))
+                start = _utc(2026, 6, 1 + day, 12 + (i % 8), (i * 7) % 60)
                 numbers.append(
                     stable_channel_number(5000, start, f"m:cfb:{day}_{i}", _ET)
                 )


### PR DESCRIPTION
## What

Number virtual channels by **kickoff time** as a stable **integer**, so the list sorts strictly by day then start time and the guide binds correctly in the **Xtream Codes API** (and the plain M3U/EPG output) with no client setting.

## Why

#119 made numbers stable but **fractional**. Xtream Codes requires integer channel numbers — Dispatcharr floors the fraction and collision-bumps duplicates, **scrambling the order** (the soonest/marquee game landed at the bottom for XC clients). XC also binds the EPG by the integer channel number (`epg_channel_id`), so #117's `tvg_id` advice never applied to XC.

## How

`number = virtual_base + minutes-since-fixed-origin(local tz) × SLOTS + hash % SLOTS` (integer).

- Monotonic in kickoff time → sorts by day then start time, **no score in the order**.
- Stable per game for life (kickoff is fixed) → the list "renumbers" as games come/go without any existing number moving → #117 mismatch is structurally impossible, in both default and XC output.
- Integer → passes XC's `channel_num_map` unchanged (no floor/scramble).
- `CHANNEL_NUMBER_ORIGIN=2026-01-01`, `CHANNEL_NUMBER_TIEBREAK_SLOTS=16`; integer +1 nudge for the rare same-minute hash collision. Trade-off: numbers are large (time-encoded, ~7 digits). Bump 1.3.0 → 1.4.0.

## Tests

Full suite **3194 passed**. New/updated: `stable_channel_number` is-int, earlier-kickoff-sorts-first (across days AND within a day), same-minute tiebreak, pre-origin clamp, local-tz boundary, uniqueness; integer collision nudge in `_assign_channel_numbers`.

## Live verification — actual Xtream Codes path (`xc_get_live_streams`, 25 WC channels)

```
1) all num are integers (no XC flooring/scramble): True   (unique: True)
2) num order is chronological by kickoff:           True
3) epg_channel_id == str(num) (XC binds by this):   True
4) num UNCHANGED after slate shuffle (no #117):     True   drifted=0
VERDICT: PASS
```

Paraguay at United States (soonest kickoff) is now `num=3758907` — **first** in the list, not last. Order is purely chronological (06-13 → 06-19); ★8.7 Australia/US sits near the end because it's a later day. Shuffling the slate and re-applying left every `num` unchanged.

Refs #119
Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)