### PR TITLE
Favorites-only curation mode (off / strict / postseason)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.8.0"
+__version__ = "1.9.0"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",
@@ -87,14 +87,14 @@
       "type": "boolean",
       "label": "FIFA World Cup",
       "default": false,
-      "help_text": "Quadrennial international tournament. Pure knockout in V1 — group-stage importance not yet modeled (filed as follow-up). LAST_32 (new 48-team format) → R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
+      "help_text": "Quadrennial international tournament. Both phases are produced: every group-stage match plus the knockout bracket (LAST_32 in the new 48-team format → R16 → QF → SF → Final). The group stage alone is dozens of matches across all participating nations; to see only your country's games, list it in Favorites and set 'Favorites only' below (knockout rounds still score on stage). Requires Football-Data.org key."
     },
     {
       "id": "enable_euros",
       "type": "boolean",
       "label": "UEFA European Championship (EURO)",
       "default": false,
-      "help_text": "UEFA's quadrennial national-team tournament. Pure knockout in V1 — group-stage importance not yet modeled. R16 → QF → SF → Final → Champion. Requires Football-Data.org key."
+      "help_text": "UEFA's quadrennial national-team tournament. Both phases are produced: every group-stage match plus the knockout bracket (R16 → QF → SF → Final). The group stage alone is dozens of matches across all participating nations; to see only your country's games, list it in Favorites and set 'Favorites only' below (knockout rounds still score on stage). Requires Football-Data.org key."
     },
     {
       "id": "enable_intl_friendlies",
@@ -352,6 +352,27 @@
       "help_text": "Substring-matched against home/away team names (with team-qualifier whitelist for soccer suffixes like 'FC', 'AFC', 'City', 'United'). Always shown regardless of rank, with a flat score boost. Teams in playoff races still get the 'impact-on-favorite' signal automatically when they sit near a favorite's position."
     },
     {
+      "id": "favorites_only",
+      "type": "select",
+      "label": "Favorites only",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off (curate all enabled sports normally)"
+        },
+        {
+          "value": "strict",
+          "label": "Favorites only (just the teams above)"
+        },
+        {
+          "value": "postseason",
+          "label": "Favorites only, but show all postseason/playoff games"
+        }
+      ],
+      "help_text": "Restricts the curated guide to games involving a team in your Favorites list above. 'Favorites only' shows ONLY your teams across every enabled sport, so an event like the World Cup shows just your country's matches instead of all 48. 'Favorites only, but show all postseason/playoff games' adds back the big championship games (NFL playoffs, NCAA tournament, NHL/NBA/MLB playoffs, soccer knockout rounds) even when no favorite is playing, while regular-season games and World Cup / EURO group-stage games stay limited to your favorites. No effect unless you've listed at least one Favorite team (otherwise it would blank your guide). Independent of the Friendlies favorites gate above."
+    },
+    {
       "id": "curation_preset",
       "type": "select",
       "label": "Curation preset",
@@ -539,8 +560,14 @@
       "label": "Stream ordering",
       "default": "quality",
       "options": [
-        { "value": "quality", "label": "Quality (highest resolution/bitrate first)" },
-        { "value": "us_preferred", "label": "Prefer US broadcasts (quality first, US breaks ties)" }
+        {
+          "value": "quality",
+          "label": "Quality (highest resolution/bitrate first)"
+        },
+        {
+          "value": "us_preferred",
+          "label": "Prefer US broadcasts (quality first, US breaks ties)"
+        }
       ],
       "help_text": "How a virtual channel's stacked fallback streams are ordered. 'Quality' sorts by ffprobe resolution then bitrate, falling back to HD/FHD/UHD hints in the stream name when a stream was never probed (the historical behavior). 'Prefer US broadcasts' keeps that quality ordering but, among streams of EQUAL quality, puts the US English feed (ESPN/FOX/NBC/ABC/CBS/etc.) ahead of Canadian (TSN/Sportsnet) and overseas feeds. It never promotes a lower-quality US feed over a higher-quality non-US one. US is detected from the stream name; Spanish-language US feeds (ESPN Deportes, Telemundo) are not treated as the preferred US feed."
     },

--- a/plugin.py
+++ b/plugin.py
@@ -93,6 +93,28 @@ _STREAM_PRIORITY_SETTING = "stream_priority"
 _STREAM_PRIORITY_QUALITY = "quality"       # default: quality-only ordering
 _STREAM_PRIORITY_US = "us_preferred"       # quality first, US breaks ties
 
+# Favorites-only curation (Discord req: justinglock40 wanted USMNT-only World
+# Cup, not all 48 countries, while keeping the full NFL/NCAA list incl.
+# playoffs). A select, not two booleans, so the modes can't contradict each
+# other ("both on" is meaningless). The value strings are constants (not inline
+# literals) so the runtime read and plugin.json can't drift silently;
+# test_manifest_favorites_only_matches_code pins plugin.json to these.
+#   - off:        curate every enabled sport normally (historical behavior).
+#   - strict:     keep ONLY games involving a Favorites team, across all sports.
+#   - postseason: keep Favorites games AND any postseason/playoff game
+#                 regardless of favorite (NFL playoffs, NCAA tournament, soccer
+#                 knockout). Regular-season league play and WC/EURO GROUP_STAGE
+#                 are still favorites-gated, so the all-countries WC group
+#                 flood stays suppressed even in this mode.
+_FAVORITES_ONLY_SETTING = "favorites_only"
+_FAVORITES_ONLY_OFF = "off"                # default: no filtering
+_FAVORITES_ONLY_STRICT = "strict"          # favorite-involved games only
+_FAVORITES_ONLY_POSTSEASON = "postseason"  # favorites + any postseason game
+# The modes that actually filter (everything except OFF / unrecognized).
+_FAVORITES_ONLY_ACTIVE_MODES = frozenset({
+    _FAVORITES_ONLY_STRICT, _FAVORITES_ONLY_POSTSEASON,
+})
+
 CACHE_PATH = os.path.join(PLUGIN_DIR, "cache.json")
 # Sidecar cache for LLM-rewritten descriptions. Separate from cache.json so the
 # main cache file stays purely deterministic (score, breakdown, score_notes
@@ -720,6 +742,92 @@ def _resolve_max_games(settings: Dict[str, Any]) -> int:
     return int(settings.get("max_games", 25))
 
 
+# Stage strings that are NOT postseason. A game with any OTHER non-empty
+# `extra["stage"]` is treated as a knockout/playoff round. DO NOT invert this
+# into an allowlist of postseason stages: every bracket source defines its own
+# stage vocabulary (NFL WC/DIV/CONF/SB, NHL/NBA/MLB rounds + FINALS, NCAA
+# R64..NCG, BSB_REG/SB_REG regionals, soccer LAST_32..FINAL, golf MAJOR) and new
+# ones get added, so over-including an unknown stage as postseason is the safe
+# failure direction (mirrors the source layer's "better to over-emit a new
+# knockout stage than under-emit a known one" rule in sources/soccer.py).
+# Note BSB_REG / SB_REG are postseason Regionals despite the "_REG" suffix, so
+# this set is exact strings, never a substring/suffix match. GROUP_STAGE is
+# excluded on purpose: it keeps the World Cup / EURO group phase favorites-gated
+# even in 'postseason' mode (the original all-countries complaint). The group
+# LETTER lives in extra["group_stage"]="GROUP_A", not in extra["stage"].
+_NON_POSTSEASON_STAGES = frozenset({
+    "REGULAR_SEASON",  # FD.org soccer league play
+    "GROUP_STAGE",     # WC / EURO group phase
+    "ALLSTAR",         # exhibition (most sources reject it upstream anyway)
+    "EVENT",           # field-event regular tour stop (weekly golf/F1/NASCAR)
+})
+
+
+def _empty_refresh_result(msg: str, src_summary: List[str]) -> Dict[str, Any]:
+    """Log `msg`, persist an empty cache (so a stale prior cache doesn't keep
+    serving games that no longer pass the curator), and return the action's
+    ok-with-message payload. Shared by the no-games-fetched and
+    everything-filtered-out exits so the two can't drift."""
+    logger.info("[ranked_matchups] %s", msg)
+    _write_cache({
+        "games": [],
+        "refreshed_at": datetime.now(timezone.utc).isoformat(),
+        "summary": src_summary,
+    })
+    return {"status": "ok", "message": msg}
+
+
+def _is_postseason_game(game: Any) -> bool:
+    """True when this game is a postseason/playoff round (vs regular season,
+    group stage, or a weekly field event). Reads the source-set
+    `extra["stage"]`; see `_NON_POSTSEASON_STAGES` for the taxonomy."""
+    stage = (getattr(game, "extra", None) or {}).get("stage")
+    if not stage:
+        # No stage = regular-season league play (NFL/NBA/NHL/MLB only stamp a
+        # stage on playoff games; their parsers return None otherwise).
+        return False
+    return str(stage).strip().upper() not in _NON_POSTSEASON_STAGES
+
+
+def _filter_favorites_only(games, sources, favorites, mode):
+    """Apply the favorites-only curation gate, returning (games, sources,
+    dropped_count) filtered in lockstep so the parallel game/source association
+    survives. No-op (returns inputs unchanged, dropped=0) when the mode is off,
+    unrecognized, or no favorites are configured.
+
+    Favorite matching reuses scoring.match_favorites so the gate and the
+    favorite SCORING signal agree on what "involves a favorite" means (same
+    word-boundary + soccer-qualifier rules); a divergence would drop a game the
+    score still treats as a favorite. In 'postseason' mode a non-favorite game
+    is rescued iff `_is_postseason_game` is true."""
+    if mode not in _FAVORITES_ONLY_ACTIVE_MODES:
+        return games, sources, 0
+    if not favorites:
+        # Strict mode with no favorites would blank the entire guide; even
+        # postseason mode would silently drop all regular-season output. Both
+        # are surprising, so favorites-only is a no-op until the user lists at
+        # least one favorite. The caller logs a user-facing warning.
+        return games, sources, 0
+
+    from .scoring import match_favorites
+
+    kept_games, kept_sources, dropped = [], [], 0
+    for g, src in zip(games, sources):
+        keep = bool(match_favorites(g.home, g.away, favorites))
+        if (
+            not keep
+            and mode == _FAVORITES_ONLY_POSTSEASON
+            and _is_postseason_game(g)
+        ):
+            keep = True
+        if keep:
+            kept_games.append(g)
+            kept_sources.append(src)
+        else:
+            dropped += 1
+    return kept_games, kept_sources, dropped
+
+
 def _build_sources(settings: Dict[str, Any]):
     from .sources import (
         GroupStageSoccerSource, KnockoutSoccerSource, MlbPlayoffSource, MlbRegularSource,
@@ -1130,12 +1238,10 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
         logger.info("[ranked_matchups] %s: pulled %d games", src.sport_label, len(games))
 
     if not all_games:
-        msg = "No games found in lookahead window. " + " | ".join(src_summary)
-        logger.info("[ranked_matchups] %s", msg)
-        cache = {"games": [], "refreshed_at": datetime.now(timezone.utc).isoformat(),
-                 "summary": src_summary}
-        _write_cache(cache)
-        return {"status": "ok", "message": msg}
+        return _empty_refresh_result(
+            "No games found in lookahead window. " + " | ".join(src_summary),
+            src_summary,
+        )
 
     # 1a. Series dedup. Best-of-N playoff sources (NHL, NBA, MLB, NCAA
     # basketball/baseball) return EVERY scheduled game in a series, so a
@@ -1156,6 +1262,41 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
             "series-game rows (kept earliest per team-pair)",
             deduped_count,
         )
+
+    # 1b. Favorites-only gate (Discord req). Applied BEFORE scoring so the
+    # Monte Carlo importance simulation never runs on a game we're about to
+    # drop. Independent of and composable with the per-source
+    # friendlies_favorites_only gate (a friendly already gated to favorites
+    # simply survives this too). See `_filter_favorites_only`.
+    fav_only_mode = str(settings.get(_FAVORITES_ONLY_SETTING, _FAVORITES_ONLY_OFF)
+                        or _FAVORITES_ONLY_OFF).lower()
+    if fav_only_mode in _FAVORITES_ONLY_ACTIVE_MODES and not favorites:
+        logger.warning(
+            "[ranked_matchups] favorites_only=%s but no Favorites are "
+            "configured; gate is a no-op (would otherwise blank the guide)",
+            fav_only_mode,
+        )
+        src_summary.append("favorites-only: ignored (no favorites set)")
+    else:
+        all_games, game_sources, fav_dropped = _filter_favorites_only(
+            all_games, game_sources, favorites, fav_only_mode,
+        )
+        if fav_dropped:
+            postseason_note = (
+                " (postseason games kept)"
+                if fav_only_mode == _FAVORITES_ONLY_POSTSEASON else ""
+            )
+            logger.info(
+                "[ranked_matchups] favorites_only=%s: dropped %d non-favorite "
+                "game(s)%s", fav_only_mode, fav_dropped, postseason_note,
+            )
+            src_summary.append(f"favorites-only ({fav_only_mode}): dropped {fav_dropped}")
+        if not all_games:
+            return _empty_refresh_result(
+                "Favorites-only filter dropped every game in the lookahead "
+                "window. " + " | ".join(src_summary),
+                src_summary,
+            )
 
     # 2. Score. The Lahvička Monte Carlo importance signal covers three
     # related concerns structurally:
@@ -3530,7 +3671,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.8.0"
+    version = "1.9.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -8,6 +8,7 @@ __init__.py."""
 import importlib.util
 import os
 import sys
+import types
 from datetime import timezone
 
 import pytest
@@ -210,6 +211,158 @@ class TestBuildSourcesFriendliesGate:
         assert srcs[0].gender == "w"
         assert srcs[0].favorites_only is True
         assert srcs[0].favorites == ["United States"]
+
+
+class TestIsPostseasonGame:
+    """`_is_postseason_game` classifies a game from its source-set
+    `extra["stage"]`. The contract is an EXCLUSION set (non-postseason stages);
+    any other non-empty stage is postseason, so future bracket stages default
+    to postseason without code changes."""
+
+    def _game(self, stage):
+        extra = {} if stage is None else {"stage": stage}
+        return types.SimpleNamespace(home="A", away="B", extra=extra)
+
+    def test_regular_season_league_has_no_stage(self, plugin):
+        # NFL/NBA/NHL/MLB stamp a stage ONLY on playoff games; regular season
+        # has no stage key at all.
+        assert plugin._is_postseason_game(self._game(None)) is False
+        assert plugin._is_postseason_game(types.SimpleNamespace(extra=None)) is False
+
+    def test_explicit_non_postseason_stages(self, plugin):
+        for stage in ("REGULAR_SEASON", "GROUP_STAGE", "ALLSTAR", "EVENT"):
+            assert plugin._is_postseason_game(self._game(stage)) is False, stage
+
+    def test_world_cup_group_stage_is_not_postseason(self, plugin):
+        # The original complaint: WC group phase must stay favorites-gated even
+        # in postseason mode. The group LETTER lives in extra["group_stage"],
+        # so extra["stage"] is "GROUP_STAGE".
+        g = types.SimpleNamespace(
+            home="Brazil", away="Serbia",
+            extra={"stage": "GROUP_STAGE", "group_stage": "GROUP_A"},
+        )
+        assert plugin._is_postseason_game(g) is False
+
+    def test_team_sport_playoff_stages_are_postseason(self, plugin):
+        # A representative slice across every bracket source's vocabulary.
+        for stage in (
+            "WC", "DIV", "CONF", "SB",          # NFL playoffs
+            "FINALS", "CONF_FINAL", "CUP_FINAL",  # NBA / NHL
+            "LDS", "LCS",                        # MLB
+            "R64", "R32", "S16", "E8", "F4", "NCG",  # NCAA basketball
+            "LAST_32", "LAST_16", "QUARTER_FINALS", "SEMI_FINALS", "FINAL",  # soccer KO
+        ):
+            assert plugin._is_postseason_game(self._game(stage)) is True, stage
+
+    def test_ncaa_regionals_are_postseason_despite_reg_suffix(self, plugin):
+        # BSB_REG / SB_REG are NCAA Regionals (postseason), NOT regular season.
+        # A naive "_REG" suffix exclusion would wrongly drop these.
+        assert plugin._is_postseason_game(self._game("BSB_REG")) is True
+        assert plugin._is_postseason_game(self._game("SB_REG")) is True
+
+    def test_golf_major_is_postseason_event_is_not(self, plugin):
+        assert plugin._is_postseason_game(self._game("MAJOR")) is True
+        assert plugin._is_postseason_game(self._game("EVENT")) is False
+
+    def test_case_insensitive(self, plugin):
+        assert plugin._is_postseason_game(self._game("group_stage")) is False
+        assert plugin._is_postseason_game(self._game("final")) is True
+
+
+class TestFilterFavoritesOnly:
+    """`_filter_favorites_only` is the curation gate. It filters games and
+    their parallel source list in lockstep and returns a drop count."""
+
+    def _g(self, home, away, stage=None):
+        extra = {} if stage is None else {"stage": stage}
+        return types.SimpleNamespace(home=home, away=away, extra=extra)
+
+    def _run(self, plugin, games, favorites, mode):
+        # Sources are opaque to the filter; tag them so we can assert the
+        # parallel association survives.
+        sources = [f"src{i}" for i in range(len(games))]
+        kept_g, kept_s, dropped = plugin._filter_favorites_only(
+            games, sources, favorites, mode,
+        )
+        # Parallel association must hold: each kept source is the one that
+        # originally accompanied its kept game.
+        for g, s in zip(kept_g, kept_s):
+            assert s == f"src{games.index(g)}"
+        return kept_g, dropped
+
+    def test_off_is_noop(self, plugin):
+        games = [self._g("USA", "Wales"), self._g("Brazil", "Serbia")]
+        kept, dropped = self._run(plugin, games, ["United States"], "off")
+        assert dropped == 0 and kept == games
+
+    def test_unrecognized_mode_is_noop(self, plugin):
+        games = [self._g("Brazil", "Serbia")]
+        kept, dropped = self._run(plugin, games, ["United States"], "bogus")
+        assert dropped == 0 and kept == games
+
+    def test_empty_favorites_is_noop_even_when_mode_on(self, plugin):
+        # Strict with no favorites would blank the guide; the gate no-ops.
+        games = [self._g("Brazil", "Serbia")]
+        for mode in ("strict", "postseason"):
+            kept, dropped = self._run(plugin, games, [], mode)
+            assert dropped == 0 and kept == games, mode
+
+    def test_strict_keeps_only_favorite_games(self, plugin):
+        usa = self._g("United States", "Wales", stage="GROUP_STAGE")
+        bra = self._g("Brazil", "Serbia", stage="GROUP_STAGE")
+        final = self._g("France", "Argentina", stage="FINAL")  # KO, but no fav
+        kept, dropped = self._run(plugin, [usa, bra, final], ["United States"], "strict")
+        assert kept == [usa]
+        assert dropped == 2  # strict drops the non-favorite final too
+
+    def test_postseason_rescues_playoff_non_favorites(self, plugin):
+        usa_group = self._g("United States", "Wales", stage="GROUP_STAGE")
+        bra_group = self._g("Brazil", "Serbia", stage="GROUP_STAGE")   # dropped
+        wc_final = self._g("France", "Argentina", stage="FINAL")        # rescued
+        nfl_playoff = self._g("Bills", "Ravens", stage="DIV")          # rescued
+        nfl_regular = self._g("Jets", "Texans")                         # dropped
+        kept, dropped = self._run(
+            plugin,
+            [usa_group, bra_group, wc_final, nfl_playoff, nfl_regular],
+            ["United States"],
+            "postseason",
+        )
+        assert kept == [usa_group, wc_final, nfl_playoff]
+        assert dropped == 2  # bra_group (WC group) + nfl_regular
+
+
+class TestManifestFavoritesOnlyMatchesCode:
+    """plugin.json's favorites_only option values must equal the code
+    constants, mirroring test_manifest_stream_priority_matches_code."""
+
+    def test_options_match_constants(self, plugin):
+        import json
+        with open(os.path.join(REPO_ROOT, "plugin.json")) as f:
+            manifest = json.load(f)
+        field = next(x for x in manifest["fields"] if x["id"] == "favorites_only")
+        values = [o["value"] for o in field["options"]]
+        assert values == [
+            plugin._FAVORITES_ONLY_OFF,
+            plugin._FAVORITES_ONLY_STRICT,
+            plugin._FAVORITES_ONLY_POSTSEASON,
+        ]
+        assert field["default"] == plugin._FAVORITES_ONLY_OFF
+        assert field["id"] == plugin._FAVORITES_ONLY_SETTING
+
+
+class TestEmptyRefreshResult:
+    """Shared exit for the no-games-fetched and everything-filtered-out paths.
+    Must persist an EMPTY cache (so a stale prior cache stops serving dropped
+    games) and return the action's ok-with-message payload."""
+
+    def test_returns_ok_and_persists_empty_cache(self, plugin, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(plugin, "_write_cache", lambda c: captured.update(c))
+        out = plugin._empty_refresh_result("nothing here", ["NFL: 0 games"])
+        assert out == {"status": "ok", "message": "nothing here"}
+        assert captured["games"] == []
+        assert captured["summary"] == ["NFL: 0 games"]
+        assert "refreshed_at" in captured
 
 
 class TestBuildMarkerKey:


### PR DESCRIPTION
## What & why

Discord request (justinglock40): enabling the **World Cup** added all 48 countries' matches; he wanted **only USMNT** games, while keeping the full NFL / NCAA list including playoffs. He asked for a "favorites only" toggle, plus a variant that still shows championship-season games (NCAA tournament, NFL playoffs).

## Design

A single **`favorites_only` select** (not two booleans — they could contradict each other; the plugin's other multi-mode settings are selects too) with three modes:

| Mode | Behavior |
|---|---|
| `off` (default) | Unchanged — curate every enabled sport |
| `strict` | Keep only games involving a Favorites team, across all sports → USMNT-only World Cup |
| `postseason` | Favorites everywhere **plus** any playoff/knockout game regardless of favorite (NFL playoffs, NCAA tournament, NHL/NBA/MLB playoffs, soccer knockout) |

The subtlety that matches the actual complaint: **World Cup / EURO group-stage games stay favorites-gated even in `postseason` mode** (only knockout rounds come back), and regular-season league play stays gated too. So the all-48-countries group flood never returns; the leagues' full programmed list (incl. playoffs) is what `off` already gives.

## How it's grounded

- Reuses the existing `friendlies_favorites_only` pattern and `scoring.match_favorites`, so the gate and the favorite *scoring* signal agree on "involves a favorite."
- Postseason detection keys off the source-set `extra["stage"]` via an **exclusion set** (`REGULAR_SEASON`, `GROUP_STAGE`, `ALLSTAR`, `EVENT`) — verified against what every source emits. `BSB_REG`/`SB_REG` are postseason Regionals and stay included despite the `_REG` suffix; unknown future stages default to postseason (safe direction).
- Filter runs before scoring, so dropped games skip the Monte Carlo importance cost.
- No-ops with a warning when no Favorites are set (would otherwise blank the guide).
- Also fixed stale `enable_world_cup`/`enable_euros` help text that still claimed "Pure knockout in V1" while `GroupStageSoccerSource` emits every group match (the literal cause of the complaint), and pointed it at the new setting.

## Tests

Full suite **3275 passed**. New: postseason predicate across every bracket vocabulary + the non-postseason set, filter off/strict/postseason/empty-favorites + parallel game↔source association, `_empty_refresh_result` shared-exit contract, and a manifest↔code value-string sync test.

## Live verification (prod codepath, real instance)

Deployed to the running container (v1.9.0), driven through the HTTP run action → daemon thread → subprocess → cache. Real refreshes against a live config with `favorites = [..., United States, ...]` during World Cup:

- **Baseline (`off`)**: 25 games, only 1 favorite-involved (Turkey vs United States); rest were non-favorite WC group games + NCAA baseball postseason — i.e. the complaint reproduced.
- **`strict`**: pulled 36 (WC 33 + F1 1 + UFC 1 + NCAA Baseball Postseason 1) → `dropped 35 non-favorite game(s)` → cache = **1 game** (Turkey vs United States).
- **`postseason`**: `dropped 34 non-favorite game(s) (postseason games kept)` → cache = **2 games** (Turkey vs United States + North Carolina vs Oklahoma [NCAA Baseball Postseason]). The 32 non-USA WC **group-stage** games dropped; the championship game returned. Exactly the intended distinction.
- Restored `favorites_only` to off; cache rebuilt to the full 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)