### PR TITLE
Fix field-event sports (UFC, F1, golf, NASCAR, ATP/WTA) never matching a channel (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-13
+
+### Fixed
+
+- **Field-event sports (UFC, F1, golf, NASCAR, ATP/WTA) now match channels
+  (#127).** These single-event sports have no opponent, so their source emits an
+  away-side `"Field"` sentinel. The matcher's both-teams gate fed that sentinel
+  into its keyword logic, and since no channel or EPG title ever contains the
+  word "Field" the gate could never be satisfied: every field-event game fell
+  through to a placeholder with no streams. The matcher and the EPG candidate
+  lookup now detect the single-event shape and match on the event name alone,
+  dropping the away-side requirement. Two-team sports are unchanged.
+
+### Changed
+
+- **"Diagnose matching" now diagnoses field events too.** Previously it skipped
+  them as unmatchable (#127); now that they match, an unmatched field event is an
+  ordinary diagnosable target, with the window scan keyed on the event name
+  instead of a head-to-head separator.
+
+### Internal
+
+- The `"Field"` away sentinel and field-event detection are consolidated into a
+  single `_util.is_field_event()` / `FIELD_AWAY_SENTINEL`, replacing three
+  independent copies (`sources/field_event.py`, `logos.py`, an inline literal in
+  `plugin.py`).
+
 ## [1.6.0] - 2026-06-13
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.6.0"
+__version__ = "1.7.0"

--- a/_util.py
+++ b/_util.py
@@ -168,6 +168,31 @@ GENERIC_TEAM_SECOND_WORDS = (
 )
 
 
+# Sentinel `away` value emitted by field-event sources (F1, NASCAR, golf, UFC,
+# ATP, WTA): a single event with a whole field of competitors and no
+# head-to-head opponent. This module is the SINGLE SOURCE OF TRUTH for the
+# value. DO NOT re-declare a local `_FIELD_AWAY_SENTINEL = "Field"` or compare
+# against the bare string "Field" anywhere else: every layer that special-cases
+# field events (sources/field_event.py emits it, matcher drops its both-teams
+# gate on it, logos skips the head-to-head thumb lookup, the diagnose action
+# labels it) MUST import this constant or call is_field_event(), or they drift.
+# See sources/field_event.py and #127.
+FIELD_AWAY_SENTINEL = "Field"
+
+
+def is_field_event(away: Optional[str], extra: Optional[Dict[str, Any]] = None) -> bool:
+    """Whether a game is a single-event sport with no head-to-head opponent.
+
+    Primary signal is the source-set `extra["is_field_event"]` flag; falls back
+    to the `away` sentinel so callers that only carry a cached game dict (which
+    may predate the flag, or strip `extra`) still classify correctly. Either
+    signal alone is sufficient; both are set by current field-event sources.
+    """
+    if extra and extra.get("is_field_event"):
+        return True
+    return away == FIELD_AWAY_SENTINEL
+
+
 # ---------- playoff-series rendering ----------
 #
 # The sport-agnostic `extra["series"]` schema that best-of-N sources populate

--- a/logos.py
+++ b/logos.py
@@ -27,6 +27,8 @@ import urllib.request
 from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
+from ._util import is_field_event
+
 logger = logging.getLogger(__name__)
 
 _SEARCH_URL = "https://www.thesportsdb.com/api/v1/json/{key}/searchevents.php?e={q}"
@@ -55,10 +57,6 @@ _TRAILING_CLUB_QUALIFIERS = ("FC", "AFC", "CF", "SC", "FK", "AC")
 _TRAILING_QUALIFIER_RE = re.compile(
     r"\s+(" + "|".join(_TRAILING_CLUB_QUALIFIERS) + r")$", re.IGNORECASE
 )
-
-# Sentinel `away` value used by field-event sources (F1, golf, UFC, tennis,
-# NASCAR). These have no home/away matchup so SportsDB lookup is skipped.
-_FIELD_AWAY_SENTINEL = "Field"
 
 # Plugin sport_prefix -> substring that must appear in SportsDB's strLeague or
 # strSport for the result to be accepted. Disambiguates same-name cross-sport
@@ -256,7 +254,7 @@ def resolve_thumb_url(
     """Search SportsDB for a matchup event and return its strThumb URL.
 
     Returns None when:
-      - away == "Field" (field-event sentinel: no h2h matchup)
+      - the game is a field event (is_field_event: no h2h matchup)
       - the search returns no events
       - no event matches both the date tolerance AND the sport hint
       - the matched event has no strThumb
@@ -266,7 +264,7 @@ def resolve_thumb_url(
     """
     if not home or not away:
         return None
-    if away == _FIELD_AWAY_SENTINEL:
+    if is_field_event(away):
         return None
 
     q = _build_search_query(home, away)

--- a/matcher.py
+++ b/matcher.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from ._util import GENERIC_TEAM_SECOND_WORDS, TEAM_SUFFIX_TOKENS
+from ._util import GENERIC_TEAM_SECOND_WORDS, TEAM_SUFFIX_TOKENS, is_field_event
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.matcher")
 
@@ -159,10 +159,17 @@ def _kw_hit(text: str, keywords: List[str]) -> bool:
 def _regex_filter(
     candidates: List[ChannelCandidate],
     team_a: str,
-    team_b: str,
+    team_b: Optional[str] = None,
 ) -> List[ChannelCandidate]:
-    """Programs whose title contains references to BOTH teams."""
+    """Programs whose title references both teams.
+
+    `team_b=None` is the single-sided mode for field events (#127): one event,
+    no opponent, so we match on the event name (`team_a`) alone. The both-teams
+    gate would otherwise be unsatisfiable against the "Field" away sentinel.
+    """
     a_kws = _team_keywords(team_a)
+    if team_b is None:
+        return [c for c in candidates if _kw_hit(c.program_title, a_kws)]
     b_kws = _team_keywords(team_b)
     return [c for c in candidates
             if _kw_hit(c.program_title, a_kws) and _kw_hit(c.program_title, b_kws)]
@@ -171,7 +178,7 @@ def _regex_filter(
 def _regex_filter_channel_name(
     candidates: List[ChannelCandidate],
     team_a: str,
-    team_b: str,
+    team_b: Optional[str] = None,
 ) -> List[ChannelCandidate]:
     """Stricter filter: channels whose CHANNEL NAME contains both teams.
 
@@ -185,8 +192,13 @@ def _regex_filter_channel_name(
     channels (US/AU/EU regional variants, different bitrates), all of which
     name both teams in the channel name. Returning the full set lets the
     caller stack them as fallback streams on the virtual channel.
+
+    `team_b=None` is the single-sided mode for field events (#127): the event
+    name (`team_a`) alone identifies the broadcast, since there is no opponent.
     """
     a_kws = _team_keywords(team_a)
+    if team_b is None:
+        return [c for c in candidates if _kw_hit(c.channel_name, a_kws)]
     b_kws = _team_keywords(team_b)
     return [c for c in candidates
             if _kw_hit(c.channel_name, a_kws) and _kw_hit(c.channel_name, b_kws)]
@@ -353,10 +365,18 @@ def match_games_to_channels(
             results[i].note = "no EPG candidates in time window"
             continue
 
-        # Tier 1 (strongest signal): channels whose NAME contains both teams.
-        # These are dedicated match channels: typically multiple regional /
-        # quality variants of the same fixture. Stack all of them.
-        strict = _regex_filter_channel_name(candidates, game.home, game.away)
+        # Field events (UFC/F1/golf/NASCAR/ATP/WTA, #127) have no opponent: the
+        # away side is the "Field" sentinel, which no channel or title ever
+        # names. Drop the both-teams gate and match on the event name (home)
+        # alone, exactly as field_event.py's design contract assumes. Two-team
+        # games keep `match_away = game.away` and the full both-teams gate.
+        match_away = None if is_field_event(game.away, getattr(game, "extra", None)) else game.away
+
+        # Tier 1 (strongest signal): channels whose NAME contains both teams
+        # (or, for field events, the event name). These are dedicated match
+        # channels: typically multiple regional / quality variants of the same
+        # fixture. Stack all of them.
+        strict = _regex_filter_channel_name(candidates, game.home, match_away)
         if strict:
             primary = strict[0]
             results[i].channel_id = primary.channel_id
@@ -375,7 +395,7 @@ def match_games_to_channels(
         # 'Pre-game ...') stripped: those mark team-branded home channels
         # that surface upcoming-game EPG cards but don't broadcast the match.
         filtered = _strip_preview_titles(
-            _regex_filter(candidates, game.home, game.away)
+            _regex_filter(candidates, game.home, match_away)
         )
         if len(filtered) == 1:
             c = filtered[0]

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/plugin.py
+++ b/plugin.py
@@ -47,6 +47,7 @@ from ._util import (
     group_phase_text,
     group_results_lines,
     group_standings_lines,
+    is_field_event,
     parse_iso_utc,
     series_phase_text,
     series_record_text,
@@ -1343,11 +1344,21 @@ def _build_epg_lookup():
         window_start = game.start_time - timedelta(minutes=pre_min)
         window_end = game.start_time + timedelta(hours=post_hours)
 
+        # Field events (#127) have no opponent: the away side is the "Field"
+        # sentinel. Match on the event name (home) alone, both for the Path A
+        # title pre-filter and the Path B channel-name query below, mirroring
+        # the matcher's single-sided tiers. Two-team games keep both sides.
+        field = is_field_event(game.away, getattr(game, "extra", None))
         home_kws = _team_keywords(game.home)
-        away_kws = _team_keywords(game.away)
-        all_kws = home_kws + away_kws
-        if not (home_kws and away_kws):
-            return []
+        away_kws = [] if field else _team_keywords(game.away)
+        if field:
+            all_kws = home_kws
+            if not home_kws:
+                return []
+        else:
+            all_kws = home_kws + away_kws
+            if not (home_kws and away_kws):
+                return []
 
         # Path A: programs in window whose TITLE mentions any team keyword.
         title_q = Q()
@@ -1373,12 +1384,19 @@ def _build_epg_lookup():
         home_name_q = Q()
         for kw in home_kws:
             home_name_q |= Q(name__icontains=kw)
-        away_name_q = Q()
-        for kw in away_kws:
-            away_name_q |= Q(name__icontains=kw)
+        if field:
+            # Single-sided: a channel naming the event is the broadcast. ANDing
+            # the "Field" sentinel here (as the two-team path does) would match
+            # nothing, which is the #127 bug.
+            name_q = home_name_q
+        else:
+            away_name_q = Q()
+            for kw in away_kws:
+                away_name_q |= Q(name__icontains=kw)
+            name_q = home_name_q & away_name_q
         name_match_chans = list(
             Channel.objects
-            .filter(home_name_q & away_name_q)
+            .filter(name_q)
             .exclude(_owned_tvg_id_q())
             .only("id", "name", "epg_data_id")
         )
@@ -2855,19 +2873,24 @@ def _named_sides(text: str, home_kws: List[str], away_kws: List[str]) -> Tuple[b
     return _kw_hit(text, home_kws), _kw_hit(text, away_kws)
 
 
-def _diagnose_window_sample(start_dt, sport_prefix, home, away, home_kws, away_kws):
-    """Return rows of MATCHUP-shaped programming airing in the chosen game's
-    window, so a human can spot the game sitting under a spelling our keywords
-    miss.
+def _diagnose_window_sample(start_dt, sport_prefix, home, away, home_kws, away_kws,
+                            field=False):
+    """Return rows of candidate programming airing in the chosen game's window,
+    so a human can spot the game sitting under a spelling our keywords miss.
 
-    Only programs whose title looks like a head-to-head ("A vs B", "A @ B") are
-    returned (see _MATCHUP_MARKERS): that is what a game listing is in any
-    language, and it keeps the list to actual fixtures instead of every sports
-    channel in the window.
+    Two-team games: only programs whose title looks like a head-to-head
+    ("A vs B", "A @ B") are returned (see _MATCHUP_MARKERS): that is what a game
+    listing is in any language, and it keeps the list to actual fixtures instead
+    of every sports channel in the window. annotation flags whether the row
+    names BOTH teams, one team, or neither.
+
+    Field events (#127): there is no opponent, so the head-to-head separators
+    don't apply (golf/F1/NASCAR titles have none). Instead we surface programs
+    whose title names the event itself (home keywords), and annotate " [event]"
+    when the channel/title names it. `away_kws` is empty in this mode.
 
     rows: list of (channel_name, program_title, annotation), one per channel,
-    ordered with team-naming channels first. annotation flags whether the row
-    names BOTH teams, one team, or neither.
+    ordered with naming channels first.
     """
     from apps.epg.models import ProgramData
     from apps.channels.models import Channel
@@ -2878,8 +2901,13 @@ def _diagnose_window_sample(start_dt, sport_prefix, home, away, home_kws, away_k
     win_end = start_dt + timedelta(hours=post_hours)
 
     title_q = Q()
-    for t in _MATCHUP_MARKERS:
-        title_q |= Q(title__icontains=t)
+    if field:
+        # Find programs that name the event; there is no h2h separator to key on.
+        for kw in home_kws:
+            title_q |= Q(title__icontains=kw)
+    else:
+        for t in _MATCHUP_MARKERS:
+            title_q |= Q(title__icontains=t)
 
     progs = list(
         ProgramData.objects
@@ -2909,7 +2937,10 @@ def _diagnose_window_sample(start_dt, sport_prefix, home, away, home_kws, away_k
             nh, na = _named_sides(c.name, home_kws, away_kws)
             th, ta = _named_sides(title, home_kws, away_kws)
             h, a = (nh or th), (na or ta)
-            if h and a:
+            if field:
+                # Single-sided: there is only the event name to find.
+                ann, rank = (" [event]", 1) if h else ("", 2)
+            elif h and a:
                 ann, rank = " [BOTH TEAMS]", 0
             elif h:
                 ann, rank = f" [{home}]", 1
@@ -2952,6 +2983,10 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
     unmatched = [g for g in games if not g.get("channel_name_current")]
 
     def _label(g: Dict[str, Any]) -> str:
+        # Field events have no opponent, so render the event name alone instead
+        # of the misleading "Field at <event>".
+        if is_field_event(g.get("away"), g.get("extra")):
+            return f"{g.get('sport_prefix', '?')} {g.get('home', '')} ({g.get('kickoff_local', '')})"
         return (f"{g.get('sport_prefix', '?')} {g.get('away', '')} at "
                 f"{g.get('home', '')} ({g.get('kickoff_local', '')})")
 
@@ -2963,17 +2998,16 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
         return {"status": "ok",
                 "message": f"Ranked Matchups: {len(games)} games, all matched. Nothing to diagnose."}
 
-    # Deep-dive the SOONEST-starting unmatched game that CAN match (skip the
-    # "Field" field-event sentinel, #127). Soonest, not highest-scored: a game
-    # is only diagnosable once its guide exists, so a far-future game would
-    # trivially show an empty window. Soonest is also the game a user is most
-    # likely asking about, regardless of its interestingness score.
+    # Deep-dive the SOONEST-starting unmatched game. Soonest, not
+    # highest-scored: a game is only diagnosable once its guide exists, so a
+    # far-future game would trivially show an empty window. Soonest is also the
+    # game a user is most likely asking about, regardless of its
+    # interestingness score. Field events (#127) are matched single-sided and
+    # are ordinary diagnosable targets, not skipped.
     from datetime import datetime, timezone
     now = datetime.now(timezone.utc)
     diggable = []
     for g in unmatched:
-        if g.get("away") == "Field":
-            continue
         dt = parse_iso_utc(g.get("start_time_utc"))
         if dt is not None:
             diggable.append((dt, g))
@@ -2999,16 +3033,19 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
     rows: List[Any] = []
     verdict = ""
     toast: List[str] = []
+    field = False
 
     if target is None:
-        non_field = [g for g in unmatched if g.get("away") != "Field"]
-        verdict = ("All unmatched games are field-event sports (UFC/F1/golf), not "
-                   "matchable yet (#127)." if not non_field else
-                   "Could not pick a game to diagnose (no kickoff time in cache); send us this.")
+        verdict = "Could not pick a game to diagnose (no kickoff time in cache); send us this."
         toast = [verdict]
     else:
         home, away = target.get("home", ""), target.get("away", "")
-        home_kws, away_kws = _team_keywords(home), _team_keywords(away)
+        # Field events (#127) match single-sided on the event name; there is no
+        # away side to search for, so away_kws is empty and the both-teams
+        # bookkeeping below collapses to a single "names the event" signal.
+        field = is_field_event(away, target.get("extra"))
+        home_kws = _team_keywords(home)
+        away_kws = [] if field else _team_keywords(away)
         start_dt = parse_iso_utc(target.get("start_time_utc"))
         head = f"Closest of {len(unmatched)} unmatched: {_label(target)}"
         if start_dt is None:
@@ -3017,7 +3054,8 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
         else:
             try:
                 rows = _diagnose_window_sample(
-                    start_dt, target.get("sport_prefix"), home, away, home_kws, away_kws)
+                    start_dt, target.get("sport_prefix"), home, away,
+                    home_kws, away_kws, field=field)
             except Exception:  # diagnostic must never raise
                 rows = []
             # Single most relevant listing that names a team (both > one); an
@@ -3025,20 +3063,29 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
             both = next((r for r in rows if r[2] == " [BOTH TEAMS]"), None)
             one = next((r for r in rows if r[2] and r[2] != " [BOTH TEAMS]"), None)
             shim = SimpleNamespace(sport_prefix=target.get("sport_prefix"),
-                                   start_time=start_dt, home=home, away=away)
+                                   start_time=start_dt, home=home, away=away,
+                                   extra=target.get("extra") or {})
             try:
                 cands = _build_epg_lookup()(shim)
             except Exception:
                 cands = []
-            if cands and _regex_filter_channel_name(cands, home, away):
-                verdict = ("A channel name has both teams but it didn't match - "
-                           "unexpected; please send us this.")
+            # Single-sided channel-name check for field events (team_b=None).
+            name_match = _regex_filter_channel_name(
+                cands, home, None if field else away) if cands else []
+            if name_match:
+                verdict = (("A channel name has the event but it didn't match - "
+                            if field else
+                            "A channel name has both teams but it didn't match - ")
+                           + "unexpected; please send us this.")
             elif both:
                 verdict = ("A listing names BOTH teams but wasn't auto-picked - reply "
                            "and we'll fix it.")
             elif one:
                 verdict = ("Likely a name/spelling gap: if 'Saw' above is this game, "
                            "reply with that exact title.")
+            elif field:
+                verdict = ("Nothing in your guide names this event - likely not carried "
+                           "(often a future event), or named differently; reply if you spot it.")
             else:
                 verdict = ("Nothing in your guide names either team - likely not carried "
                            "(often a future game), or named differently; reply if you spot it.")
@@ -3056,8 +3103,12 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
     ]
     if target is not None:
         vlog.append(f"deep dive (soonest unmatched): {_label(target)}")
-        vlog.append(f"  searched - {away}: {', '.join(away_kws)} | "
-                    f"{home}: {', '.join(home_kws)}")
+        if field:
+            vlog.append(f"  searched - event {home}: {', '.join(home_kws)} "
+                        "(field event, no opponent)")
+        else:
+            vlog.append(f"  searched - {away}: {', '.join(away_kws)} | "
+                        f"{home}: {', '.join(home_kws)}")
         if rows:
             vlog.append(f"  head-to-head listings in its window ({len(rows)}):")
             for name, title, ann in rows[:40]:
@@ -3069,7 +3120,7 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
     vlog.append(f"  verdict: {verdict}")
     vlog.append(f"all unmatched ({len(unmatched)}):")
     for g in unmatched:
-        tag = " (field event #127)" if g.get("away") == "Field" else ""
+        tag = " (field event)" if is_field_event(g.get("away"), g.get("extra")) else ""
         vlog.append(f"  {_label(g)}{tag}")
     if matched:
         vlog.append(f"matched ({len(matched)}):")
@@ -3260,7 +3311,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.6.0"
+    version = "1.7.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -36,12 +36,9 @@ from typing import Any, List, Optional, Pattern
 import requests
 
 from .base import GameRow, SportSource
-from .._util import parse_iso_utc
+from .._util import FIELD_AWAY_SENTINEL, parse_iso_utc
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.field_event")
-
-
-_FIELD_AWAY_SENTINEL = "Field"
 
 
 class FieldEventSource(SportSource):
@@ -118,7 +115,7 @@ class FieldEventSource(SportSource):
                 sport_prefix=self.sport_prefix,
                 sport_label=self.sport_label,
                 home=display_name,
-                away=_FIELD_AWAY_SENTINEL,
+                away=FIELD_AWAY_SENTINEL,
                 rank_home=None,
                 rank_away=None,
                 start_time=start,

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -42,6 +42,19 @@ def plugin():
     return _load("plugin")
 
 
+@pytest.fixture(autouse=True)
+def _restore_plugin_attrs(plugin):
+    """`_run` stubs module-level callables by direct assignment; snapshot and
+    restore them so the stubs don't leak into other test files sharing this
+    process (notably test_field_event_lookup, which drives the real
+    _build_epg_lookup)."""
+    names = ("_read_cache", "_diagnose_window_sample", "_build_epg_lookup", "logger")
+    saved = {n: getattr(plugin, n) for n in names}
+    yield
+    for n, v in saved.items():
+        setattr(plugin, n, v)
+
+
 @pytest.fixture(scope="module")
 def ChannelCandidate():
     return _load("matcher").ChannelCandidate
@@ -144,11 +157,32 @@ class TestDeepDive:
         saw_line = next(l for l in msg.splitlines() if l.startswith("Saw "))
         assert len(saw_line) < 90
 
-    def test_all_field_events_short_circuits(self, plugin):
+    def test_field_event_is_diagnosed_not_skipped(self, plugin):
+        # #127: field events now match single-sided, so an unmatched one is an
+        # ordinary diagnosable target (previously short-circuited as
+        # "unmatchable").
         games = [_game("Field", "UFC Freedom 250: Topuria vs Gaethje", prefix="UFC", score=2.0)]
-        msg = _run(plugin, games)
-        assert "field-event" in msg and "#127" in msg
-        assert "Closest of" not in msg
+        msg = _run(plugin, games, window_rows=[])
+        assert "Closest of 1 unmatched" in msg
+        assert "UFC Freedom 250" in msg          # rendered as the event name...
+        assert "Field at" not in msg             # ...not the misleading "Field at"
+        assert "names this event" in msg         # field-specific verdict
+
+    def test_field_event_with_event_listing_yields_spelling_gap(self, plugin):
+        rows = [("BT Sport 1", "UFC 250: Topuria vs Gaethje", " [event]")]
+        games = [_game("Field", "UFC 250: Topuria vs Gaethje", prefix="UFC", score=2.0)]
+        msg = _run(plugin, games, window_rows=rows)
+        assert "Saw BT Sport 1" in msg
+        assert "spelling gap" in msg
+
+    def test_field_event_channel_name_match_is_unexpected(self, plugin, ChannelCandidate):
+        # A channel NAME carries the event but it didn't auto-match: flag it,
+        # with field-specific wording ("has the event", not "has both teams").
+        cands = [_cand(ChannelCandidate, "UFC 250: Topuria vs Gaethje HD")]
+        rows = [("UFC 250: Topuria vs Gaethje HD", "", " [event]")]
+        games = [_game("Field", "UFC 250: Topuria vs Gaethje", prefix="UFC", score=2.0)]
+        msg = _run(plugin, games, window_rows=rows, lookup_cands=cands)
+        assert "has the event but it didn't match" in msg
 
     def test_non_target_games_not_listed(self, plugin):
         # The full unmatched slate is NOT dumped (toast length): only the target.

--- a/tests/test_field_event_lookup.py
+++ b/tests/test_field_event_lookup.py
@@ -1,0 +1,205 @@
+"""Lookup-side coverage for #127: `_build_epg_lookup` must match field events
+(away == 'Field') on the event name alone.
+
+`_build_epg_lookup` does its Django imports lazily inside the closure, so we
+inject a tiny in-memory fake ORM into sys.modules before calling it. The fake
+`Q` builds an AND/OR predicate tree and evaluates it against plain row objects,
+which is enough to prove the query SHAPE the lookup builds:
+
+  - two-team games keep the Path-B `home AND away` channel-name gate, and
+  - field events drop it to `home` alone (the #127 fix).
+
+Before the fix, Path B ANDed the unmatchable 'Field' sentinel, so a field-event
+broadcast advertised only in the channel NAME (no program data) was invisible.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = "dispatcharr_ranked_matchups"
+
+
+# --------------------------------------------------------------------------- #
+# Minimal fake ORM
+# --------------------------------------------------------------------------- #
+class FakeQ:
+    """AND/OR predicate tree over Django-style `field__lookup=value` kwargs."""
+
+    def __init__(self, **kwargs):
+        self._tests = list(kwargs.items())
+        self._or = []
+        self._and = []
+
+    def _empty(self):
+        return not self._tests and not self._or and not self._and
+
+    def __or__(self, other):
+        if self._empty():
+            return other
+        if other._empty():
+            return self
+        n = FakeQ()
+        n._or = [self, other]
+        return n
+
+    __ior__ = __or__
+
+    def __and__(self, other):
+        if self._empty():
+            return other
+        if other._empty():
+            return self
+        n = FakeQ()
+        n._and = [self, other]
+        return n
+
+    __iand__ = __and__
+
+    def matches(self, row):
+        if self._or:
+            return any(q.matches(row) for q in self._or)
+        if self._and:
+            return all(q.matches(row) for q in self._and)
+        if not self._tests:
+            return True
+        for key, val in self._tests:
+            field, _, lookup = key.partition("__")
+            actual = getattr(row, field, "" if "time" not in field else None)
+            if lookup == "icontains":
+                if str(val).lower() not in str(actual or "").lower():
+                    return False
+            elif lookup == "startswith":
+                if not str(actual or "").startswith(str(val)):
+                    return False
+            elif lookup == "in":
+                if actual not in val:
+                    return False
+            elif lookup == "lt":
+                if not (actual is not None and actual < val):
+                    return False
+            elif lookup == "gt":
+                if not (actual is not None and actual > val):
+                    return False
+            else:  # exact
+                if actual != val:
+                    return False
+        return True
+
+
+class FakeManager:
+    def __init__(self, rows, includes=None, excludes=None):
+        self._rows = rows
+        self._inc = list(includes or [])
+        self._exc = list(excludes or [])
+
+    def filter(self, *qs, **kw):
+        inc = self._inc + list(qs) + ([FakeQ(**kw)] if kw else [])
+        return FakeManager(self._rows, inc, self._exc)
+
+    def exclude(self, *qs, **kw):
+        exc = self._exc + list(qs) + ([FakeQ(**kw)] if kw else [])
+        return FakeManager(self._rows, self._inc, exc)
+
+    def only(self, *a):
+        return self
+
+    def __iter__(self):
+        for r in self._rows:
+            if all(q.matches(r) for q in self._inc) and not any(q.matches(r) for q in self._exc):
+                yield r
+
+
+class _Row:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _install_fake_orm(monkeypatch, channels, programs):
+    """Register fake apps.channels.models / apps.epg.models / django.db.models."""
+    chan_mod = types.ModuleType("apps.channels.models")
+    chan_mod.Channel = types.SimpleNamespace(objects=FakeManager(channels))
+    epg_mod = types.ModuleType("apps.epg.models")
+    epg_mod.ProgramData = types.SimpleNamespace(objects=FakeManager(programs))
+    dj_mod = types.ModuleType("django.db.models")
+    dj_mod.Q = FakeQ
+    for name, mod in [
+        ("apps", types.ModuleType("apps")),
+        ("apps.channels", types.ModuleType("apps.channels")),
+        ("apps.channels.models", chan_mod),
+        ("apps.epg", types.ModuleType("apps.epg")),
+        ("apps.epg.models", epg_mod),
+        ("django", types.ModuleType("django")),
+        ("django.db", types.ModuleType("django.db")),
+        ("django.db.models", dj_mod),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+@pytest.fixture(scope="module")
+def plugin():
+    if f"{PKG_NAME}._util" not in sys.modules:
+        uspec = importlib.util.spec_from_file_location(
+            f"{PKG_NAME}._util", os.path.join(REPO_ROOT, "_util.py"))
+        umod = importlib.util.module_from_spec(uspec)
+        sys.modules[f"{PKG_NAME}._util"] = umod
+        uspec.loader.exec_module(umod)
+    if f"{PKG_NAME}.plugin" in sys.modules:
+        return sys.modules[f"{PKG_NAME}.plugin"]
+    spec = importlib.util.spec_from_file_location(
+        f"{PKG_NAME}.plugin", os.path.join(REPO_ROOT, "plugin.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{PKG_NAME}.plugin"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _game(home, away, *, prefix="UFC", extra=None):
+    start = datetime(2026, 6, 15, 20, 0, tzinfo=timezone.utc)
+    return types.SimpleNamespace(
+        home=home, away=away, sport_prefix=prefix, start_time=start,
+        extra=extra if extra is not None else {})
+
+
+class TestFieldEventLookup:
+    def test_field_event_matches_channel_named_for_event(self, plugin, monkeypatch):
+        # The #127 case: a broadcast advertised ONLY in the channel name, no
+        # program data. Old code ANDed the 'Field' sentinel and found nothing.
+        chans = [_Row(id=1, name="UFC 250: Topuria vs Gaethje (PPV)", epg_data_id=None)]
+        _install_fake_orm(monkeypatch, chans, programs=[])
+        game = _game("UFC 250: Topuria vs Gaethje", "Field",
+                     extra={"is_field_event": True})
+        out = plugin._build_epg_lookup()(game)
+        assert [c.channel_id for c in out] == [1]
+
+    def test_field_event_matches_program_title(self, plugin, monkeypatch):
+        # Path A: a generic channel carrying a program that names the event.
+        win = datetime(2026, 6, 15, 20, 0, tzinfo=timezone.utc)
+        chans = [_Row(id=7, name="BT Sport 1", epg_data_id=99)]
+        progs = [_Row(id=1, title="UFC 250: Topuria vs Gaethje",
+                      start_time=win, end_time=win + timedelta(hours=2), epg_id=99)]
+        _install_fake_orm(monkeypatch, chans, progs)
+        game = _game("UFC 250: Topuria vs Gaethje", "Field")  # sentinel only, no extra
+        out = plugin._build_epg_lookup()(game)
+        assert any(c.channel_id == 7 and "UFC 250" in c.program_title for c in out)
+
+    def test_two_team_game_keeps_both_sides_gate(self, plugin, monkeypatch):
+        # Regression: a channel naming only ONE team must NOT match a two-team
+        # game (the AND gate is intact for non-field events).
+        chans = [_Row(id=3, name="Arsenal TV", epg_data_id=None)]  # only home
+        _install_fake_orm(monkeypatch, chans, programs=[])
+        game = _game("Arsenal", "Chelsea", prefix="EPL")
+        out = plugin._build_epg_lookup()(game)
+        assert out == []
+
+    def test_two_team_game_matches_channel_with_both(self, plugin, monkeypatch):
+        chans = [_Row(id=4, name="EPL01: Arsenal v Chelsea", epg_data_id=None)]
+        _install_fake_orm(monkeypatch, chans, programs=[])
+        game = _game("Arsenal", "Chelsea", prefix="EPL")
+        out = plugin._build_epg_lookup()(game)
+        assert [c.channel_id for c in out] == [4]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -511,4 +511,82 @@ class TestWidenStreamPool:
             games, lambda g: cands, api_key="", model="m"
         )
         assert results[0].method == "fallback_first"
-        assert results[0].channel_ids == [400]
+
+
+class TestSingleSidedRegexFilters:
+    """#127: passing team_b=None matches on team_a (the event name) alone,
+    dropping the both-teams requirement for field events."""
+
+    def test_program_title_single_sided(self):
+        cands = [
+            _cand(1, "ESPN+", "UFC 250: Topuria vs Gaethje"),
+            _cand(2, "Random", "Premier League: Arsenal vs Chelsea"),
+        ]
+        out = _regex_filter(cands, "UFC 250: Topuria vs Gaethje")  # team_b defaults to None
+        assert [c.channel_id for c in out] == [1]
+
+    def test_channel_name_single_sided(self):
+        cands = [
+            _cand(1, "PPV: UFC 250 Topuria Gaethje", ""),
+            _cand(2, "EPL01: Arsenal v Chelsea", ""),
+        ]
+        out = _regex_filter_channel_name(cands, "UFC 250: Topuria vs Gaethje")
+        assert [c.channel_id for c in out] == [1]
+
+    def test_both_teams_still_required_when_team_b_given(self):
+        # Regression guard: two-team mode must keep the AND gate.
+        cands = [_cand(1, "ESPN", "Penn State football tonight")]  # only one team
+        assert _regex_filter(cands, "Penn State", "Ohio State") == []
+
+
+class _FieldGame:
+    """A field-event GameRow stand-in: away is the 'Field' sentinel and the
+    source flag is set in extra, exactly as field_event.py emits."""
+
+    def __init__(self, event_name):
+        self.home = event_name
+        self.away = "Field"
+        self.sport_label = "UFC"
+        self.start_time = datetime(2026, 4, 27, tzinfo=timezone.utc)
+        self.extra = {"is_field_event": True}
+
+
+class TestFieldEventMatching:
+    """#127: field events (away='Field') match on the event name alone. Before
+    the fix the both-teams gate fed the 'Field' sentinel into the keyword logic
+    and nothing could ever match."""
+
+    def test_tier1_channel_name_matches_event_name(self):
+        cands = [_cand(10, "UFC 250: Topuria vs Gaethje (PPV)", "Live")]
+        games = [(_FieldGame("UFC 250: Topuria vs Gaethje"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method == "regex_strict"
+        assert results[0].channel_id == 10
+
+    def test_tier2_program_title_matches_event_name(self):
+        # Channel name is generic; the EVENT name is in the program title only.
+        cands = [_cand(20, "BT Sport 1", "UFC 250: Topuria vs Gaethje")]
+        games = [(_FieldGame("UFC 250: Topuria vs Gaethje"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method == "regex_unique"
+        assert results[0].channel_id == 20
+
+    def test_field_event_channel_naming_neither_fails_regex_tiers(self):
+        # A channel that names neither the event nor anything relevant must NOT
+        # pass the single-sided regex tiers (it may still reach the tier-3 LLM,
+        # which is out of scope here).
+        cands = [_cand(30, "Random Movie Channel", "Some Film")]
+        games = [(_FieldGame("The Masters"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method not in ("regex_strict", "regex_unique")
+
+    def test_sentinel_alone_classifies_without_extra_flag(self):
+        # A cached game dict may strip extra; the away sentinel alone must still
+        # trigger single-sided matching.
+        bare = _Game("The Masters", "Field", sport_label="Golf")  # no .extra attr
+        cands = [_cand(40, "Golf Channel: The Masters", "Final round")]
+        results = match_games_to_channels([(bare, None, None)], lambda g: cands,
+                                          api_key="", model="m")
+        assert results[0].method == "regex_strict"
+        assert results[0].channel_id == 40
+        assert results[0].channel_ids == [40]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,11 +6,13 @@ from datetime import datetime, timedelta, timezone
 from dispatcharr_ranked_matchups._util import (
     CHANNEL_NUMBER_ORIGIN,
     CHANNEL_NUMBER_TIEBREAK_SLOTS,
+    FIELD_AWAY_SENTINEL,
     extract_game_number_after_marker,
     group_advance_text,
     group_phase_text,
     group_results_lines,
     group_standings_lines,
+    is_field_event,
     parse_iso_utc,
     series_phase_text,
     series_record_text,
@@ -18,6 +20,29 @@ from dispatcharr_ranked_matchups._util import (
     stable_channel_number,
     stable_hash_int,
 )
+
+
+class TestIsFieldEvent:
+    """#127: single source of truth for the field-event shape (no opponent)."""
+
+    def test_sentinel_away_is_field_event(self):
+        assert is_field_event(FIELD_AWAY_SENTINEL) is True
+        assert is_field_event("Field") is True
+
+    def test_real_opponent_is_not_field_event(self):
+        assert is_field_event("Ohio State") is False
+        assert is_field_event("") is False
+        assert is_field_event(None) is False
+
+    def test_extra_flag_wins_even_without_sentinel(self):
+        # A source could set the flag without using the literal sentinel; the
+        # flag is the primary signal.
+        assert is_field_event("Some Opponent", {"is_field_event": True}) is True
+
+    def test_falsy_extra_falls_back_to_sentinel(self):
+        assert is_field_event("Field", {}) is True
+        assert is_field_event("Field", {"is_field_event": False}) is True
+        assert is_field_event("Arsenal", {"is_field_event": False}) is False
 
 
 class TestParseIsoUtc:


### PR DESCRIPTION
Closes #127.

## Problem

Field-event sports have no head-to-head opponent, so their source emits an away-side `"Field"` sentinel (`sources/field_event.py`). The matcher fed that sentinel into its both-teams gate on every tier, and since no channel name or EPG title ever contains the word "Field", the gate could never be satisfied. Every UFC/F1/golf/NASCAR/ATP/WTA game fell through to a placeholder with no streams attached.

## Fix

Detect the single-event shape and match on the event name (`home`) alone, dropping the away-side requirement. Two-team sports keep the full both-teams gate unchanged.

- **matcher**: `_regex_filter` / `_regex_filter_channel_name` accept `team_b=None` for single-sided matching; `match_games_to_channels` drops the away gate when `is_field_event(game)`.
- **plugin `_build_epg_lookup`**: Path A title pre-filter and Path B channel-name query key on the event name alone for field events (Path B no longer ANDs the unmatchable sentinel, which was the core lookup bug).
- **diagnose action**: field events are now ordinary diagnosable targets (they were skipped as "unmatchable yet (#127)"); the window scan keys on the event name instead of a head-to-head separator, with field-specific verdicts and a field-aware label.
- **DRY**: the `"Field"` sentinel and field-event detection collapse into `_util.is_field_event()` / `FIELD_AWAY_SENTINEL`, replacing three independent copies (`sources/field_event.py`, `logos.py`, an inline literal in `plugin.py`).

Version 1.6.0 -> 1.7.0.

## Tests

Full suite: **3228 passed** (`python:3.11-slim`, `--memory=4g`).

- `test_matcher.py`: single-sided filters + field-event tiers. Proven failing-then-green: surgically reverting the one `match_away` line back to the old gate makes the field tiers fail with `fallback_first` instead of `regex_strict`.
- `test_field_event_lookup.py`: real-ORM-shape coverage (fake `Q`/manager) proving Path B matches field events on the event name and that two-team games keep the AND gate.
- `test_diagnose.py`: field events are diagnosed, not skipped; field-specific verdicts. Also fixed a pre-existing test-isolation leak (`_run` clobbered shared module attrs without restoring them, leaking the `_build_epg_lookup` stub into other files).
- `test_util.py`: `is_field_event` units.

## Live verification (deployed 1.7.0 to the Dispatcharr container, prod codepath)

- Loader registered the plugin at `version= 1.7.0`; scheduler thread started clean.
- Real Django/ORM `_build_epg_lookup`: a field-event game (`away="Field"`) finds the event-naming channel via single-sided Path B (`found the channel: True`); a two-team control with a bogus away returns `[]` (AND gate intact).
- `_action_diagnose` runs clean on the live cache (two-team path) and, fed a synthetic field-event cache, renders the field-specific toast + verbose log:
  ```
  Closest of 1 unmatched: UFC UFC Freedom 250: Topuria vs Gaethje (Tomorrow 8:00 PM EDT)
  => A channel name has the event but it didn't match - unexpected; please send us this.
  ...
    searched - event UFC Freedom 250: Topuria vs Gaethje: ... (field event, no opponent)
    UFC UFC Freedom 250: Topuria vs Gaethje (Tomorrow 8:00 PM EDT) (field event)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)