### PR TITLE
docs: roll CHANGELOG into [1.4.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-13
+
 ### Changed
 
 - **Stable, kickoff-time channel numbers (#121, supersedes #119).** Virtual


### PR DESCRIPTION
Post-release hygiene: v1.4.0 shipped (and is now published to the official Dispatcharr/Plugins repo via #119), so the accumulated `[Unreleased]` entries roll under a dated `## [1.4.0] - 2026-06-13` heading. No code change.