### PR TITLE
v1.8.0: stream-name matching (Path C) + Tier-1 broadcaster merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-16
+
+### Added
+
+- **Stream-name matching (Path C).** The matcher now also keys on the names of
+  individual STREAMS, not just channel names and EPG programme titles. Providers
+  spin up dedicated per-match feeds whose matchup lives in the stream name
+  ("USA Soccer10: ... Iran vs New Zealand") on a generically-named channel with
+  no EPG; Path A (EPG title) and Path B (channel name) both miss those. A stream
+  whose name names both teams (or, for field events, the event) is now attached
+  **stream-granular**: only that one stream lands on the matchup channel, not its
+  parent channel's unrelated streams. Match results carry a new `stream_ids`
+  alongside `channel_ids`, threaded through the cache and apply.
+- A **feed-prefix guard** for stream-name matching: both teams must co-occur in a
+  single `:`/`|`-delimited segment of the name. Without it the network label
+  "USA Soccer09" supplied a bogus "USA" hit for United States while the real
+  opponent appeared in a different matchup ("Australia vs Turkey"),
+  cross-matching games. Kickoff times ("Iran 02:00 New Zealand") are not treated
+  as segment boundaries.
+
+### Fixed
+
+- **Tier-1 no longer drops EPG-confirmed broadcasters when a dedicated feed
+  exists.** When a channel name named both teams (Tier-1), the matcher used to
+  return only those channels and discard every broadcaster whose EPG programme
+  title named the game (FOX/TSN/BBC). It now MERGES the program-title both-team
+  matches behind the channel-name matches as fallback streams. Both sets are
+  gated on both teams, so the merge is high-precision and needs no LLM call.
+
 ## [1.7.2] - 2026-06-14
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.7.2"
+__version__ = "1.8.0"

--- a/matcher.py
+++ b/matcher.py
@@ -1,15 +1,26 @@
-"""Match scored games to Dispatcharr channels via EPG ProgramData.
+"""Match scored games to Dispatcharr channels / streams.
 
-Flow per game:
-  1) Query ProgramData for programs airing during [game.start_time-30m, game.start_time+4h]
-     across all sports-flagged channels.
-  2) Regex pre-filter: programs whose title contains BOTH team identifiers (full
-     name or last word as fallback).
-  3) If exactly 1 candidate → match.
-  4) If multiple → Claude picks the right one given the game context.
-  5) If zero candidates → log and skip (provider may not carry this game).
+`_build_epg_lookup` (in plugin.py) supplies candidates from three sources:
+  Path A - EPG ProgramData whose programme TITLE names a team, in the game's
+           broadcast window (whole-channel: all the channel's streams attach).
+  Path B - channels whose NAME names both teams (whole-channel).
+  Path C - STREAMS whose name names both teams (stream-granular: only that one
+           stream attaches, not the parent channel's others). Candidates carry
+           a stream_id and a negative sentinel channel_id.
 
-Batch optimization: one Claude call resolves all ambiguous-match games together.
+Tiers per game (match_games_to_channels):
+  Tier 1 (regex_strict): a CHANNEL NAME (Path B) or STREAM NAME (Path C) names
+     both teams. Highest confidence. MERGES the Tier-2 program-title both-team
+     matches behind it (the live broadcasters) as fallback streams instead of
+     discarding them.
+  Tier 2 (regex_unique): exactly one non-preview programme title names both
+     teams → match it.
+  Tier 3 (llm / fallback_first): multiple or zero strict/title matches → Claude
+     disambiguates (one batched call for all ambiguous games); with no API key,
+     the first candidate is used.
+
+The result splits matched targets into channel_ids (whole-channel) and
+stream_ids (stream-granular Path C) via _partition_attach_targets.
 """
 
 from __future__ import annotations
@@ -77,6 +88,14 @@ class ChannelCandidate:
     program_title: str
     program_start: datetime
     program_end: datetime
+    # Path C (stream-name match): when set, this candidate is a SPECIFIC stream
+    # whose NAME named the game, NOT a whole channel. The apply attaches only
+    # this stream, not the parent channel's other (unrelated) streams. None =
+    # whole-channel candidate (Path A EPG title / Path B channel name): every
+    # stream on the channel attaches. For stream candidates channel_id is a
+    # negative sentinel (-stream_id), never a real PK, so the partition below
+    # never expands a parent channel for them.
+    stream_id: Optional[int] = None
 
 
 @dataclass
@@ -89,9 +108,14 @@ class MatchResult:
     # to stack multiple provider variants (different qualities/regions) onto
     # the virtual channel as fallback streams. Empty list means no match.
     channel_ids: List[int] = None  # type: ignore[assignment]
-    # 'regex_strict' (channel name had both teams), 'regex_unique' (program
-    # title regex matched exactly one non-preview), 'llm' (Claude picked from
-    # multiple), 'fallback_first' (no API key, used first candidate),
+    # Explicit stream IDs to attach (stream-granular: Path C stream-name
+    # matches), separate from channel_ids (whole-channel matches whose every
+    # stream attaches). The apply stacks BOTH, deduped by stream id. Empty
+    # unless a stream-name candidate won a tier.
+    stream_ids: List[int] = None  # type: ignore[assignment]
+    # 'regex_strict' (channel name OR stream name had both teams), 'regex_unique'
+    # (program title regex matched exactly one non-preview), 'llm' (Claude picked
+    # from multiple), 'fallback_first' (no API key, used first candidate),
     # 'unmatched'.
     method: str = "unmatched"
     note: str = ""
@@ -99,6 +123,8 @@ class MatchResult:
     def __post_init__(self):
         if self.channel_ids is None:
             self.channel_ids = []
+        if self.stream_ids is None:
+            self.stream_ids = []
 
 
 def _team_keywords(team_name: str) -> List[str]:
@@ -154,6 +180,35 @@ def _kw_hit(text: str, keywords: List[str]) -> bool:
     """
     t = (text or "").lower()
     return any(kw.lower() in t for kw in keywords)
+
+
+def both_teams_in_one_segment(
+    text: str, home_kws: List[str], away_kws: List[str]
+) -> bool:
+    """True if SOME ':'/'|'-delimited segment of `text` names BOTH sides.
+
+    Providers prefix a feed/network label onto stream names:
+    'USA Soccer09: Australia vs Turkey', 'US (Peacock 064) | Suiza v. Bosnia'.
+    The matchup lives in ONE segment; a team alias appearing only in the LABEL
+    (e.g. 'USA' in the feed-prefix 'USA Soccer09', which is NOT the United
+    States team) must not pair with an opponent token in the matchup body to
+    fake a match. Confirmed false positive: the United States vs Australia game
+    matched 'USA Soccer09: Australia vs Turkey' (USA from the prefix, Australia
+    from the body) before this gate. Requiring co-occurrence in a single segment
+    kills that class while keeping every real feed (whose matchup names both
+    teams together). Used to gate Path C stream-name candidates, where these
+    feed prefixes are common.
+
+    Splits on the label separators ':' and '|', but NOT on a ':' that is part of
+    a clock time ('Iran 02:00 New Zealand'): a colon immediately followed by a
+    digit is a time, not a feed-label boundary. Without that guard the kickoff
+    time inside 'FIFA World Cup 2026 18: Iran 02:00 New Zealand' would split the
+    matchup across segments and reject a legitimate feed.
+    """
+    for seg in re.split(r":(?!\d)|\|", text or ""):
+        if _kw_hit(seg, home_kws) and _kw_hit(seg, away_kws):
+            return True
+    return False
 
 
 def _regex_filter(
@@ -314,22 +369,39 @@ MATCHER_SYSTEM_PROMPT = (
 )
 
 
-def _stack_fallback_ids(
-    primary_id: int, cands: List[ChannelCandidate]
-) -> List[int]:
-    """Primary id first, then every other candidate id, deduped in order.
+def _partition_attach_targets(
+    primary: ChannelCandidate, cands: List[ChannelCandidate]
+) -> Tuple[List[int], List[int]]:
+    """Split an ordered candidate set into (channel_ids, stream_ids).
 
-    Used by the #108 widen path to stack same-fixture provider variants as
-    fallback streams behind the chosen primary. A single channel can appear in
-    `cands` more than once (multiple ProgramData rows), so dedupe.
+    `primary` leads (its target sits first in whichever list it belongs to),
+    then the rest of `cands` in order. Whole-channel candidates (stream_id is
+    None: Path A EPG title / Path B channel name) contribute their channel_id,
+    so the apply stacks ALL of that channel's streams. Stream-name candidates
+    (stream_id set: Path C) contribute ONLY their stream_id, so the apply
+    attaches that one stream and NOT the parent channel's unrelated streams.
+    Both lists are deduped in encounter order.
+
+    With an all-whole-channel set (the pre-stream-name shape) this returns
+    (deduped channel_ids, []), identical to the old _stack_fallback_ids it
+    replaced. Used by the #108 widen path and the Tier-1 merge to stack
+    same-fixture variants as fallback streams behind the chosen primary; a
+    single channel can appear more than once (multiple ProgramData rows), hence
+    the dedupe.
     """
-    out = [primary_id]
-    seen = {primary_id}
-    for c in cands:
-        if c.channel_id not in seen:
-            out.append(c.channel_id)
-            seen.add(c.channel_id)
-    return out
+    channel_ids: List[int] = []
+    stream_ids: List[int] = []
+    seen_ch: set = set()
+    seen_st: set = set()
+    for c in [primary, *cands]:
+        if c.stream_id is not None:
+            if c.stream_id not in seen_st:
+                seen_st.add(c.stream_id)
+                stream_ids.append(c.stream_id)
+        elif c.channel_id not in seen_ch:
+            seen_ch.add(c.channel_id)
+            channel_ids.append(c.channel_id)
+    return channel_ids, stream_ids
 
 
 def match_games_to_channels(
@@ -375,34 +447,47 @@ def match_games_to_channels(
         # Tier 1 (strongest signal): channels whose NAME contains both teams
         # (or, for field events, the event name). These are dedicated match
         # channels: typically multiple regional / quality variants of the same
-        # fixture. Stack all of them.
+        # fixture. Stack all of them. Note Path C stream-name candidates also
+        # land here when their name names both teams (their channel_name IS the
+        # stream name), so a stream-name match is treated with the same
+        # confidence as a channel-name match.
         strict = _regex_filter_channel_name(candidates, game.home, match_away)
+        # Tier 2: program-title regex, with previews ('Next Game:', 'Preview:',
+        # 'Pre-game ...') stripped: those mark team-branded home channels
+        # that surface upcoming-game EPG cards but don't broadcast the match.
+        # Computed up front so Tier-1 can MERGE it in (below).
+        filtered = _strip_preview_titles(
+            _regex_filter(candidates, game.home, match_away)
+        )
         if strict:
             primary = strict[0]
             results[i].channel_id = primary.channel_id
             results[i].channel_name = primary.channel_name
             results[i].program_title = primary.program_title
-            # De-dupe channel_ids while preserving order (a single channel can
-            # have multiple ProgramData rows that pass the filter). Tier-1
-            # always stacks every channel-name variant: this is the original
-            # multi-stream path the #108 widen flag generalizes to lower tiers,
-            # so it shares the same stacking helper.
-            results[i].channel_ids = _stack_fallback_ids(primary.channel_id, strict)
+            # MERGE: a channel-name match confirms the fixture is genuinely on
+            # air, so also stack the program-title both-team matches (the live
+            # broadcasters: FOX/TSN/BBC whose EPG names the game) behind the
+            # dedicated feeds, instead of discarding them. Before this, Tier-1
+            # short-circuited on `strict` alone and silently dropped every
+            # EPG-confirmed broadcaster the moment one dedicated-feed channel
+            # existed. Both sets are gated on BOTH teams, so the merge is
+            # high-precision and needs no LLM call. The partition routes any
+            # Path C stream-name candidates in either set to stream_ids and
+            # de-dupes (a channel can recur across multiple ProgramData rows).
+            ch_ids, st_ids = _partition_attach_targets(primary, [*strict, *filtered])
+            results[i].channel_ids = ch_ids
+            results[i].stream_ids = st_ids
             results[i].method = "regex_strict"
             continue
 
-        # Tier 2: program-title regex, with previews ('Next Game:', 'Preview:',
-        # 'Pre-game ...') stripped: those mark team-branded home channels
-        # that surface upcoming-game EPG cards but don't broadcast the match.
-        filtered = _strip_preview_titles(
-            _regex_filter(candidates, game.home, match_away)
-        )
         if len(filtered) == 1:
             c = filtered[0]
             results[i].channel_id = c.channel_id
             results[i].channel_name = c.channel_name
             results[i].program_title = c.program_title
-            results[i].channel_ids = [c.channel_id]
+            results[i].channel_ids, results[i].stream_ids = (
+                _partition_attach_targets(c, [])
+            )
             results[i].method = "regex_unique"
         elif len(filtered) == 0:
             # Tier 3: LLM with a wider net (all non-preview candidates in
@@ -460,10 +545,10 @@ def match_games_to_channels(
             results[idx].program_title = chosen.program_title
             # #108: stack the other both-team variants as fallback streams when
             # widen is on; otherwise keep the historical single-channel result.
-            if widen and both_team:
-                results[idx].channel_ids = _stack_fallback_ids(chosen.channel_id, cands)
-            else:
-                results[idx].channel_ids = [chosen.channel_id]
+            extra = cands if (widen and both_team) else []
+            results[idx].channel_ids, results[idx].stream_ids = (
+                _partition_attach_targets(chosen, extra)
+            )
             results[idx].method = "llm"
     elif ambiguous:
         # No API key: best-effort: pick first candidate to surface SOMETHING.
@@ -476,10 +561,10 @@ def match_games_to_channels(
                 # #108: same widen rule as the LLM path. Without an API key we
                 # cannot disambiguate, so the first candidate is primary and the
                 # rest stack only when they all name both teams.
-                if widen and both_team:
-                    results[idx].channel_ids = _stack_fallback_ids(c.channel_id, cands)
-                else:
-                    results[idx].channel_ids = [c.channel_id]
+                extra = cands if (widen and both_team) else []
+                results[idx].channel_ids, results[idx].stream_ids = (
+                    _partition_attach_targets(c, extra)
+                )
                 results[idx].method = "fallback_first"
                 results[idx].note = "no api key; first candidate"
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/plugin.py
+++ b/plugin.py
@@ -1285,7 +1285,8 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
             "importance_notes": signals.importance_notes,
             "importance_thresholds_hit": signals.importance_thresholds_hit,
             "channel_id": match.channel_id,           # primary, kept for backward-compat
-            "channel_ids": list(match.channel_ids),   # all matched, primary first
+            "channel_ids": list(match.channel_ids),   # whole-channel matches, primary first
+            "stream_ids": list(match.stream_ids),     # stream-granular (Path C stream-name matches)
             "channel_name_current": match.channel_name,
             "program_title": match.program_title,
             "match_method": match.method,
@@ -1306,7 +1307,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "status": "ok",
         "message": (
-            f"Refreshed: {len(games_payload)} games scored, {matched} matched to channels. "
+            f"Refreshed: {len(games_payload)} games scored, {matched} matched to a broadcast. "
             + " | ".join(src_summary)
         ),
     }
@@ -1331,8 +1332,8 @@ def _build_epg_lookup():
     against the old uncapped path was ch_id=111919 'EPL 07ⓧ: ... vs Brentford
     FC' getting omitted from the candidate list for the live game window).
     """
-    from .matcher import ChannelCandidate, _team_keywords
-    from apps.channels.models import Channel
+    from .matcher import ChannelCandidate, _team_keywords, both_teams_in_one_segment
+    from apps.channels.models import Channel, Stream
     from apps.epg.models import ProgramData
     from django.db.models import Q
 
@@ -1360,10 +1361,25 @@ def _build_epg_lookup():
             if not (home_kws and away_kws):
                 return []
 
+        def _or_icontains(dbfield, kws):
+            """OR of `<dbfield>__icontains=kw` over kws. One source of truth for
+            the three keyword-substring queries below (programme title, channel
+            name, stream name).
+
+            Empty kws returns a match-NOTHING Q, NOT a bare `Q()`: an empty
+            Django Q matches EVERY row, so a future caller passing no keywords
+            would silently select the whole table. All current call sites guard
+            against empty kws, but the safe contract is enforced here too.
+            """
+            if not kws:
+                return Q(pk__in=[])
+            q = Q()
+            for kw in kws:
+                q |= Q(**{f"{dbfield}__icontains": kw})
+            return q
+
         # Path A: programs in window whose TITLE mentions any team keyword.
-        title_q = Q()
-        for kw in all_kws:
-            title_q |= Q(title__icontains=kw)
+        title_q = _or_icontains("title", all_kws)
         title_progs = list(
             ProgramData.objects
             .filter(start_time__lt=window_end, end_time__gt=window_start)
@@ -1381,19 +1397,13 @@ def _build_epg_lookup():
         # home channels from leaking into the Tier-3 LLM candidate set, and it
         # keeps short broadcast aliases (e.g. 'USA') from dragging in every
         # unrelated channel that merely contains the substring.
-        home_name_q = Q()
-        for kw in home_kws:
-            home_name_q |= Q(name__icontains=kw)
         if field:
             # Single-sided: a channel naming the event is the broadcast. ANDing
             # the "Field" sentinel here (as the two-team path does) would match
             # nothing, which is the #127 bug.
-            name_q = home_name_q
+            name_q = _or_icontains("name", home_kws)
         else:
-            away_name_q = Q()
-            for kw in away_kws:
-                away_name_q |= Q(name__icontains=kw)
-            name_q = home_name_q & away_name_q
+            name_q = _or_icontains("name", home_kws) & _or_icontains("name", away_kws)
         name_match_chans = list(
             Channel.objects
             .filter(name_q)
@@ -1441,6 +1451,42 @@ def _build_epg_lookup():
                 program_title="",  # no real program; tier-1 matches via channel name
                 program_start=game.start_time,
                 program_end=window_end,
+            ))
+
+        # Path C: STREAMS whose NAME names both teams (or, for field events, the
+        # event name). Providers spin up dedicated per-match feeds whose matchup
+        # lives in the STREAM name ('USA Soccer10: ... Iran vs New Zealand')
+        # while the parent channel is generically named and carries no EPG, so
+        # Path A (EPG title) and Path B (channel name) both miss them. We match
+        # the stream by name and attach ONLY that stream (stream-granular):
+        # channel_id is a negative sentinel (never a real PK), and channel_name
+        # is the stream name so the matcher's Tier-1 treats a stream naming both
+        # teams with the same confidence as a channel naming both teams. Streams
+        # carry no schedule, so there is no time-window filter; the specific
+        # team-pair gate is what keeps it tight. Re-selecting a stream already
+        # attached to our own virtual channel is harmless: the apply de-dupes
+        # and the end state converges. The DB predicate is identical to Path B's
+        # `name_q` (both query a `name` field with the same both-teams gate), so
+        # it is reused rather than rebuilt; the per-segment refinement below is
+        # what makes the stream-name case safe against feed-prefix collisions.
+        for s in Stream.objects.filter(name_q).only("id", "name"):
+            # Guard the feed-prefix false positive (e.g. 'USA Soccer09: Australia
+            # vs Turkey' matching United States vs Australia: 'USA' is the feed
+            # label, not the team). Two-team games require both sides to co-occur
+            # in ONE ':'/'|'-delimited segment of the name. Field events are
+            # single-sided (just the event name), so the segment gate does not
+            # apply.
+            if not field and not both_teams_in_one_segment(
+                s.name or "", home_kws, away_kws
+            ):
+                continue
+            out.append(ChannelCandidate(
+                channel_id=-s.id,            # sentinel: not a real channel PK
+                channel_name=s.name or "",   # stream name → Tier-1 sees both teams
+                program_title=s.name or "",
+                program_start=game.start_time,
+                program_end=window_end,
+                stream_id=s.id,
             ))
         return out
 
@@ -1971,7 +2017,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     Source channels are never touched. Stale virtual channels (game no longer
     in cache) are deleted along with their EPG entries.
     """
-    from apps.channels.models import Channel, ChannelGroup, ChannelStream
+    from apps.channels.models import Channel, ChannelGroup, ChannelStream, Stream
     from apps.epg.models import EPGSource, EPGData, ProgramData
     from django.db import transaction
 
@@ -2320,9 +2366,16 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     prep_by_marker: Dict[str, Any] = {}
     for g in games:
         source_ids = list(g.get("channel_ids") or [])
-        if not source_ids:
+        # Path C stream-granular matches: specific streams to attach without
+        # pulling in their parent channel's other streams. Older caches lack
+        # this key (→ []), so behaviour is unchanged for them.
+        explicit_stream_ids = list(g.get("stream_ids") or [])
+        if not source_ids and not explicit_stream_ids:
             primary_id = g.get("channel_id")
-            if primary_id:
+            # A positive primary is a real channel; a negative one is a Path C
+            # stream sentinel with no whole-channel to expand, so ignore it here
+            # (its stream rides in explicit_stream_ids).
+            if primary_id and primary_id > 0:
                 source_ids = [primary_id]
         sources = list(Channel.objects.filter(id__in=source_ids))
         sources_by_id = {c.id: c for c in sources}
@@ -2330,7 +2383,9 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         source = sources[0] if sources else None
 
         placeholder = False
-        if not source:
+        # A stream-only match (no whole-channel source, but explicit streams) is
+        # a real match, NOT a placeholder.
+        if not source and not explicit_stream_ids:
             score_val = float(g.get("score", 0.0))
             if score_val >= placeholder_threshold:
                 placeholder = True
@@ -2411,6 +2466,27 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                     english_first=english_first, home=g["home"], away=g["away"],
                 )
                 stream_pool.append((key, src_order, s.id))
+        # Path C: attach the specific stream-name-matched streams, NOT their
+        # parent channels' other (unrelated) streams. Ordered after the channel
+        # sources; the quality sort below re-ranks the whole pool anyway, so the
+        # base offset is only a stable tiebreak. De-duped against channel
+        # streams already pooled.
+        if explicit_stream_ids:
+            base = len(sources)
+            by_id = {
+                s.id: s for s in Stream.objects.filter(id__in=explicit_stream_ids)
+                .only("id", "name", "stream_stats")
+            }
+            for j, sid in enumerate(explicit_stream_ids):
+                s = by_id.get(sid)
+                if s is None or s.id in seen_stream_ids:
+                    continue
+                seen_stream_ids.add(s.id)
+                key = _stream_sort_key(
+                    s.stream_stats, s.name or "",
+                    english_first=english_first, home=g["home"], away=g["away"],
+                )
+                stream_pool.append((key, base + j, s.id))
         stream_pool.sort()
         source_streams = [sid for _, _, sid in stream_pool]
 
@@ -3051,6 +3127,7 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
     home = away = ""
     home_kws = away_kws = []
     rows: List[Any] = []
+    stream_hits: List[str] = []  # Path C: stream NAMES that name the team(s)
     verdict = ""
     toast: List[str] = []
     field = False
@@ -3089,13 +3166,24 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
                 cands = _build_epg_lookup()(shim)
             except Exception:
                 cands = []
+            # Path C: stream NAMES (not channel names) that name the team(s).
+            # These carry stream_id; surface them so a user can see the dedicated
+            # per-match feeds the matcher now keys on.
+            stream_hits = [c.program_title for c in cands if c.stream_id is not None]
             # Single-sided channel-name check for field events (team_b=None).
             name_match = _regex_filter_channel_name(
                 cands, home, None if field else away) if cands else []
-            if name_match:
+            chan_name_match = [c for c in name_match if c.stream_id is None]
+            stream_name_match = [c for c in name_match if c.stream_id is not None]
+            if chan_name_match:
                 verdict = (("A channel name has the event but it didn't match - "
                             if field else
                             "A channel name has both teams but it didn't match - ")
+                           + "unexpected; please send us this.")
+            elif stream_name_match:
+                verdict = (("A stream name has the event but it didn't match - "
+                            if field else
+                            "A stream name has both teams but it didn't match - ")
                            + "unexpected; please send us this.")
             elif both:
                 verdict = ("A listing names BOTH teams but wasn't auto-picked - reply "
@@ -3137,6 +3225,17 @@ def _action_diagnose(settings: Dict[str, Any]) -> Dict[str, Any]:
                 vlog.append(f"    +{len(rows) - 40} more")
         else:
             vlog.append("  head-to-head listings in its window: none")
+        # Path C: streams whose NAME names the team(s). A non-empty list here on
+        # an UNMATCHED game indicates a bug (these should match via Path C), so
+        # it is the actionable signal to send us.
+        if stream_hits:
+            vlog.append(f"  streams naming the team(s) ({len(stream_hits)}):")
+            for nm in stream_hits[:40]:
+                vlog.append(f"    \"{nm}\"")
+            if len(stream_hits) > 40:
+                vlog.append(f"    +{len(stream_hits) - 40} more")
+        else:
+            vlog.append("  streams naming the team(s): none")
     vlog.append(f"  verdict: {verdict}")
     vlog.append(f"all unmatched ({len(unmatched)}):")
     for g in unmatched:
@@ -3366,7 +3465,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.7.2"
+    version = "1.8.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -61,7 +61,12 @@ def ChannelCandidate():
 
 
 def _game(away, home, *, prefix="WC", score=5.0, matched=None,
-          start="2026-06-15T20:00:00Z", label="FIFA World Cup"):
+          start="2099-06-15T20:00:00Z", label="FIFA World Cup"):
+    # Default start is FAR-FUTURE so the diagnose "soonest upcoming" selection
+    # holds regardless of the wall clock. A real near-past date (e.g. today's
+    # fixture) rots the moment the test runs the next day: it drops out of the
+    # "upcoming" window and target selection flips to whatever future game
+    # remains. Tests that care about ordering pass explicit distinct futures.
     return {
         "sport_prefix": prefix, "sport_label": label,
         "away": away, "home": home,
@@ -148,6 +153,19 @@ class TestDeepDive:
         msg = _run(plugin, games, window_rows=rows, lookup_cands=cands)
         assert "unexpected" in msg
 
+    def test_unexpected_when_stream_name_has_both(self, plugin, ChannelCandidate):
+        # Path C: a STREAM (stream_id set) names both teams but the game is
+        # unmatched -> the verdict must say "stream name" (not "channel name").
+        from datetime import datetime, timezone
+        now = datetime(2026, 6, 15, 20, 0, tzinfo=timezone.utc)
+        stream_cand = ChannelCandidate(
+            channel_id=-77, channel_name="USA Soccer10: Knicks vs Spurs",
+            program_title="USA Soccer10: Knicks vs Spurs",
+            program_start=now, program_end=now, stream_id=77)
+        games = [_game("New York Knicks", "San Antonio Spurs", prefix="NBA", score=8.0)]
+        msg = _run(plugin, games, window_rows=[], lookup_cands=[stream_cand])
+        assert "stream name has both teams but it didn't match" in msg
+
     def test_long_title_is_truncated(self, plugin):
         long_title = "FIFA World Cup Quarterfinal Extravaganza Presented by Sponsor: Japan vs"
         rows = [("Some Very Long Channel Name Here FHD", long_title, " [Japan]")]
@@ -209,7 +227,9 @@ class TestDeepDive:
         monkeypatch.setattr(plugin, "logger", _FakeLogger())
         rows = [("beIN 1", "Japan vs Netherlands", " [BOTH TEAMS]"),
                 ("Some Other Ch", "Unrelated vs Game", "")]
-        games = [_game("Japan", "Netherlands", score=9.0),
+        # Both far-future (clock-independent); Japan SOONER so it is the target,
+        # Egypt later so it is the non-target shown only in the verbose log.
+        games = [_game("Japan", "Netherlands", score=9.0, start="2099-01-01T20:00:00Z"),
                  _game("Egypt", "Belgium", score=3.0, start="2099-09-09T20:00:00Z")]
         toast = _run(plugin, games, window_rows=rows)
 

--- a/tests/test_field_event_lookup.py
+++ b/tests/test_field_event_lookup.py
@@ -120,10 +120,11 @@ class _Row:
         self.__dict__.update(kw)
 
 
-def _install_fake_orm(monkeypatch, channels, programs):
+def _install_fake_orm(monkeypatch, channels, programs, streams=None):
     """Register fake apps.channels.models / apps.epg.models / django.db.models."""
     chan_mod = types.ModuleType("apps.channels.models")
     chan_mod.Channel = types.SimpleNamespace(objects=FakeManager(channels))
+    chan_mod.Stream = types.SimpleNamespace(objects=FakeManager(streams or []))
     epg_mod = types.ModuleType("apps.epg.models")
     epg_mod.ProgramData = types.SimpleNamespace(objects=FakeManager(programs))
     dj_mod = types.ModuleType("django.db.models")
@@ -203,3 +204,76 @@ class TestFieldEventLookup:
         game = _game("Arsenal", "Chelsea", prefix="EPL")
         out = plugin._build_epg_lookup()(game)
         assert [c.channel_id for c in out] == [4]
+
+
+class TestStreamNameLookup:
+    """Path C: streams whose NAME names both teams become stream-granular
+    candidates even when no channel (name or EPG) names the game. This is the
+    'matchup lives only in the stream name' failure mode."""
+
+    def test_stream_named_both_teams_becomes_candidate(self, plugin, monkeypatch):
+        # Generic channel, no EPG, but a stream names both teams.
+        chans = [_Row(id=9, name="USA Sports 24/7", epg_data_id=None)]
+        streams = [
+            _Row(id=500, name="USA Soccer10: FIFA World Cup : Iran vs New Zealand @ 9pm"),
+            _Row(id=501, name="Random Movie Stream"),  # noise
+        ]
+        _install_fake_orm(monkeypatch, chans, programs=[], streams=streams)
+        game = _game("Iran", "New Zealand", prefix="WC")
+        out = plugin._build_epg_lookup()(game)
+        # Only the both-team stream becomes a candidate, carrying its stream_id
+        # and a negative sentinel channel_id (never a real PK).
+        sc = [c for c in out if c.stream_id is not None]
+        assert [c.stream_id for c in sc] == [500]
+        assert sc[0].channel_id == -500
+        assert "Iran" in sc[0].channel_name and "New Zealand" in sc[0].channel_name
+
+    def test_stream_naming_one_team_does_not_match(self, plugin, monkeypatch):
+        streams = [_Row(id=600, name="Iran National Team 24/7")]  # only home
+        _install_fake_orm(monkeypatch, [], programs=[], streams=streams)
+        game = _game("Iran", "New Zealand", prefix="WC")
+        out = plugin._build_epg_lookup()(game)
+        assert [c for c in out if c.stream_id is not None] == []
+
+    def test_feed_prefix_does_not_fake_a_match(self, plugin, monkeypatch):
+        # Confirmed false positive: the feed label 'USA Soccer09' supplies a
+        # bogus 'USA' home hit for United States, while the away token (Australia,
+        # the real opponent) appears in a DIFFERENT matchup. The two tokens are
+        # in different ':'-segments, so the stream must NOT become a candidate.
+        streams = [_Row(id=800, name="USA Soccer09: Australia vs Turkey ( TSN5 ) @ 12am")]
+        _install_fake_orm(monkeypatch, [], programs=[], streams=streams)
+        game = _game("United States", "Australia", prefix="WC")
+        out = plugin._build_epg_lookup()(game)
+        assert [c for c in out if c.stream_id is not None] == []
+
+    def test_feed_prefix_with_real_matchup_still_matches(self, plugin, monkeypatch):
+        # The same feed-label shape is legitimate when the matchup names BOTH the
+        # game's teams in one segment: 'USA Soccer10: ... Iran vs New Zealand'.
+        streams = [_Row(id=801, name="USA Soccer10: FIFA World Cup : Iran vs New Zealand @ 9pm")]
+        _install_fake_orm(monkeypatch, [], programs=[], streams=streams)
+        game = _game("Iran", "New Zealand", prefix="WC")
+        out = plugin._build_epg_lookup()(game)
+        assert [c.stream_id for c in out if c.stream_id is not None] == [801]
+
+    def test_kickoff_time_colon_does_not_split_matchup(self, plugin, monkeypatch):
+        # 'FIFA World Cup 2026 18: Iran 02:00 New Zealand': the kickoff time
+        # '02:00' contains a colon, but it must NOT split the matchup segment
+        # (else both teams land in different segments and the feed is wrongly
+        # rejected). The label colon after '18' is the only real boundary.
+        streams = [_Row(id=802, name="FIFA World Cup 2026 18: Iran 02:00 New Zealand")]
+        _install_fake_orm(monkeypatch, [], programs=[], streams=streams)
+        game = _game("Iran", "New Zealand", prefix="WC")
+        out = plugin._build_epg_lookup()(game)
+        assert [c.stream_id for c in out if c.stream_id is not None] == [802]
+
+    def test_field_event_stream_single_sided(self, plugin, monkeypatch):
+        streams = [
+            _Row(id=700, name="PPV: UFC 250 Topuria vs Gaethje 4K"),
+            _Row(id=701, name="Premier League Arsenal v Chelsea"),  # noise
+        ]
+        _install_fake_orm(monkeypatch, [], programs=[], streams=streams)
+        game = _game("UFC 250: Topuria vs Gaethje", "Field",
+                     extra={"is_field_event": True})
+        out = plugin._build_epg_lookup()(game)
+        sc = [c for c in out if c.stream_id is not None]
+        assert [c.stream_id for c in sc] == [700]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -513,6 +513,98 @@ class TestWidenStreamPool:
         assert results[0].method == "fallback_first"
 
 
+def _scand(stream_id, name):
+    """A Path C stream-name candidate: channel_name == program_title == the
+    stream name, channel_id a negative sentinel, stream_id set."""
+    return ChannelCandidate(
+        channel_id=-stream_id,
+        channel_name=name,
+        program_title=name,
+        program_start=datetime(2026, 4, 27, tzinfo=timezone.utc),
+        program_end=datetime(2026, 4, 27, 4, tzinfo=timezone.utc),
+        stream_id=stream_id,
+    )
+
+
+class TestTier1Merge:
+    """Tier-1 (channel-name both-team) must MERGE the program-title both-team
+    matches behind it as fallback streams, not short-circuit and drop them.
+
+    Regression: once one dedicated-feed channel (channel name has both teams)
+    existed, the matcher returned ONLY that channel and silently dropped every
+    EPG-confirmed broadcaster (FOX/TSN/BBC whose programme title names the game)
+    whose stream pool used to back the matchup channel."""
+
+    def test_strict_merges_program_title_broadcasters(self):
+        cands = [
+            # dedicated feed: both teams in the CHANNEL NAME (Tier-1 strict)
+            _cand(10, "FIFA World Cup 2026 18: Penn State 02:00 Ohio State", "Live"),
+            # broadcaster: both teams only in the PROGRAMME TITLE (Tier-2)
+            _cand(20, "FOX Sports 1", "Penn State at Ohio State"),
+            _cand(21, "TSN 1", "Penn State vs Ohio State"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method == "regex_strict"
+        # Dedicated feed primary, broadcasters stacked behind it (no LLM).
+        assert results[0].channel_ids == [10, 20, 21]
+        assert results[0].stream_ids == []
+
+    def test_strict_alone_unchanged_when_no_program_title_matches(self):
+        # No broadcaster programme names both teams: behaviour is exactly the
+        # pre-merge shape (strict variants only).
+        cands = [
+            _cand(10, "EPL01: Penn State 20:00 Ohio State", "Live"),
+            _cand(11, "AU: Penn State v Ohio State", "Live"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].channel_ids == [10, 11]
+        assert results[0].stream_ids == []
+
+
+class TestStreamGranularRouting:
+    """Path C stream candidates (stream_id set) route to stream_ids, never to
+    channel_ids, so the apply attaches the specific stream and not the parent
+    channel's unrelated streams."""
+
+    def test_pure_stream_match_via_tier1(self):
+        # A stream naming both teams is a Tier-1 match (its channel_name IS the
+        # stream name); it must land in stream_ids with empty channel_ids.
+        cands = [_scand(500, "USA Soccer10: Penn State vs Ohio State 9pm")]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method == "regex_strict"
+        assert results[0].channel_ids == []
+        assert results[0].stream_ids == [500]
+
+    def test_channel_and_stream_match_split_correctly(self):
+        cands = [
+            _cand(10, "EPL01: Penn State v Ohio State", "Live"),       # whole channel
+            _scand(500, "USA Soccer10: Penn State vs Ohio State 9pm"),  # one stream
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].channel_ids == [10]
+        assert results[0].stream_ids == [500]
+
+    def test_stream_match_via_llm_routes_to_stream_ids(self, monkeypatch):
+        # Channel name lacks both teams, programme title (= stream name) has them;
+        # two such streams → LLM disambiguation. The LLM picks one by its
+        # (negative-sentinel) channel_id, and it lands in stream_ids.
+        cands = [
+            _scand(500, "USA Soccer10: Penn State vs Ohio State"),
+            _scand(501, "USA Soccer11: Penn State vs Ohio State"),
+        ]
+        games = [(_Game("Penn State", "Ohio State"), None, None)]
+        # NOTE: these are Tier-1 strict (channel_name = stream name has both
+        # teams), so they merge deterministically without the LLM. Assert that.
+        results = match_games_to_channels(games, lambda g: cands, api_key="", model="m")
+        assert results[0].method == "regex_strict"
+        assert results[0].channel_ids == []
+        assert sorted(results[0].stream_ids) == [500, 501]
+
+
 class TestSingleSidedRegexFilters:
     """#127: passing team_b=None matches on team_a (the event name) alone,
     dropping the both-teams requirement for field events."""

--- a/tests/test_stream_ids_contract.py
+++ b/tests/test_stream_ids_contract.py
@@ -1,0 +1,58 @@
+"""Producer/consumer contract for the `stream_ids` key (Path C stream-granular).
+
+`stream_ids` is a runtime string key crossing three layers:
+  - MatchResult.stream_ids (matcher produces it)
+  - the refresh cache payload writes "stream_ids" (serialised)
+  - _action_apply reads g.get("stream_ids") and attaches those streams
+
+Nothing else couples these by type, so a rename on one side would silently
+break stream attachment with every unit test still green. These static checks
+fail loudly if any layer drops the key. AST/source-level (not runtime) because
+the refresh + apply paths are deeply Django-coupled, matching the approach in
+test_apply_no_network_in_transaction.py.
+"""
+
+import ast
+import os
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PLUGIN_PY = os.path.join(REPO_ROOT, "plugin.py")
+MATCHER_PY = os.path.join(REPO_ROOT, "matcher.py")
+
+
+@pytest.fixture(scope="module")
+def plugin_src():
+    return open(PLUGIN_PY, encoding="utf-8").read()
+
+
+def _func(src, name):
+    tree = ast.parse(src, filename="plugin.py")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    pytest.fail(f"{name} not found in plugin.py")
+
+
+def test_matchresult_declares_stream_ids():
+    src = open(MATCHER_PY, encoding="utf-8").read()
+    assert "stream_ids" in src, "MatchResult must carry stream_ids"
+
+
+def test_refresh_writes_stream_ids_to_cache(plugin_src):
+    # Producer: the cache payload built in _action_refresh must serialise
+    # match.stream_ids under the "stream_ids" key.
+    fn = _func(plugin_src, "_action_refresh")
+    body = ast.get_source_segment(plugin_src, fn)
+    assert '"stream_ids"' in body, "_action_refresh must write the stream_ids key"
+    assert "match.stream_ids" in body, "cache must serialise match.stream_ids"
+
+
+def test_apply_reads_stream_ids(plugin_src):
+    # Consumer: _action_apply must read the stream_ids key back and attach those
+    # streams (Stream.objects.filter on the explicit ids).
+    fn = _func(plugin_src, "_action_apply")
+    body = ast.get_source_segment(plugin_src, fn)
+    assert 'get("stream_ids")' in body, "_action_apply must read g.get('stream_ids')"
+    assert "explicit_stream_ids" in body, "apply must attach the explicit streams"

--- a/tools/export_snapshot.py
+++ b/tools/export_snapshot.py
@@ -25,7 +25,7 @@ def main():
     import django
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dispatcharr.settings")
     django.setup()
-    from apps.channels.models import Channel
+    from apps.channels.models import Channel, Stream
     from apps.epg.models import ProgramData
 
     chans = [
@@ -40,8 +40,15 @@ def main():
          "epg_id": p.epg_id}
         for p in ProgramData.objects.all().only("id", "title", "start_time", "end_time", "epg_id")
     ]
-    json.dump({"channels": chans, "programs": progs}, open(out, "w"))
-    print(f"exported {len(chans)} channels, {len(progs)} programs -> {out}")
+    # Streams power Path C (stream-name matching). Only id + name are needed by
+    # the lookup; SELECT just those columns.
+    streams = [
+        {"id": s.id, "name": s.name}
+        for s in Stream.objects.all().only("id", "name")
+    ]
+    json.dump({"channels": chans, "programs": progs, "streams": streams}, open(out, "w"))
+    print(f"exported {len(chans)} channels, {len(progs)} programs, "
+          f"{len(streams)} streams -> {out}")
 
 
 if __name__ == "__main__":

--- a/tools/replay_match.py
+++ b/tools/replay_match.py
@@ -151,12 +151,17 @@ def load_snapshot(path):
     progs = [_Row(id=p["id"], title=p["title"] or "", epg_id=p["epg_id"],
                   start_time=_dt(p["start_time"]), end_time=_dt(p["end_time"]))
              for p in data["programs"]]
-    return chans, progs
+    # Streams power Path C (stream-name matching). Older snapshots predate the
+    # key; default to empty so they still replay (Path C just finds nothing).
+    streams = [_Row(id=s["id"], name=s["name"] or "")
+               for s in data.get("streams", [])]
+    return chans, progs, streams
 
 
-def install_orm(chans, progs):
+def install_orm(chans, progs, streams):
     chan_mod = types.ModuleType("apps.channels.models")
     chan_mod.Channel = SimpleNamespace(objects=FakeManager(chans))
+    chan_mod.Stream = SimpleNamespace(objects=FakeManager(streams))
     epg_mod = types.ModuleType("apps.epg.models")
     epg_mod.ProgramData = SimpleNamespace(objects=FakeManager(progs))
     dj = types.ModuleType("django.db.models")
@@ -215,10 +220,11 @@ def main():
     ap.add_argument("--start", default="2026-06-15T00:00:00Z")
     args = ap.parse_args()
 
-    chans, progs = load_snapshot(args.snapshot)
-    install_orm(chans, progs)
+    chans, progs, streams = load_snapshot(args.snapshot)
+    install_orm(chans, progs, streams)
     matcher, plugin = load_pkg()
-    print(f"snapshot: {len(chans)} channels, {len(progs)} programs\n")
+    print(f"snapshot: {len(chans)} channels, {len(progs)} programs, "
+          f"{len(streams)} streams\n")
 
     if args.cache:
         cache = json.load(open(args.cache))
@@ -230,7 +236,8 @@ def main():
         for g, r, was in zip(games, results, cached_match):
             tag = "OK " if bool(r.channel_id) == bool(was) else "DIFF"
             print(f"[{tag}] {g.sport_prefix} {g.home[:40]!r}")
-            print(f"       replay: {r.method} -> {r.channel_name!r} ({len(r.channel_ids)} streams)")
+            print(f"       replay: {r.method} -> {r.channel_name!r} "
+                  f"({len(r.channel_ids)} chans, {len(r.stream_ids)} streams)")
             print(f"       cache : {was!r}")
         return
 
@@ -250,7 +257,8 @@ def main():
         print(f"   [{c.channel_id}] {c.channel_name!r}")
     res = matcher.match_games_to_channels([(game, None, None)], plugin._build_epg_lookup(),
                                           api_key="", model="m")[0]
-    print(f"\nVERDICT: method={res.method} primary={res.channel_name!r} stacked={len(res.channel_ids)}")
+    print(f"\nVERDICT: method={res.method} primary={res.channel_name!r} "
+          f"channels={res.channel_ids} streams={res.stream_ids}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Two changes to channel/stream matching, prompted by a user whose dedicated per-match WC feeds weren't landing on the matchup channel.

### 1. Stream-name matching (Path C) — stream-granular
The matcher keyed only on **channel names** (Path B) and **EPG programme titles** (Path A), never on the **stream's own name**. Providers spin up dedicated per-match feeds whose matchup lives in the stream name (`USA Soccer10: ... Iran vs New Zealand`) on a generically-named channel with no EPG — invisible to both existing paths.

Path C matches a stream whose name names both teams (or the event, for field events) and attaches **only that stream**, not its parent channel's unrelated streams. `MatchResult` carries a new `stream_ids` alongside `channel_ids`, threaded through the cache and the apply.

**Feed-prefix guard:** both teams must co-occur in one `:`/`|`-delimited segment. Without it the network label `USA Soccer09` supplied a bogus `USA` hit for United States while the real opponent appeared in a *different* matchup (`Australia vs Turkey`), cross-matching games. Kickoff times (`Iran 02:00 New Zealand`) are not treated as boundaries.

### 2. Tier-1 broadcaster merge (fix)
When a channel name named both teams (Tier-1), the matcher returned only those channels and **discarded every EPG-confirmed broadcaster** (FOX/TSN/BBC) whose programme title named the game. Once a provider added one dedicated feed, the reliable broadcasters vanished from the channel. Tier-1 now **merges** the program-title both-team matches behind the channel-name matches as fallback streams. Both sets are both-teams-gated, so no LLM call.

## Verification

Offline replay harness (`tools/replay_match.py`) against a real read-only snapshot of the live instance — faithful replay of the production matcher code, zero container runtime:

- **Broadcasters restored:** the Iran/NZ game went from 11 dedicated-feed channels back to 30 (11 feeds + the 19 broadcasters the old code dropped).
- **Stream feeds fold in:** 8 previously-unmatched WC games (Switzerland, Argentina, France, England, ...) now match via Spanish-language Peacock stream feeds.
- **False positive caught + fixed:** the replay flagged `United States` cross-matching `USA Soccer09: Australia vs Turkey`; the segment guard fixes it, confirmed in a re-run.

Harness + snapshot exporter extended to carry streams. **3251 tests pass** (added matcher tier/partition/merge tests, Path C lookup + feed-prefix + kickoff-time tests, diagnose stream verdict, and a `stream_ids` producer→consumer contract test). Also fixed a pre-existing date-rot in the diagnose tests and a latent `_or_icontains` empty-kwargs landmine found in review.

Not yet deployed/prod-tested on the live container (that renumbers channels + needs a restart) — holding for the go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)