### PR TITLE
Fix scheduler DB-connection leak that locked up the container (#82/#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-06-14
+
+### Fixed
+
+- **Scheduler no longer leaks a Postgres connection, which could lock up the
+  whole container (#82 / #136).** The background scheduler thread reads settings
+  from the DB each tick but never closed its connection, so a parked scheduler
+  pinned one Postgres backend open; and because Dispatcharr re-instantiates the
+  plugin on every discovery (opening the Plugins page, running an action, saving
+  settings, reloading), each re-instantiation churned a new scheduler thread and
+  orphaned the previous one's connection. Connections accumulated until Postgres
+  `max_connections` was hit and every request (including login) blocked, which
+  presented as the server locking up. This was independent of channel count, so
+  it hit small installs too. The scheduler now closes its DB connection before
+  every sleep and on exit, and `Plugin.__init__` is idempotent: a healthy
+  scheduler thread is left running instead of being restarted on every
+  discovery.
+
 ## [1.7.1] - 2026-06-14
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/plugin.py
+++ b/plugin.py
@@ -3179,23 +3179,20 @@ def _scheduler_registry():
     return reg
 
 
-def _stop_scheduler(thread, stop_event, reason: str, *, join: bool = True) -> None:
-    """Signal a scheduler thread to exit. The loop polls its own stop_event
-    between work units, so setting it drops the loop out at its next wake-up
-    (immediate: set() wakes a thread waiting on the Event).
+def _stop_scheduler(thread, stop_event, reason: str) -> None:
+    """Signal a scheduler thread to exit and briefly block to confirm it did.
 
-    join controls whether we then block to confirm exit:
-      - join=True (disable/delete via stop()): block briefly; teardown is not
-        on a latency-sensitive path and confirming exit is tidy.
-      - join=False (reload via __init__): DO NOT block. __init__ runs inside a
-        gevent request greenlet during discovery; a blocking join there stalls
-        the worker's whole hub (every greenlet shares one OS thread). The orphan
-        exits on its own once signaled, and __init__ repoints the registry at
-        the replacement immediately after, so the signaled orphan is unreachable
-        and harmless while it unwinds. Keeps the hot reload path non-blocking."""
+    The loop polls its own stop_event between work units (and on every park via
+    _scheduler_sleep), so setting it drops the loop out at its next wake-up
+    (immediate: set() wakes a thread waiting on the Event); the loop's finally
+    then closes its DB connection. Only stop() (disable/delete) calls this now:
+    __init__ is idempotent and leaves a healthy thread running rather than
+    restarting it (#82/#136), so there is no longer a reload path that needed the
+    old non-blocking (join=False) variant.
+    """
     if stop_event is not None:
         stop_event.set()
-    if join and thread is not None and thread.is_alive():
+    if thread is not None and thread.is_alive():
         thread.join(timeout=5.0)
         if thread.is_alive():
             logger.warning(
@@ -3242,47 +3239,85 @@ def _next_fire_time(times: List[Tuple[int, int]], tz, now: Optional[datetime] = 
     return min(future) if future else None
 
 
+def _scheduler_close_db():
+    """Release this scheduler greenlet's Django DB connection.
+
+    Django opens a connection lazily on first query and, in a NON-request thread,
+    NEVER closes it automatically (the request/response cycle is what normally
+    closes connections). The scheduler reads settings from the DB each tick, so
+    without this it pins one Postgres backend open the entire time it sleeps; and
+    because the loader spawns a fresh scheduler per discovery, orphaned ones
+    accumulate one leaked connection apiece until `max_connections` is hit and
+    every request blocks on connection acquisition. That is the #82 lock-up,
+    rediscovered in #136. Closing before every park keeps a sleeping scheduler at
+    ZERO held connections; the next tick reopens transparently. DO NOT swap the
+    _scheduler_sleep calls below for a bare `stop_event.wait`: that reintroduces
+    the leak.
+    """
+    try:
+        from django.db import connection
+        connection.close()
+    except Exception:
+        pass
+
+
+def _scheduler_sleep(stop_event, timeout):
+    """Close the DB connection (see _scheduler_close_db), THEN park on the stop
+    event. Every scheduler sleep MUST go through here so a parked scheduler holds
+    no connection. Returns True if the stop event fired (caller should exit)."""
+    _scheduler_close_db()
+    return stop_event.wait(timeout=timeout)
+
+
 def _scheduler_loop(plugin_ref, stop_event):
     """Auto-refresh + apply at every time listed in scheduled_times.
 
     stop_event is THIS thread's own Event, held in the reload-stable registry
     (#110), not a module global: a later reload can stop this exact thread even
     after the module that started it has been unloaded and its globals reset.
+
+    Holds NO DB connection while parked: every sleep goes through
+    _scheduler_sleep (which closes first), and the finally closes on exit so a
+    reclaimed (reload-orphaned or stopped) greenlet releases its backend instead
+    of leaking it (#82/#136).
     """
-    while not stop_event.is_set():
-        try:
-            settings = plugin_ref.get_current_settings()
-            if not settings.get("auto_refresh_enabled", False):
-                stop_event.wait(timeout=300)
-                continue
-            tz = _resolve_tz(settings.get("local_timezone", "UTC"))
-            times = _parse_scheduled_times(settings.get("scheduled_times", "0400"))
-            if not times:
-                logger.warning("[ranked_matchups] no valid scheduled_times; idling 5m")
-                stop_event.wait(timeout=300)
-                continue
-            target = _next_fire_time(times, tz)
-            if target is None:
-                stop_event.wait(timeout=300)
-                continue
-            sleep_s = (target - datetime.now(tz)).total_seconds()
-            logger.info(
-                "[ranked_matchups] scheduler sleeping %.0fs until %s (next of %s)",
-                sleep_s, target.isoformat(), times,
-            )
-            if stop_event.wait(timeout=sleep_s):
-                return
-            logger.info("[ranked_matchups] scheduler firing auto_pipeline")
-            # Delegates to the shared lock/inflight/subprocess path so the
-            # scheduler runs the work OUT OF PROCESS (the Monte Carlo scoring
-            # holds the GIL and would freeze this gevent worker's hub if run
-            # inline) and can't drift out of sync with the HTTP launchers.
-            # run_scheduled_pipeline acquires the cross-worker lock itself and
-            # no-ops if another worker holds it. See tasks.py header.
-            tasks.run_scheduled_pipeline(settings)
-        except Exception:
-            logger.exception("[ranked_matchups] scheduler loop crashed; sleeping 10m")
-            stop_event.wait(timeout=600)
+    try:
+        while not stop_event.is_set():
+            try:
+                settings = plugin_ref.get_current_settings()
+                if not settings.get("auto_refresh_enabled", False):
+                    _scheduler_sleep(stop_event, 300)
+                    continue
+                tz = _resolve_tz(settings.get("local_timezone", "UTC"))
+                times = _parse_scheduled_times(settings.get("scheduled_times", "0400"))
+                if not times:
+                    logger.warning("[ranked_matchups] no valid scheduled_times; idling 5m")
+                    _scheduler_sleep(stop_event, 300)
+                    continue
+                target = _next_fire_time(times, tz)
+                if target is None:
+                    _scheduler_sleep(stop_event, 300)
+                    continue
+                sleep_s = (target - datetime.now(tz)).total_seconds()
+                logger.info(
+                    "[ranked_matchups] scheduler sleeping %.0fs until %s (next of %s)",
+                    sleep_s, target.isoformat(), times,
+                )
+                if _scheduler_sleep(stop_event, sleep_s):
+                    return
+                logger.info("[ranked_matchups] scheduler firing auto_pipeline")
+                # Delegates to the shared lock/inflight/subprocess path so the
+                # scheduler runs the work OUT OF PROCESS (the Monte Carlo scoring
+                # holds the GIL and would freeze this gevent worker's hub if run
+                # inline) and can't drift out of sync with the HTTP launchers.
+                # run_scheduled_pipeline acquires the cross-worker lock itself and
+                # no-ops if another worker holds it. See tasks.py header.
+                tasks.run_scheduled_pipeline(settings)
+            except Exception:
+                logger.exception("[ranked_matchups] scheduler loop crashed; sleeping 10m")
+                _scheduler_sleep(stop_event, 600)
+    finally:
+        _scheduler_close_db()
 
 
 _SCHEDULER_LOCK_KEY = f"plugins:{PLUGIN_KEY}:scheduler:lock"
@@ -3331,19 +3366,30 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.7.1"
+    version = "1.7.2"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than
         # relying on stale init-time settings.
         reg = _scheduler_registry()
-        # #110: the loader reloads us without calling stop(), so a thread started
-        # by a PRIOR module incarnation is still running and is only reachable
-        # via the reload-stable registry. Reclaim and stop it here before
-        # starting our own, otherwise every reload leaks a thread + DB connection
-        # (the #82 leak, through the reload path #82's stop() never covered).
+        # IDEMPOTENT across the loader's per-discovery re-instantiation (#82/#136).
+        # The loader re-execs plugin.py and rebuilds this Plugin on EVERY discovery
+        # (discover_plugins defaults to use_cache=False). Two paths, both verified
+        # live (2026-06-15):
+        #   - Routine discovery (plugins-list view / run): does NOT call stop(),
+        #     so the prior incarnation's scheduler is still in the reload-stable
+        #     registry (#110) with is_alive()==True. We MUST leave it running:
+        #     stopping+starting on every UI poll churned a thread and (pre-fix)
+        #     leaked a DB connection per poll until max_connections was hit (the
+        #     #82 lock-up). This early return is what prevents that churn.
+        #   - The reload endpoint: the loader calls stop() FIRST (loader.py), which
+        #     clears reg.thread, so we fall through and start a fresh one; the old
+        #     thread was already signaled and releases its DB connection in
+        #     _scheduler_loop's finally, and the new one parks holding none.
+        # Either way no connection leaks. Code updates ship via container restart
+        # (fresh process -> fresh thread), so a kept thread never runs stale code.
         if reg.thread is not None and reg.thread.is_alive():
-            _stop_scheduler(reg.thread, reg.stop_event, "reload", join=False)
+            return
         stop_event = threading.Event()
         t = threading.Thread(target=_scheduler_loop, args=(self, stop_event), daemon=True,
                              name="ranked_matchups-scheduler")

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1910,16 +1910,17 @@ class _StubThread:
 
 
 class TestPluginStopTeardown:
-    """The Plugin class spawns a daemon scheduler thread in __init__. Without
-    teardown, every reload leaks one thread per uwsgi worker, each holding a
-    Postgres connection via its 5-min settings-poll loop, until max_connections
-    is hit and the API 500s with "too many clients" (#82).
+    """The Plugin class spawns a daemon scheduler thread in __init__. The thread
+    reads settings from Postgres each tick, so a leaked or churned thread leaks a
+    Postgres connection until max_connections is hit and the API 500s with "too
+    many clients" (#82).
 
-    #110: the loader unloads + re-imports this module on reload WITHOUT calling
-    stop() (it only calls stop() on disable/delete). So the scheduler (thread +
-    its stop Event) lives in a reload-stable registry, and __init__ reclaims and
-    stops a prior incarnation's thread before starting its own. These tests
-    drive that registry-based lifecycle.
+    The scheduler (thread + its stop Event) lives in a reload-stable registry
+    (#110) so a later disable can reach it even after the module that started it
+    is unloaded. __init__ is IDEMPOTENT (#82/#136): the loader re-instantiates
+    Plugin on EVERY discovery, so if a healthy thread is already in the registry
+    it is LEFT running (no restart, no churn, no per-discovery connection leak);
+    only stop() (disable/delete) tears it down. These tests drive that lifecycle.
     """
 
     @pytest.fixture(autouse=True)
@@ -1984,34 +1985,60 @@ class TestPluginStopTeardown:
         assert _isolate_registry.thread is not None
         assert _isolate_registry.stop_event is not None
 
-    def test_reload_init_reclaims_orphan_without_blocking(self, plugin, monkeypatch, _isolate_registry):
-        # THE #110 fix: the loader reloads WITHOUT calling stop(), so a thread
-        # from the prior module incarnation is still running, reachable only via
-        # the reload-stable registry. A fresh Plugin() (the reload's new
-        # instance) must SIGNAL that orphan to exit and repoint the registry at
-        # its own thread. The reload path must NOT block-join (it runs in a
-        # gevent request greenlet during discovery); the orphan self-exits on
-        # the signal, so join is not called here.
+    def test_reload_init_keeps_live_thread_idempotent(self, plugin, monkeypatch, _isolate_registry):
+        # #82/#136: the loader re-instantiates Plugin on EVERY discovery
+        # (plugins-list view, run, settings-save, reload). A healthy scheduler
+        # from a prior incarnation is reachable via the reload-stable registry
+        # and reads settings live from the DB, so __init__ must LEAVE it running:
+        # no signal, no replacement, no new spawn. Restarting per discovery is
+        # what churned a thread and leaked a DB connection each time (the #82
+        # lock-up).
         import threading
         reg = _isolate_registry
-        orphan_event = threading.Event()
-        orphan = _StubThread(orphan_event)
-        reg.thread, reg.stop_event = orphan, orphan_event
+        live_event = threading.Event()
+        live = _StubThread(live_event)  # is_alive() -> True
+        reg.thread, reg.stop_event = live, live_event
+
+        spawned = []
+
+        class TrackingThread(threading.Thread):
+            def __init__(self, *a, **kw):
+                spawned.append(kw.get("name"))
+                super().__init__(*a, **kw)
+            def start(self):  # don't run a live thread in tests
+                pass
+
+        monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
+        plugin.Plugin()  # a later discovery's incarnation
+
+        # The live thread is untouched: not signaled, not joined, not replaced,
+        # and no new thread spawned.
+        assert not live_event.is_set()
+        assert live.join_calls == 0
+        assert reg.thread is live
+        assert reg.stop_event is live_event
+        assert spawned == []
+
+    def test_reload_init_replaces_dead_thread(self, plugin, monkeypatch, _isolate_registry):
+        # If the registry's thread has died, __init__ starts a fresh one (the
+        # idempotency check is is_alive(), not mere presence).
+        import threading
+        reg = _isolate_registry
+        dead_event = threading.Event()
+        dead = _StubThread(dead_event)
+        dead._alive = False  # a thread that has exited
+        reg.thread, reg.stop_event = dead, dead_event
 
         class TrackingThread(threading.Thread):
             def start(self):  # don't run a live thread in tests
                 pass
 
         monkeypatch.setattr(plugin.threading, "Thread", TrackingThread)
-        plugin.Plugin()  # the reloaded incarnation
+        plugin.Plugin()
 
-        # Orphan was signaled (it will exit on its next wake), NOT join-blocked,
-        # and the registry now holds a NEW thread + event, not the orphan.
-        assert orphan_event.is_set()
-        assert orphan.join_calls == 0  # reload path must not block on join
-        assert reg.thread is not orphan
+        assert reg.thread is not dead
         assert isinstance(reg.thread, TrackingThread)
-        assert reg.stop_event is not orphan_event
+        assert reg.stop_event is not dead_event
 
     def test_stop_still_joins_on_teardown(self, plugin, _isolate_registry):
         # The disable/delete path (stop()) is not latency-sensitive and SHOULD

--- a/tests/test_scheduler_connection_lifecycle.py
+++ b/tests/test_scheduler_connection_lifecycle.py
@@ -1,0 +1,119 @@
+"""Regression guards for the scheduler DB-connection leak (#82/#136).
+
+The scheduler thread reads settings from Postgres each tick. Two bugs caused a
+connection leak that eventually hit `max_connections` and locked up the server:
+
+1. The loop slept WITHOUT closing its DB connection, so a parked scheduler
+   pinned one backend open indefinitely.
+2. `Plugin.__init__` (re-run on every loader discovery) stopped+started the
+   scheduler each time, orphaning the old greenlet's connection.
+
+This file locks in the connection-lifecycle half of the fix: every park closes
+the connection, and no bare `stop_event.wait` slips back into the loop. The
+idempotent-__init__ half (no restart when a healthy thread is already running)
+is covered in test_plugin_helpers.py::TestPluginStopTeardown against the real
+reload-stable registry.
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG = "dispatcharr_ranked_matchups"
+PLUGIN_PY = os.path.join(REPO_ROOT, "plugin.py")
+
+
+@pytest.fixture(scope="module")
+def plugin():
+    if f"{PKG}._util" not in sys.modules:
+        s = importlib.util.spec_from_file_location(f"{PKG}._util", os.path.join(REPO_ROOT, "_util.py"))
+        m = importlib.util.module_from_spec(s)
+        sys.modules[f"{PKG}._util"] = m
+        s.loader.exec_module(m)
+    if PKG not in sys.modules:
+        pkg = types.ModuleType(PKG)
+        pkg.__path__ = [REPO_ROOT]
+        sys.modules[PKG] = pkg
+    if f"{PKG}.plugin" not in sys.modules:
+        s = importlib.util.spec_from_file_location(f"{PKG}.plugin", PLUGIN_PY)
+        m = importlib.util.module_from_spec(s)
+        sys.modules[f"{PKG}.plugin"] = m
+        s.loader.exec_module(m)
+    return sys.modules[f"{PKG}.plugin"]
+
+
+class _RecordingConn:
+    def __init__(self):
+        self.closed = 0
+
+    def close(self):
+        self.closed += 1
+
+
+def _install_fake_db(monkeypatch, conn):
+    db = types.ModuleType("django.db")
+    db.connection = conn
+    monkeypatch.setitem(sys.modules, "django", types.ModuleType("django"))
+    monkeypatch.setitem(sys.modules, "django.db", db)
+
+
+class TestSchedulerClosesConnection:
+    def test_close_db_closes_the_connection(self, plugin, monkeypatch):
+        conn = _RecordingConn()
+        _install_fake_db(monkeypatch, conn)
+        plugin._scheduler_close_db()
+        assert conn.closed == 1
+
+    def test_close_db_swallows_errors(self, plugin, monkeypatch):
+        # A DB layer that raises on close must not crash the scheduler.
+        boom = types.ModuleType("django.db")
+
+        class _Boom:
+            def close(self):
+                raise RuntimeError("nope")
+        boom.connection = _Boom()
+        monkeypatch.setitem(sys.modules, "django", types.ModuleType("django"))
+        monkeypatch.setitem(sys.modules, "django.db", boom)
+        plugin._scheduler_close_db()  # must not raise
+
+    def test_sleep_closes_then_waits(self, plugin, monkeypatch):
+        conn = _RecordingConn()
+        _install_fake_db(monkeypatch, conn)
+        order = []
+
+        class _Evt:
+            def wait(self, timeout=None):
+                order.append(("wait", conn.closed))  # capture closed-count AT wait time
+                return True
+        out = plugin._scheduler_sleep(_Evt(), 5)
+        assert out is True
+        # The connection was already closed BEFORE the wait happened.
+        assert order == [("wait", 1)]
+
+
+class TestNoBareWaitInSchedulerLoop:
+    """Every sleep in _scheduler_loop must route through _scheduler_sleep (which
+    closes the connection). A bare `stop_event.wait(...)` would reintroduce the
+    leak, so fail if one appears."""
+
+    def test_no_bare_stop_event_wait(self):
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        loop = next((n for n in ast.walk(tree)
+                     if isinstance(n, ast.FunctionDef) and n.name == "_scheduler_loop"), None)
+        assert loop is not None, "_scheduler_loop not found"
+        bare = []
+        for node in ast.walk(loop):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "wait"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "stop_event"):
+                bare.append(node.lineno)
+        assert not bare, (
+            f"bare stop_event.wait() in _scheduler_loop at lines {bare}; "
+            f"route every sleep through _scheduler_sleep so it closes the DB "
+            f"connection first (#82/#136)")


### PR DESCRIPTION
Refs #82, #136. (Leaving #136 open for you to close after merge + your own confirmation.)

## Problem

The background scheduler thread reads settings from Postgres each tick but never closed its connection, so a parked scheduler pinned one backend open. And Dispatcharr re-instantiates the plugin on **every discovery** (notably the plugins-list view / UI polling, `use_cache=False`), so each re-instantiation churned a new scheduler thread and leaked a connection until `max_connections` was hit and every request (including login) blocked. That presented as the server locking up. It is **independent of channel count**, so it hit small installs too (the other user's ~323-channel box). This is the #82 leak class, rediscovered while chasing #136.

## Fix (both discovery paths verified live on a ~6.3k-channel instance)

- `_scheduler_loop` closes its DB connection before **every** park (via the new `_scheduler_sleep` helper) and on loop exit (`finally`), so a parked scheduler holds **zero** connections and a stopped/reclaimed one releases its backend.
- `Plugin.__init__` is **idempotent**: routine discovery (plugins-list / run) does NOT call `stop()`, so the live scheduler stays in the reload-stable registry (#110) and `__init__` leaves it running instead of churning a new thread. The reload endpoint DOES call `stop()` first, so a fresh thread spawns there, but the old one's connection is released by the `finally` and the new one parks holding none. Either path: no leak.
- `_stop_scheduler` loses its now-unused `join=False` parameter (only `stop()` calls it; the reload path no longer does).

## Live verification

- **8 rapid reloads** held the client-connection count to a **24→35 plateau** (pre-fix it climbed unbounded toward `max_connections=200`); login never wedged (0.003–0.054s throughout, vs the pre-fix wedge around the 8th reload).
- Instrumented `__init__` confirmed the two paths: plugins-list discovery logged `is_alive()==True` and spawned **no** new thread (idempotency firing); the reload endpoint cleared `reg.thread` (loader calls `stop()`) and spawned a fresh one with no connection leak.

## Tests (full suite: 3236 passed)

- `tests/test_scheduler_connection_lifecycle.py`: connection closed before park (`_scheduler_close_db` / `_scheduler_sleep`); AST guard that no bare `stop_event.wait` re-enters the loop and skips the close, **proven failing-then-green** against the pre-fix code.
- `tests/test_plugin_helpers.py::TestPluginStopTeardown`: rewritten idempotency cases (keep live thread / replace dead thread) reflecting the new contract.

## Known residual (Dispatcharr-core, not this plugin)

The loader re-execs the whole plugin module (~309ms, measured) on every discovery. That is a brief per-poll hub stall, not the lock-up, and the plugin can't control it. Worth a separate upstream note.

Version 1.7.1 → 1.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)