### PR TITLE
Fix apply holding a DB transaction open across per-game network I/O (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-06-14
+
+### Fixed
+
+- **Apply no longer holds a DB transaction open across network I/O (#136).** The
+  apply step wrapped its per-game writes in a single `transaction.atomic()` block
+  and, inside it, made a Claude LLM-description call and a SportsDB logo lookup
+  per game. On a large channel lineup (or whenever new, uncached games appear,
+  e.g. right after enabling a sport) that held one Postgres transaction open
+  across dozens of sequential network calls, then committed all at once, which
+  starved the login/token worker and could make the server's login time out. All
+  network-backed values are now resolved in a pre-pass BEFORE the transaction;
+  the transaction does only fast in-memory to DB writes. The park step also uses
+  a single `bulk_update` instead of one save per existing virtual channel. No
+  change to apply output (channel names, EPG, logos are identical).
+
 ## [1.7.0] - 2026-06-13
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/plugin.py
+++ b/plugin.py
@@ -2303,154 +2303,174 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         )
         return logo_obj.id, "matchup"
 
+    # Resolve ALL network-backed values BEFORE opening the transaction (#136).
+    # The apply transaction below must hold only fast DB writes. LLM-description
+    # and SportsDB-logo calls are network I/O; making them INSIDE
+    # transaction.atomic() holds the transaction (and its DB connection) open
+    # across every slow call, which starves the login/token worker on large
+    # instances and on the scheduled refresh (observed: a 14s login timeout +
+    # a 13.9s Postgres checkpoint right after an apply on a ~6.3k-channel box).
+    # Both calls are cache-backed, so this pass moves them earlier, it does not
+    # add work. Each surviving game's precomputed plan is stored by marker; the
+    # transaction then does nothing but writes. This pre-pass mirrors the skip /
+    # placeholder / bad-start-time semantics of the write loop exactly (same
+    # marker key, same seen_markers set, same counters) so the two stay in lockstep.
+    from types import SimpleNamespace
+    from .scoring import pick_tagline
+    prep_by_marker: Dict[str, Any] = {}
+    for g in games:
+        source_ids = list(g.get("channel_ids") or [])
+        if not source_ids:
+            primary_id = g.get("channel_id")
+            if primary_id:
+                source_ids = [primary_id]
+        sources = list(Channel.objects.filter(id__in=source_ids))
+        sources_by_id = {c.id: c for c in sources}
+        sources = [sources_by_id[sid] for sid in source_ids if sid in sources_by_id]
+        source = sources[0] if sources else None
+
+        placeholder = False
+        if not source:
+            score_val = float(g.get("score", 0.0))
+            if score_val >= placeholder_threshold:
+                placeholder = True
+                placeholder_channels_created += 1
+            else:
+                skipped_unmatched += 1
+                continue
+
+        marker = _build_marker_key(g)
+        seen_markers.add(marker)
+
+        signals, score = _build_signals_score_from_payload(g)
+        extra = g.get("extra") or {}
+        rank_source = extra.get("rank_source", "poll")
+        tagline = pick_tagline(
+            score_breakdown=g.get("score_breakdown", {}),
+            favorites_matched=g.get("favorites_matched", []),
+            spread=g.get("spread"),
+            closeness=g.get("closeness"),
+            importance_thresholds=(
+                g.get("importance_thresholds_hit")
+                or g.get("stakes_thresholds_hit")  # pre-C.4 cache fallback
+                or []
+            ),
+            tournament_stage=g.get("tournament_stage"),
+            rank_a=g.get("rank_home"),
+            rank_b=g.get("rank_away"),
+            rank_source=rank_source,
+        )
+        start_dt = parse_iso_utc(g.get("start_time_utc"))
+        if start_dt is None:
+            logger.warning("[ranked_matchups] bad start_time_utc on %s", marker)
+            continue
+
+        new_name = format_channel_name(
+            g["sport_prefix"], signals, score, g["home"], g["away"],
+            tagline=tagline,
+            template=name_template,
+            rank_source=rank_source,
+            sport_label=g.get("sport_label", ""),
+            venue=g.get("venue"),
+            start_dt=start_dt,
+            tz=apply_tz,
+        )
+
+        description = _build_description(g=g, tagline=tagline, placeholder=placeholder)
+        # Optional Claude-rewritten prose (network, cached). Placeholders keep the
+        # deterministic "match pending" note. Failures fall back to `description`.
+        if llm_enabled and not placeholder:
+            _ctx = _league_context_for(g)
+            _boundary = _ctx.boundary_summary if _ctx else ""
+            before = description
+            description = llm_descriptions.llm_describe_or_fallback(
+                g=g,
+                tagline=tagline,
+                fallback_description=description,
+                api_key=llm_api_key,
+                model=llm_model,
+                cache=llm_cache,
+                boundary_summary=_boundary,
+                marker=marker,
+            )
+            if description is before:
+                llm_failed += 1
+            else:
+                llm_used += 1
+
+        # Rank the streams from every matched source channel (DB reads only).
+        stream_pool = []  # list of (sort_key, src_order, stream_id)
+        seen_stream_ids = set()
+        for src_order, src in enumerate(sources):
+            for s in src.streams.all().only("id", "name", "stream_stats"):
+                if s.id in seen_stream_ids:
+                    continue
+                seen_stream_ids.add(s.id)
+                key = _stream_sort_key(
+                    s.stream_stats, s.name or src.name or "",
+                    english_first=english_first, home=g["home"], away=g["away"],
+                )
+                stream_pool.append((key, src_order, s.id))
+        stream_pool.sort()
+        source_streams = [sid for _, _, sid in stream_pool]
+
+        resolved_logo_id, logo_outcome = _resolve_matchup_logo_id(g, marker, source)
+        if matchup_logos_enabled and not dry_run:
+            if logo_outcome == "matchup":
+                matchup_logos_used += 1
+            elif logo_outcome == "badge":
+                matchup_logos_badge += 1
+            else:
+                matchup_logos_fallback += 1
+
+        prep_by_marker[marker] = SimpleNamespace(
+            new_name=new_name,
+            description=description,
+            tagline=tagline,
+            logo_id=resolved_logo_id,
+            source_streams=source_streams,
+            start_dt=start_dt,
+        )
+
     with transaction.atomic():
         # Phase 0: park existing virtual channels in a high temporary number
         # range so we can renumber based on cache order without colliding with
         # the unique (channel_group, channel_number) constraint. park_base is
         # guaranteed to be past every target number we're about to write.
         if not dry_run and existing_virtuals:
-            for i, ch in enumerate(existing_virtuals.values()):
+            parked = list(existing_virtuals.values())
+            for i, ch in enumerate(parked):
                 ch.channel_number = float(park_base + i)
-            for ch in existing_virtuals.values():
-                ch.save(update_fields=["channel_number"])
+            # One UPDATE rather than N per-row saves (#136): on a large slate of
+            # existing virtuals the park step shouldn't issue a query per channel.
+            Channel.objects.bulk_update(parked, ["channel_number"])
 
         for g in games:
-            # channel_ids is the full list of matched provider channels (e.g.
-            # multiple regional/quality variants of the same fixture). Falls
-            # back to the single-channel `channel_id` key for cache entries
-            # written by an older plugin version. Primary (first) drives
-            # the channel logo and EPG context.
-            source_ids = list(g.get("channel_ids") or [])
-            if not source_ids:
-                primary_id = g.get("channel_id")
-                if primary_id:
-                    source_ids = [primary_id]
-            sources = list(Channel.objects.filter(id__in=source_ids))
-            # Preserve the matcher-given order (channel_ids is primary-first).
-            sources_by_id = {c.id: c for c in sources}
-            sources = [sources_by_id[sid] for sid in source_ids if sid in sources_by_id]
-            source = sources[0] if sources else None
-
-            placeholder = False
-            if not source:
-                score_val = float(g.get("score", 0.0))
-                if score_val >= placeholder_threshold:
-                    placeholder = True
-                    placeholder_channels_created += 1
-                else:
-                    skipped_unmatched += 1
-                    continue
-
+            # Per-game writes consume the plan resolved in the pre-pass above
+            # (#136); the transaction holds no network I/O. `prep` is None for
+            # games the pre-pass skipped (unmatched below the placeholder
+            # threshold, or a bad start_time): keying off the same marker and
+            # skipping here keeps the two passes in lockstep without re-running
+            # resolution or double-counting. _build_marker_key is pure, so the
+            # marker computed here equals the one the pre-pass stored under.
             marker = _build_marker_key(g)
-            seen_markers.add(marker)
-
-            from .scoring import pick_tagline
-            signals, score = _build_signals_score_from_payload(g)
-            extra = g.get("extra") or {}
-            rank_source = extra.get("rank_source", "poll")
-            tagline = pick_tagline(
-                score_breakdown=g.get("score_breakdown", {}),
-                favorites_matched=g.get("favorites_matched", []),
-                spread=g.get("spread"),
-                closeness=g.get("closeness"),
-                importance_thresholds=(
-                    g.get("importance_thresholds_hit")
-                    or g.get("stakes_thresholds_hit")  # pre-C.4 cache fallback
-                    or []
-                ),
-                tournament_stage=g.get("tournament_stage"),
-                rank_a=g.get("rank_home"),
-                rank_b=g.get("rank_away"),
-                rank_source=rank_source,
-            )
-            start_dt = parse_iso_utc(g.get("start_time_utc"))
-            if start_dt is None:
-                logger.warning("[ranked_matchups] bad start_time_utc on %s", marker)
+            prep = prep_by_marker.get(marker)
+            if prep is None:
                 continue
-
-            # Stable, kickoff-time-based channel number for this game. Keyed by
-            # marker (not slate position) so it never moves across applies, yet
-            # it increases with start time so the list still sorts soonest-first.
-            # Being a stable integer is what makes BOTH the default M3U/XMLTV
-            # output and the Xtream Codes API bind the EPG correctly with no
-            # client setup (#121). _assign_channel_numbers computed the whole map
-            # up front; marker is guaranteed present here because that map skips
-            # exactly the same bad-start_time rows we just skipped.
+            new_name = prep.new_name
+            description = prep.description
+            tagline = prep.tagline
+            resolved_logo_id = prep.logo_id
+            source_streams = prep.source_streams
+            start_dt = prep.start_dt
+            # Stable, kickoff-time-based channel number (keyed by marker, see
+            # _assign_channel_numbers / #121). Guaranteed present: both this map
+            # and the pre-pass skip exactly the same bad-start_time rows, so any
+            # marker with a plan also has a number here.
             target_chnum = chnum_by_marker[marker]
-
-            new_name = format_channel_name(
-                g["sport_prefix"], signals, score, g["home"], g["away"],
-                tagline=tagline,
-                template=name_template,
-                rank_source=rank_source,
-                sport_label=g.get("sport_label", ""),
-                venue=g.get("venue"),
-                start_dt=start_dt,
-                tz=apply_tz,
-            )
             prog_start = start_dt - timedelta(minutes=EPG_PRE_MIN)
             prog_end = start_dt + timedelta(hours=EPG_POST_HOURS)
-
-            description = _build_description(
-                g=g,
-                tagline=tagline,
-                placeholder=placeholder,
-            )
-
-            # If LLM-rewritten descriptions are enabled and this isn't a
-            # placeholder (placeholders have no EPG match yet, so the "channel
-            # match pending" note matters more than prose), try the call and
-            # fall back to `description` on any failure.
-            if llm_enabled and not placeholder:
-                _ctx = _league_context_for(g)
-                _boundary = _ctx.boundary_summary if _ctx else ""
-                before = description
-                description = llm_descriptions.llm_describe_or_fallback(
-                    g=g,
-                    tagline=tagline,
-                    fallback_description=description,
-                    api_key=llm_api_key,
-                    model=llm_model,
-                    cache=llm_cache,
-                    boundary_summary=_boundary,
-                    marker=marker,
-                )
-                if description is before:
-                    llm_failed += 1
-                else:
-                    llm_used += 1
-
-            # Gather streams from EVERY matched source channel and rank by
-            # composite key: valid ffprobe data (height/bitrate) ranks first,
-            # then name-keyword fallback, then probe-failed streams last. When
-            # english_first is on (#111) the language rank is prepended so all
-            # English variants sort ahead of all non-English ones, quality
-            # preserved within each. Stable secondary sort by source-channel
-            # order keeps equal-key streams in the matcher's primary-first order.
-            stream_pool = []  # list of (sort_key, src_order, stream_id)
-            seen_stream_ids = set()
-            for src_order, src in enumerate(sources):
-                for s in src.streams.all().only("id", "name", "stream_stats"):
-                    if s.id in seen_stream_ids:
-                        continue
-                    seen_stream_ids.add(s.id)
-                    key = _stream_sort_key(
-                        s.stream_stats, s.name or src.name or "",
-                        english_first=english_first, home=g["home"], away=g["away"],
-                    )
-                    stream_pool.append((key, src_order, s.id))
-            stream_pool.sort()
-            source_streams = [sid for _, _, sid in stream_pool]
             existing = existing_virtuals.get(marker)
-
-            resolved_logo_id, logo_outcome = _resolve_matchup_logo_id(g, marker, source)
-            if matchup_logos_enabled and not dry_run:
-                if logo_outcome == "matchup":
-                    matchup_logos_used += 1
-                elif logo_outcome == "badge":
-                    matchup_logos_badge += 1
-                else:
-                    matchup_logos_fallback += 1
 
             if existing:
                 changed = False
@@ -3311,7 +3331,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.7.0"
+    version = "1.7.1"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_apply_no_network_in_transaction.py
+++ b/tests/test_apply_no_network_in_transaction.py
@@ -1,0 +1,126 @@
+"""Regression guard for #136: `_action_apply` must not perform network I/O
+inside its DB transaction.
+
+The apply step holds a single `with transaction.atomic():` block. If the
+per-game LLM-description call (`llm_describe_or_fallback`) or the SportsDB
+logo resolution (`_resolve_matchup_logo_id`) runs INSIDE that block, the
+transaction (and its DB connection) stays open across every slow network
+call, which starves the login/token worker on large instances and on the
+scheduled refresh. The fix resolves all network-backed values in a pre-pass
+BEFORE opening the transaction.
+
+This is a static (AST) contract rather than a runtime test because
+`_action_apply` is deeply Django-coupled (Channel/EPGData/ProgramData ORM,
+`transaction.atomic`) and the invariant we care about is purely about call
+ORDER relative to the transaction, which the AST captures exactly. It fails
+on the pre-fix code (calls inside/after the atomic block) and passes on the
+fix (calls hoisted above it).
+"""
+
+import ast
+import os
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PLUGIN_PY = os.path.join(REPO_ROOT, "plugin.py")
+
+# The network-backed calls that must be resolved before the transaction opens.
+NETWORK_CALLS = {"llm_describe_or_fallback", "_resolve_matchup_logo_id"}
+
+
+def _called_name(call: ast.Call):
+    """The bare callable name for a Call node (`f(...)` -> 'f', `a.b.f(...)` -> 'f')."""
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+@pytest.fixture(scope="module")
+def apply_fn():
+    tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_action_apply":
+            return node
+    pytest.fail("_action_apply not found in plugin.py")
+
+
+def _atomic_lineno(apply_fn):
+    """Line of the `with transaction.atomic():` statement inside _action_apply."""
+    for node in ast.walk(apply_fn):
+        if isinstance(node, ast.With):
+            for item in node.items:
+                call = item.context_expr
+                if (isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+                        and call.func.attr == "atomic"):
+                    return node.lineno
+    return None
+
+
+class TestNoNetworkInsideApplyTransaction:
+    def test_transaction_atomic_present(self, apply_fn):
+        assert _atomic_lineno(apply_fn) is not None, \
+            "_action_apply no longer wraps writes in transaction.atomic()"
+
+    def test_network_calls_exist_and_precede_the_transaction(self, apply_fn):
+        atomic_line = _atomic_lineno(apply_fn)
+        seen = {name: [] for name in NETWORK_CALLS}
+        for node in ast.walk(apply_fn):
+            if isinstance(node, ast.Call):
+                name = _called_name(node)
+                if name in NETWORK_CALLS:
+                    seen[name].append(node.lineno)
+
+        # Both calls must still exist (guards against a silent removal that would
+        # make the "before the transaction" check vacuously pass).
+        for name in NETWORK_CALLS:
+            assert seen[name], f"{name} call disappeared from _action_apply"
+
+        # Every network call site must be ABOVE the transaction. The invocation
+        # inside `transaction.atomic()` is what wedged login (#136).
+        offenders = {n: ls for n, ls in seen.items()
+                     if any(line >= atomic_line for line in ls)}
+        assert not offenders, (
+            f"network I/O inside/after transaction.atomic() (line {atomic_line}): "
+            f"{offenders} -- resolve these in the pre-pass before the transaction (#136)")
+
+
+class TestPrepContract:
+    """The pre-pass produces a `prep_by_marker[...] = SimpleNamespace(...)` plan
+    that the write loop consumes as `prep.<attr>`. That's a producer/consumer
+    data contract: every attribute the write loop reads must be one the pre-pass
+    sets, or apply breaks at runtime with AttributeError. Lock it statically so a
+    future edit that reads `prep.foo` without producing `foo` fails in CI."""
+
+    def _prep_fields_produced(self, apply_fn):
+        """kwargs of the SimpleNamespace assigned into prep_by_marker[...]."""
+        for node in ast.walk(apply_fn):
+            if (isinstance(node, ast.Assign)
+                    and isinstance(node.targets[0], ast.Subscript)
+                    and isinstance(node.targets[0].value, ast.Name)
+                    and node.targets[0].value.id == "prep_by_marker"
+                    and isinstance(node.value, ast.Call)):
+                return {kw.arg for kw in node.value.keywords if kw.arg}
+        return None
+
+    def _prep_attrs_consumed(self, apply_fn):
+        """every `prep.<attr>` read in _action_apply."""
+        attrs = set()
+        for node in ast.walk(apply_fn):
+            if (isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+                    and node.value.id == "prep"):
+                attrs.add(node.attr)
+        return attrs
+
+    def test_every_consumed_prep_attr_is_produced(self, apply_fn):
+        produced = self._prep_fields_produced(apply_fn)
+        assert produced, "prep_by_marker[...] = SimpleNamespace(...) not found in _action_apply"
+        consumed = self._prep_attrs_consumed(apply_fn)
+        assert consumed, "write loop reads no prep.<attr> -- contract anchor moved?"
+        missing = consumed - produced
+        assert not missing, (
+            f"write loop reads prep attrs the pre-pass never sets: {missing}. "
+            f"Produced: {sorted(produced)} (#136 prep contract)")

--- a/tools/export_snapshot.py
+++ b/tools/export_snapshot.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Export a read-only snapshot of a Dispatcharr instance's channels + EPG.
+
+Runs INSIDE the Dispatcharr container (it needs Django). Writes the JSON the
+offline replay harness (tools/replay_match.py) consumes, so the matcher/lookup
+can be exercised against real data with NO plugin runtime, NO discovery, NO
+reload, i.e. without wedging the live worker.
+
+Read-only: SELECTs only, no writes. Safe to run on a production container.
+
+  docker cp tools/export_snapshot.py Dispatcharr:/tmp/export_snapshot.py
+  docker exec Dispatcharr python /tmp/export_snapshot.py /tmp/dg_snapshot.json
+  docker cp Dispatcharr:/tmp/dg_snapshot.json ./dg_snapshot.json
+
+Then replay offline on the host:
+  python tools/replay_match.py dg_snapshot.json --game "UFC Freedom 250: ..." --prefix UFC
+"""
+import json
+import os
+import sys
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "/tmp/dg_snapshot.json"
+    import django
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dispatcharr.settings")
+    django.setup()
+    from apps.channels.models import Channel
+    from apps.epg.models import ProgramData
+
+    chans = [
+        {"id": c.id, "name": c.name, "tvg_id": getattr(c, "tvg_id", None),
+         "epg_data_id": c.epg_data_id}
+        for c in Channel.objects.all().only("id", "name", "tvg_id", "epg_data_id")
+    ]
+    progs = [
+        {"id": p.id, "title": p.title,
+         "start_time": p.start_time.isoformat() if p.start_time else None,
+         "end_time": p.end_time.isoformat() if p.end_time else None,
+         "epg_id": p.epg_id}
+        for p in ProgramData.objects.all().only("id", "title", "start_time", "end_time", "epg_id")
+    ]
+    json.dump({"channels": chans, "programs": progs}, open(out, "w"))
+    print(f"exported {len(chans)} channels, {len(progs)} programs -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/replay_match.py
+++ b/tools/replay_match.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Offline replay harness for the matcher/lookup, NO Dispatcharr runtime.
+
+Runs the plugin's REAL code (`matcher.match_games_to_channels` +
+`plugin._build_epg_lookup`) against a JSON *snapshot* of a Dispatcharr
+instance's channels + EPG, served through a tiny in-memory ORM. This produces
+the exact candidate set and match verdict the plugin would produce in-process,
+without ever touching the live container (whose plugin reloads/discovery wedge
+the worker, see the dispatcharr skill).
+
+This is a faithful replay, not a mock: the matching code is the production code;
+only the ORM backend is swapped for an in-memory store over the snapshot.
+
+Snapshot format (see tools/export_snapshot.py / the skill):
+  {"channels":[{"id","name","tvg_id","epg_data_id"}...],
+   "programs":[{"id","title","start_time"(iso),"end_time"(iso),"epg_id"}...]}
+
+Usage:
+  python tools/replay_match.py SNAPSHOT.json --cache CACHE.json
+      Replay every scored game from a plugin cache.json and compare each
+      match verdict against the channel_name_current the cache recorded.
+  python tools/replay_match.py SNAPSHOT.json \
+      --game "UFC Freedom 250: Topuria vs. Gaethje" --away Field \
+      --prefix UFC --start 2026-06-15T00:00:00Z
+      Replay a single synthetic game (away defaults to the Field sentinel
+      when omitted, i.e. a field event).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PKG = "dispatcharr_ranked_matchups"
+
+
+# --------------------------------------------------------------------------- #
+# In-memory ORM (Django-shaped subset the lookup uses)
+# --------------------------------------------------------------------------- #
+class FakeQ:
+    """AND/OR predicate tree over Django-style `field__lookup=value` kwargs."""
+
+    def __init__(self, **kwargs):
+        self._tests = list(kwargs.items())
+        self._or = []
+        self._and = []
+
+    def _empty(self):
+        return not self._tests and not self._or and not self._and
+
+    def __or__(self, other):
+        if self._empty():
+            return other
+        if other._empty():
+            return self
+        n = FakeQ()
+        n._or = [self, other]
+        return n
+
+    __ior__ = __or__
+
+    def __and__(self, other):
+        if self._empty():
+            return other
+        if other._empty():
+            return self
+        n = FakeQ()
+        n._and = [self, other]
+        return n
+
+    __iand__ = __and__
+
+    def matches(self, row):
+        if self._or:
+            return any(q.matches(row) for q in self._or)
+        if self._and:
+            return all(q.matches(row) for q in self._and)
+        if not self._tests:
+            return True
+        for key, val in self._tests:
+            field, _, lookup = key.partition("__")
+            actual = getattr(row, field, None)
+            if lookup == "icontains":
+                if str(val).lower() not in str(actual or "").lower():
+                    return False
+            elif lookup == "startswith":
+                if not str(actual or "").startswith(str(val)):
+                    return False
+            elif lookup == "in":
+                if actual not in val:
+                    return False
+            elif lookup == "lt":
+                if not (actual is not None and actual < val):
+                    return False
+            elif lookup == "gt":
+                if not (actual is not None and actual > val):
+                    return False
+            else:  # exact
+                if actual != val:
+                    return False
+        return True
+
+
+class FakeManager:
+    def __init__(self, rows, inc=None, exc=None):
+        self._rows = rows
+        self._inc = list(inc or [])
+        self._exc = list(exc or [])
+
+    def filter(self, *qs, **kw):
+        inc = self._inc + list(qs) + ([FakeQ(**kw)] if kw else [])
+        return FakeManager(self._rows, inc, self._exc)
+
+    def exclude(self, *qs, **kw):
+        exc = self._exc + list(qs) + ([FakeQ(**kw)] if kw else [])
+        return FakeManager(self._rows, self._inc, exc)
+
+    def only(self, *a):
+        return self
+
+    def __iter__(self):
+        for r in self._rows:
+            if all(q.matches(r) for q in self._inc) and not any(q.matches(r) for q in self._exc):
+                yield r
+
+
+class _Row:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _dt(s):
+    if not s:
+        return None
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+# --------------------------------------------------------------------------- #
+# Wiring
+# --------------------------------------------------------------------------- #
+def load_snapshot(path):
+    data = json.load(open(path))
+    chans = [_Row(id=c["id"], name=c["name"] or "", tvg_id=c.get("tvg_id") or "",
+                  epg_data_id=c["epg_data_id"]) for c in data["channels"]]
+    progs = [_Row(id=p["id"], title=p["title"] or "", epg_id=p["epg_id"],
+                  start_time=_dt(p["start_time"]), end_time=_dt(p["end_time"]))
+             for p in data["programs"]]
+    return chans, progs
+
+
+def install_orm(chans, progs):
+    chan_mod = types.ModuleType("apps.channels.models")
+    chan_mod.Channel = SimpleNamespace(objects=FakeManager(chans))
+    epg_mod = types.ModuleType("apps.epg.models")
+    epg_mod.ProgramData = SimpleNamespace(objects=FakeManager(progs))
+    dj = types.ModuleType("django.db.models")
+    dj.Q = FakeQ
+    for name, mod in [
+        ("apps", types.ModuleType("apps")),
+        ("apps.channels", types.ModuleType("apps.channels")),
+        ("apps.channels.models", chan_mod),
+        ("apps.epg", types.ModuleType("apps.epg")),
+        ("apps.epg.models", epg_mod),
+        ("django", types.ModuleType("django")),
+        ("django.db", types.ModuleType("django.db")),
+        ("django.db.models", dj),
+    ]:
+        sys.modules[name] = mod
+
+
+def load_pkg():
+    """Load real _util + matcher + plugin by file path (no Django import)."""
+    if f"{PKG}._util" not in sys.modules:
+        s = importlib.util.spec_from_file_location(f"{PKG}._util", os.path.join(REPO_ROOT, "_util.py"))
+        m = importlib.util.module_from_spec(s)
+        sys.modules[f"{PKG}._util"] = m
+        s.loader.exec_module(m)
+    if PKG not in sys.modules:
+        pkg = types.ModuleType(PKG)
+        pkg.__path__ = [REPO_ROOT]
+        sys.modules[PKG] = pkg
+    out = {}
+    for sub in ("matcher", "plugin"):
+        full = f"{PKG}.{sub}"
+        if full not in sys.modules:
+            s = importlib.util.spec_from_file_location(full, os.path.join(REPO_ROOT, f"{sub}.py"))
+            m = importlib.util.module_from_spec(s)
+            sys.modules[full] = m
+            s.loader.exec_module(m)
+        out[sub] = sys.modules[full]
+    return out["matcher"], out["plugin"]
+
+
+def game_from_cache(g):
+    return SimpleNamespace(
+        home=g.get("home", ""), away=g.get("away", ""),
+        sport_prefix=g.get("sport_prefix", ""), sport_label=g.get("sport_label", ""),
+        start_time=_dt(g.get("start_time_utc")) or datetime.now(timezone.utc),
+        extra=g.get("extra") or {})
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("snapshot")
+    ap.add_argument("--cache", help="plugin cache.json: replay every scored game")
+    ap.add_argument("--game", help="single synthetic game home/event name")
+    ap.add_argument("--away", default="Field", help="away team (default: Field sentinel)")
+    ap.add_argument("--prefix", default="UFC")
+    ap.add_argument("--start", default="2026-06-15T00:00:00Z")
+    args = ap.parse_args()
+
+    chans, progs = load_snapshot(args.snapshot)
+    install_orm(chans, progs)
+    matcher, plugin = load_pkg()
+    print(f"snapshot: {len(chans)} channels, {len(progs)} programs\n")
+
+    if args.cache:
+        cache = json.load(open(args.cache))
+        games = [game_from_cache(g) for g in cache.get("games", [])]
+        cached_match = [g.get("channel_name_current") for g in cache.get("games", [])]
+        results = matcher.match_games_to_channels(
+            [(g, None, None) for g in games], plugin._build_epg_lookup(),
+            api_key="", model="m")  # no key -> LLM tier degrades to fallback_first
+        for g, r, was in zip(games, results, cached_match):
+            tag = "OK " if bool(r.channel_id) == bool(was) else "DIFF"
+            print(f"[{tag}] {g.sport_prefix} {g.home[:40]!r}")
+            print(f"       replay: {r.method} -> {r.channel_name!r} ({len(r.channel_ids)} streams)")
+            print(f"       cache : {was!r}")
+        return
+
+    home = args.game or "UFC Freedom 250: Topuria vs. Gaethje"
+    extra = {"is_field_event": True} if args.away == "Field" else {}
+    game = SimpleNamespace(home=home, away=args.away, sport_prefix=args.prefix,
+                           sport_label=args.prefix, start_time=_dt(args.start), extra=extra)
+    print(f"GAME: {game.sport_prefix} {home!r} vs {game.away!r}  @ {game.start_time.isoformat()}")
+    print("home keywords:", matcher._team_keywords(home))
+    cands = plugin._build_epg_lookup()(game)
+    print(f"\ncandidates in window: {len(cands)}")
+    field = game.extra.get("is_field_event") or game.away == "Field"
+    away = None if field else game.away
+    t1 = matcher._regex_filter_channel_name(cands, home, away)
+    print(f"tier-1 (channel name) matches: {len(t1)}")
+    for c in t1[:15]:
+        print(f"   [{c.channel_id}] {c.channel_name!r}")
+    res = matcher.match_games_to_channels([(game, None, None)], plugin._build_epg_lookup(),
+                                          api_key="", model="m")[0]
+    print(f"\nVERDICT: method={res.method} primary={res.channel_name!r} stacked={len(res.channel_ids)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #136 (this is a correct improvement but does NOT close the wedge; see issue).

## Problem

`_action_apply` wrapped its per-game writes in a single `transaction.atomic()` block and, inside it, made a Claude LLM-description call and a SportsDB logo lookup **per game**, committing everything at once. On a large lineup (or whenever new uncached games appear, e.g. right after enabling a sport) that held one Postgres transaction open across dozens of sequential network calls, starving the login/token worker. Observed on a ~6,271-channel instance: `POST /api/accounts/token/` timed out at ~14s while `version` answered in ~1.6ms, with a 13.9s Postgres checkpoint right after the apply. It would also hit the scheduled daily refresh, not just manual runs.

## Fix

- Resolve all network-backed values (LLM descriptions, logo ids) in a **pre-pass before** `transaction.atomic()`, keyed by marker. Both are already cache-backed, so this moves the work earlier, it does not add work.
- The transaction now consumes the precomputed plan (`prep_by_marker`) and does **only fast in-memory to DB writes**. The pre-pass mirrors the write loop's skip / placeholder / bad-start-time / counter semantics exactly so the two stay in lockstep.
- Park step uses one `Channel.objects.bulk_update` instead of N per-row saves (signal-equivalent: neither path touches `epg_data`, so the destructive EPG `post_save` never fired).
- **No change to apply output** (channel names, EPG, logos identical); the write half of the loop is byte-for-byte unchanged.

## Tests

`tests/test_apply_no_network_in_transaction.py`:
- **Failing-then-green** AST contract: both network call sites must precede the transaction. Proven: on the pre-fix code the calls (lines 2408, 2446) sit after the `transaction.atomic()` at 2306 and the test fails; on the fix they are hoisted above it and it passes.
- AST contract that every `prep.<attr>` the write loop consumes is produced by the pre-pass `SimpleNamespace` (guards the new producer/consumer contract).

Full suite: **3231 passed** (`python:3.11-slim`, `--memory=4g`).

## Repro / verification

- **Symptom (REPRODUCED-MANUAL):** login-timeout + 13.9s checkpoint logs correlated with apply, captured in #136.
- **Invariant (deterministic, failing-then-green):** the AST contract above.
- **No-regression:** write half unchanged + full suite green.
- **End-to-end wedge relief:** pending a controlled single apply on the large instance (the wedge-risk operation), to be run jointly rather than unilaterally. Will confirm login stays responsive during the apply and append the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)