### PR TITLE
Add "Diagnose matching" action (#128) + matcher/dispatch cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/matcher.py
+++ b/matcher.py
@@ -145,6 +145,17 @@ def _team_keywords(team_name: str) -> List[str]:
     return list(dict.fromkeys(keywords))
 
 
+def _kw_hit(text: str, keywords: List[str]) -> bool:
+    """Whether any keyword (case-insensitive substring) appears in `text`.
+
+    Single source of truth for the substring-hit test every matcher tier uses
+    (and the diagnose action reuses), so the matched-vs-explained logic can
+    never drift apart. Tolerates None/empty text.
+    """
+    t = (text or "").lower()
+    return any(kw.lower() in t for kw in keywords)
+
+
 def _regex_filter(
     candidates: List[ChannelCandidate],
     team_a: str,
@@ -153,14 +164,8 @@ def _regex_filter(
     """Programs whose title contains references to BOTH teams."""
     a_kws = _team_keywords(team_a)
     b_kws = _team_keywords(team_b)
-    out = []
-    for c in candidates:
-        title = c.program_title.lower()
-        a_hit = any(kw.lower() in title for kw in a_kws)
-        b_hit = any(kw.lower() in title for kw in b_kws)
-        if a_hit and b_hit:
-            out.append(c)
-    return out
+    return [c for c in candidates
+            if _kw_hit(c.program_title, a_kws) and _kw_hit(c.program_title, b_kws)]
 
 
 def _regex_filter_channel_name(
@@ -183,14 +188,8 @@ def _regex_filter_channel_name(
     """
     a_kws = _team_keywords(team_a)
     b_kws = _team_keywords(team_b)
-    out = []
-    for c in candidates:
-        name = (c.channel_name or "").lower()
-        a_hit = any(kw.lower() in name for kw in a_kws)
-        b_hit = any(kw.lower() in name for kw in b_kws)
-        if a_hit and b_hit:
-            out.append(c)
-    return out
+    return [c for c in candidates
+            if _kw_hit(c.channel_name, a_kws) and _kw_hit(c.channel_name, b_kws)]
 
 
 # Keywords that mark a program as a preview/highlight wrapper rather than the

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",
@@ -585,6 +585,11 @@
       "id": "preview_names",
       "label": "Test naming convention",
       "description": "Render the channel name template against sample games (no DB writes, no cache needed) so you can check the layout before applying. Reports any template errors and lists every available variable."
+    },
+    {
+      "id": "diagnose",
+      "label": "Diagnose matching",
+      "description": "Explain, in one copy-pasteable block, why each curated game did or did not match a channel: which of your channels named one team, both, or none, and why a near-miss was skipped. Read-only, no DB writes. Run this and paste the result when streams are not attaching."
     }
   ]
 }

--- a/plugin.py
+++ b/plugin.py
@@ -2819,6 +2819,184 @@ def _action_show_status(settings: Dict[str, Any]) -> Dict[str, Any]:
     return {"status": "ok", "message": "\n".join(lines)}
 
 
+# ---------- diagnose matching ----------
+
+# Cap near-miss channels listed per game so the paste stays manageable on a
+# busy slate. Any extras beyond the cap are COUNTED in the output, never
+# silently dropped (a hidden truncation would read as "covered everything").
+_DIAGNOSE_MAX_CANDIDATES = 8
+
+
+def _named_sides(text: str, home_kws: List[str], away_kws: List[str]) -> Tuple[bool, bool]:
+    """Whether `text` (a channel name or program title) names the home / away
+    side. Delegates to matcher._kw_hit, the SAME test the matcher tiers use, so
+    the diagnostic reports exactly what the matcher saw, not a parallel
+    heuristic that could drift."""
+    from .matcher import _kw_hit
+    return _kw_hit(text, home_kws), _kw_hit(text, away_kws)
+
+
+def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Explain, in one copy-pasteable block, why each curated game did or did
+    not match a channel.
+
+    Built for users who cannot read container logs (the common case for an
+    installed plugin): it re-runs the EXACT candidate lookup the matcher uses
+    (`_build_epg_lookup`) against the cached slate, then reports per game which
+    of the user's channels named one team, both teams, or none, and why a
+    near-miss was skipped (preview card, only one team). See #128.
+
+    Read-only: no DB writes, no apply, safe to run anytime. Reflects the EPG as
+    it stands now, which can differ slightly from refresh time if the guide has
+    since updated.
+    """
+    del settings  # interface-required (Plugin.run dispatch), not read here
+    from types import SimpleNamespace
+    from .matcher import (
+        _team_keywords,
+        _regex_filter_channel_name,
+        _is_preview_title,
+    )
+
+    cache = _read_cache()
+    games = cache.get("games", [])
+    if not games:
+        return {"status": "ok", "message": "Cache empty. Run refresh first, then re-run this."}
+
+    epg_lookup = _build_epg_lookup()
+    matched = [g for g in games if g.get("channel_name_current")]
+    unmatched = [g for g in games if not g.get("channel_name_current")]
+
+    lines: List[str] = [
+        "Ranked Matchups - Match Diagnostics  (copy this whole block)",
+        f"plugin v{Plugin.version}  -  {len(games)} games  -  "
+        f"{len(matched)} matched  -  {len(unmatched)} unmatched",
+        "",
+    ]
+
+    if not unmatched:
+        lines.append("Every curated game matched a channel. Nothing to diagnose.")
+    else:
+        lines.append("UNMATCHED - why each found no streams:")
+        lines.append("")
+
+    for g in unmatched:
+        home = g.get("home", "")
+        away = g.get("away", "")
+        sport = g.get("sport_prefix", "?")
+        kickoff = g.get("kickoff_local", "")
+        lines.append(f"* {sport} - {away} at {home}  ({kickoff})")
+
+        # Field-event sports (#127): away is the "Field" sentinel, which the
+        # matcher's both-teams gate can never satisfy. Say so plainly rather
+        # than reporting a misleading "0 candidates".
+        if away == "Field":
+            lines.append("   -> known limitation: field-event sports (UFC, F1, golf, "
+                         "etc.) can't match yet (issue #127). Nothing you can "
+                         "configure fixes this; a plugin fix is needed.")
+            lines.append("")
+            continue
+
+        home_kws = _team_keywords(home)
+        away_kws = _team_keywords(away)
+        lines.append(f"   searched for: {' / '.join(repr(k) for k in home_kws)}"
+                     f"  AND  {' / '.join(repr(k) for k in away_kws)}")
+
+        start_dt = parse_iso_utc(g.get("start_time_utc"))
+        if start_dt is None:
+            lines.append("   -> cannot diagnose: missing/invalid start time in cache.")
+            lines.append("")
+            continue
+
+        shim = SimpleNamespace(sport_prefix=sport, start_time=start_dt,
+                               home=home, away=away)
+        try:
+            candidates = epg_lookup(shim)
+        except Exception as e:  # diagnostic must never raise; report and move on
+            lines.append(f"   -> diagnostic lookup failed: {type(e).__name__}: {e}")
+            lines.append("")
+            continue
+
+        if not candidates:
+            lines.append("   channels naming either team in this window: 0")
+            lines.append("   -> the game's feed likely is not in your lineup, OR your "
+                         "channels have no per-game guide naming the teams. This plugin "
+                         "can only attach a channel it can identify as carrying this "
+                         "exact game.")
+            lines.append("")
+            continue
+
+        lines.append(f"   channels naming either team in this window: {len(candidates)}")
+        shown = 0
+        both_count = 0       # candidates naming BOTH teams (any tier)
+        both_live = 0        # ...of those, the ones that are NOT preview cards
+        for c in candidates:
+            nh, na = _named_sides(c.channel_name, home_kws, away_kws)
+            th, ta = _named_sides(c.program_title, home_kws, away_kws)
+            named_both = (nh and na) or (th and ta)
+            if named_both:
+                both_count += 1
+                if not _is_preview_title(c.program_title):
+                    both_live += 1
+            if shown >= _DIAGNOSE_MAX_CANDIDATES:
+                continue
+            shown += 1
+            sides = []
+            if nh or th:
+                sides.append("home")
+            if na or ta:
+                sides.append("away")
+            named = "+".join(sides) if sides else "neither"
+            guide = c.program_title or "(no guide entry; channel-name match)"
+            note = "  [PREVIEW card - skipped on purpose]" if (
+                named_both and _is_preview_title(c.program_title)) else ""
+            lines.append(f"     - \"{c.channel_name}\"  guide: \"{guide}\"  "
+                         f"-> named: {named}{note}")
+        extra = len(candidates) - shown
+        if extra > 0:
+            lines.append(f"     ... and {extra} more (omitted to keep this short)")
+
+        # Conclusion: classify the failure so the user knows the next move.
+        strict = _regex_filter_channel_name(candidates, home, away)
+        if strict:
+            lines.append("   -> a channel NAME contains both teams but it did not "
+                         "stick; this is unexpected, please send this block to us.")
+        elif both_count == 0:
+            lines.append("   -> no channel named BOTH teams. Likely a name-spelling "
+                         "gap: if a channel above is the right game under a different "
+                         "spelling, tell us the exact title and we can add an alias.")
+        elif both_live == 0:
+            # strict empty + both_count>0 means the both-team hits were titles,
+            # and none survived the preview filter, so they were all preview cards.
+            lines.append("   -> the only channels naming both teams were preview / "
+                         "pre-game cards, not the live broadcast. The live feed either "
+                         "is not in your lineup or its guide does not name the teams.")
+        else:
+            # Live-looking both-team candidates exist but none was auto-selected:
+            # the match was ambiguous and the LLM tie-break did not resolve it.
+            lines.append(f"   -> {both_live} channel(s) named both teams but the match "
+                         "was ambiguous and not auto-resolved (the Claude API key may be "
+                         "unset, or it abstained). Set the key, or tell us which feed is "
+                         "correct.")
+        lines.append("")
+
+    if matched:
+        lines.append("MATCHED (for contrast - this is what success looks like):")
+        for g in matched[:_DIAGNOSE_MAX_CANDIDATES]:
+            lines.append(f"  * {g.get('sport_prefix','?')} - {g.get('away','')} at "
+                         f"{g.get('home','')}  -> \"{g.get('channel_name_current')}\"")
+        if len(matched) > _DIAGNOSE_MAX_CANDIDATES:
+            lines.append(f"  ... and {len(matched) - _DIAGNOSE_MAX_CANDIDATES} more matched.")
+        lines.append("")
+
+    lines.append("How matching works: this plugin attaches streams from channels you "
+                 "ALREADY have, by finding one whose GUIDE names both teams, or whose "
+                 "channel NAME contains both. Generic-named channels with no per-game "
+                 "guide cannot be matched.")
+
+    return {"status": "ok", "message": "\n".join(lines)}
+
+
 # ---------- scheduler ----------
 
 # Scheduler state (the running thread + its stop Event) lives in a registry
@@ -2976,12 +3154,29 @@ def _release_scheduler_lock() -> None:
 
 # ---------- Plugin entry ----------
 
+# Single source of truth mapping every action id to its handler. run() dispatches
+# through this, and plugin.json's "actions" must declare exactly these ids: the
+# contract test (tests/test_diagnose.py) asserts the two sets match, so a manifest
+# button with no handler (or a handler with no button) fails CI instead of
+# silently returning "Unknown action" at runtime. Every handler has the uniform
+# (settings) -> dict shape. refresh/auto_pipeline map to their ASYNC entrypoints
+# (the HTTP-facing wrappers); see #84 and the run() docstring.
+_ACTION_HANDLERS = {
+    "refresh": _action_refresh_async,
+    "apply": _action_apply,
+    "auto_pipeline": _action_auto_pipeline_async,
+    "show_status": _action_show_status,
+    "preview_names": _action_preview_names,
+    "diagnose": _action_diagnose,
+}
+
+
 class Plugin:
     name = "Ranked Matchups (Top Games)"
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.4.0"
+    version = "1.5.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than
@@ -3038,21 +3233,15 @@ class Plugin:
         if params:
             settings.update(params)
         try:
-            # refresh + auto_pipeline run too long for browsers / axios
-            # default fetch timeouts (~30s). Dispatch via Celery and return
-            # immediately with a task id; UI polls show_status for progress.
-            # See #84 and tasks.py. apply stays synchronous (~17s, fits).
-            if action == "refresh":
-                return _action_refresh_async(settings)
-            if action == "apply":
-                return _action_apply(settings)
-            if action == "auto_pipeline":
-                return _action_auto_pipeline_async(settings)
-            if action == "show_status":
-                return _action_show_status(settings)
-            if action == "preview_names":
-                return _action_preview_names(settings)
-            return {"status": "error", "message": f"Unknown action: {action!r}"}
+            # _ACTION_HANDLERS is the single dispatch table. refresh + auto_pipeline
+            # map to ASYNC entrypoints because they run too long for browser / axios
+            # default fetch timeouts (~30s): they queue and return a task id, and the
+            # UI polls show_status for progress. See #84 and tasks.py. apply stays
+            # synchronous (~17s, fits).
+            handler = _ACTION_HANDLERS.get(action)
+            if handler is None:
+                return {"status": "error", "message": f"Unknown action: {action!r}"}
+            return handler(settings)
         except Exception as e:
             logger.exception("[ranked_matchups] action %r failed", action)
             return {"status": "error", "message": f"{type(e).__name__}: {e}"}

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -1,0 +1,201 @@
+"""Tests for the "Diagnose matching" action (`_action_diagnose`, #128).
+
+The action re-runs the matcher's candidate lookup against the cached slate and
+explains, per game, why a match did or did not land. The live verification on a
+real instance exercised the 0-candidates branch thoroughly; these tests pin the
+branches that real data did not hit at ship time: the near-miss "named only one
+team" path, the preview-card skip path, and the field-event (#127) short-circuit.
+
+`plugin.py` does its Django imports lazily inside functions, so the module loads
+without a database. We stub `_read_cache` (the slate) and `_build_epg_lookup`
+(the candidate source) so the whole action runs in-process with no ORM.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+def _load(submodule):
+    """Load a leaf submodule of the (conftest-registered) package without
+    exec-ing __init__.py. _util must be registered before matcher/plugin import
+    it. Idempotent across the two submodules this test needs."""
+    if f"{PKG_NAME}._util" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            f"{PKG_NAME}._util", os.path.join(REPO_ROOT, "_util.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[f"{PKG_NAME}._util"] = mod
+        spec.loader.exec_module(mod)
+    full = f"{PKG_NAME}.{submodule}"
+    if full in sys.modules:
+        return sys.modules[full]
+    spec = importlib.util.spec_from_file_location(
+        full, os.path.join(REPO_ROOT, f"{submodule}.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[full] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def plugin():
+    return _load("plugin")
+
+
+@pytest.fixture(scope="module")
+def ChannelCandidate():
+    return _load("matcher").ChannelCandidate
+
+
+def _game(away, home, *, prefix="NBA", matched=None, start="2026-06-15T20:00:00Z"):
+    return {
+        "sport_prefix": prefix,
+        "away": away,
+        "home": home,
+        "kickoff_local": "Today 8:00 PM EDT",
+        "start_time_utc": start,
+        "channel_name_current": matched,
+    }
+
+
+def _run(plugin, ChannelCandidate, games, candidates_by_home):
+    """Drive _action_diagnose with a stubbed cache + lookup. `candidates_by_home`
+    maps a game's home-team string to the ChannelCandidate list the lookup
+    should return for it (the matcher keys nothing on home; this is just a
+    convenient test handle)."""
+    plugin._read_cache = lambda: {"games": games}
+
+    def fake_lookup_factory():
+        def lookup(game):
+            return candidates_by_home.get(game.home, [])
+        return lookup
+
+    plugin._build_epg_lookup = fake_lookup_factory
+    out = plugin._action_diagnose({})
+    assert out["status"] == "ok"
+    return out["message"]
+
+
+def _cand(ChannelCandidate, channel_name, program_title):
+    from datetime import datetime, timezone
+    now = datetime(2026, 6, 15, 20, 0, tzinfo=timezone.utc)
+    return ChannelCandidate(
+        channel_id=1,
+        channel_name=channel_name,
+        program_title=program_title,
+        program_start=now,
+        program_end=now,
+    )
+
+
+class TestDiagnoseBranches:
+    def test_zero_candidates(self, plugin, ChannelCandidate):
+        games = [_game("New York Knicks", "San Antonio Spurs")]
+        msg = _run(plugin, ChannelCandidate, games, {"San Antonio Spurs": []})
+        assert "channels naming either team in this window: 0" in msg
+        assert "feed likely is not in your lineup" in msg
+
+    def test_near_miss_one_team_only(self, plugin, ChannelCandidate):
+        # A channel whose guide names ONLY the away team. Both-team gate fails,
+        # so it is a near-miss the user can act on (likely an alias gap).
+        cands = [_cand(ChannelCandidate, "Sports 5", "Lakers Game Tonight")]
+        games = [_game("Los Angeles Lakers", "Boston Celtics")]
+        msg = _run(plugin, ChannelCandidate, games, {"Boston Celtics": cands})
+        assert "channels naming either team in this window: 1" in msg
+        assert "named: away" in msg                 # hit Lakers, not Celtics
+        assert "name-spelling gap" in msg           # the alias-gap conclusion
+
+    def test_preview_card_is_flagged_and_skipped(self, plugin, ChannelCandidate):
+        # A preview card names BOTH teams but is not the live broadcast. The
+        # matcher strips it; the diagnostic must say so rather than imply a match.
+        cands = [
+            _cand(ChannelCandidate, "ESPN", "NBA Tonight"),                  # neither
+            _cand(ChannelCandidate, "NBA TV", "Next Game: Knicks vs Spurs"), # both, preview
+        ]
+        games = [_game("New York Knicks", "San Antonio Spurs")]
+        msg = _run(plugin, ChannelCandidate, games, {"San Antonio Spurs": cands})
+        assert "[PREVIEW card - skipped on purpose]" in msg
+        assert "preview / pre-game cards" in msg
+        assert "named: neither" in msg              # the ESPN line
+
+    def test_field_event_short_circuit(self, plugin, ChannelCandidate):
+        # away == "Field" sentinel (#127): say it is a known limitation, do not
+        # run the lookup or report a misleading "0 candidates".
+        games = [_game("Field", "UFC Freedom 250: Topuria vs. Gaethje", prefix="UFC")]
+        msg = _run(plugin, ChannelCandidate, games, {})
+        assert "known limitation" in msg
+        assert "#127" in msg
+        assert "channels naming either team" not in msg
+
+    def test_matched_games_shown_for_contrast(self, plugin, ChannelCandidate):
+        games = [
+            _game("New York Knicks", "San Antonio Spurs"),                    # unmatched
+            _game("Scotland", "Haiti", prefix="WC", matched="Peacock 12"),    # matched
+        ]
+        msg = _run(plugin, ChannelCandidate, games, {"San Antonio Spurs": []})
+        assert "1 matched" in msg and "1 unmatched" in msg
+        assert "MATCHED (for contrast" in msg
+        assert "Peacock 12" in msg
+
+    def test_empty_cache_prompts_refresh(self, plugin, ChannelCandidate):
+        msg = _run(plugin, ChannelCandidate, [], {})
+        assert "Cache empty" in msg and "refresh" in msg.lower()
+
+    def test_ambiguous_multiple_live_both_team_candidates(self, plugin, ChannelCandidate):
+        # Two NON-preview channels both name both teams: not a preview situation,
+        # not an alias gap. The matcher could not auto-pick (LLM off/abstained).
+        cands = [
+            _cand(ChannelCandidate, "Feed A", "Knicks vs Spurs - Feed A"),
+            _cand(ChannelCandidate, "Feed B", "Knicks vs Spurs - Feed B"),
+        ]
+        games = [_game("New York Knicks", "San Antonio Spurs")]
+        msg = _run(plugin, ChannelCandidate, games, {"San Antonio Spurs": cands})
+        assert "ambiguous" in msg
+        assert "2 channel(s) named both teams" in msg
+        assert "PREVIEW card" not in msg            # not the preview branch
+        assert "name-spelling gap" not in msg       # not the alias branch
+
+    def test_candidate_list_is_capped_and_counts_remainder(self, plugin, ChannelCandidate):
+        cap = plugin._DIAGNOSE_MAX_CANDIDATES
+        cands = [_cand(ChannelCandidate, f"Ch {i}", "Lakers Tonight")
+                 for i in range(cap + 3)]                  # only away team named
+        games = [_game("Los Angeles Lakers", "Boston Celtics")]
+        msg = _run(plugin, ChannelCandidate, games, {"Boston Celtics": cands})
+        assert f"channels naming either team in this window: {cap + 3}" in msg
+        assert f"and 3 more (omitted" in msg
+        assert msg.count('- "Ch ') == cap               # exactly `cap` lines shown
+
+    def test_matched_list_is_capped_and_counts_remainder(self, plugin, ChannelCandidate):
+        cap = plugin._DIAGNOSE_MAX_CANDIDATES
+        games = [_game(f"Away {i}", f"Home {i}", prefix="WC", matched=f"Ch {i}")
+                 for i in range(cap + 2)]
+        msg = _run(plugin, ChannelCandidate, games, {})
+        assert "Every curated game matched a channel" in msg   # no unmatched
+        assert "MATCHED (for contrast" in msg
+        assert "and 2 more matched." in msg
+
+
+class TestActionContract:
+    """The dispatch table and the manifest must declare the SAME action ids.
+    A manifest button with no handler returns 'Unknown action' at runtime; a
+    handler with no button is dead. Catch both here instead of in production."""
+
+    def test_manifest_actions_match_dispatch_table(self, plugin):
+        import json
+        manifest = json.load(open(os.path.join(REPO_ROOT, "plugin.json")))
+        manifest_ids = {a["id"] for a in manifest["actions"]}
+        handler_ids = set(plugin._ACTION_HANDLERS)
+        assert manifest_ids == handler_ids, (
+            f"manifest-only: {manifest_ids - handler_ids}; "
+            f"handler-only: {handler_ids - manifest_ids}"
+        )
+
+    def test_every_handler_is_callable(self, plugin):
+        assert all(callable(h) for h in plugin._ACTION_HANDLERS.values())


### PR DESCRIPTION
Closes #128.

## What

A new **Diagnose matching** plugin action whose entire output is one copy-pasteable block explaining, per game, why a match did or did not land. Built for the recurring "channels show up but no streams attach" report from users who cannot read container logs.

For each unmatched game it reports:
- the exact team keywords the matcher searched for (so an alias/spelling gap is eyeball-obvious),
- which channels named one team, both, or neither in the time window,
- why a near-miss was skipped: preview/pre-game card, only-one-team, or ambiguous-with-no-LLM-tiebreak,
- a plain "known limitation" line for field-event sports (#127) instead of a misleading "0 candidates".

It re-runs the matcher's own `_build_epg_lookup`, so it reports exactly what the matcher saw, never a parallel heuristic. Read-only: no DB writes, no apply.

## Review-pass cleanup (same touched files)

- Extracted `matcher._kw_hit`, the single substring-hit test now shared by every matcher tier and the diagnostic (was duplicated 4x in `matcher.py`).
- Replaced `run()`'s action if-chain with a single `_ACTION_HANDLERS` dispatch table (one source of truth for action ids). A contract test asserts the manifest's action ids equal the table's keys, so a button with no handler (or a handler with no button) fails CI rather than returning "Unknown action" at runtime.
- Fixed a conclusion-logic bug found in review: an ambiguous match with the LLM off was mislabeled as "preview cards"; now distinguished.

## Tests

`tests/test_diagnose.py`: every branch (0-candidates, near-miss one-team, preview-skip, ambiguous, field-event, matched-contrast, empty-cache), both truncation caps, and the manifest↔dispatch contract. Full suite **3208 passed**.

## Live verification

Built, deployed to the live container, and invoked end-to-end through the HTTP run API (`POST .../run/ {"action":"diagnose"}`) both before and after the review refactor. Real output against a 25-game slate correctly classified 9 matched / 16 unmatched, and immediately revealed the field's "future games not carried yet" pattern. The refactor produced byte-identical classification, confirming `_kw_hit` and the dispatch table are non-breaking.

## Surfaced (filed separately, not fixed here)

- #127 — field-event sports (UFC/F1/golf/etc.) never match (the "Field" sentinel defeats the both-teams gate).
- #129 — matcher false positives (generic channels, wrong-opponent feeds).

Version bumped to 1.5.0 across `plugin.py` / `plugin.json` / `__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)