### PR TITLE
Preserve DVR recordings when matchups reaps the game channel (#146)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -520,6 +520,13 @@
       "help_text": "Apply creates virtual channels in this ChannelGroup, cloning streams from the matched source channels (source channels untouched). A matching dummy EPGSource is created with the same name; each virtual channel gets a ProgramData entry whose description explains WHY the game made the cut. Tip: prefix with '!' (e.g. '!Top Matchups') so it sorts to the top of your group list. If you rename the group, the next apply will detect the old group/source by tvg_id markers and clean them up automatically."
     },
     {
+      "id": "recordings_group_name",
+      "type": "string",
+      "label": "Recordings group name",
+      "default": "Matchups Recordings",
+      "help_text": "Channel group that keeps your DVR recordings after a game's virtual channel is removed. When the plugin reaps a past game it would otherwise CASCADE-delete any recording made on that channel; instead the recording is re-homed into this group so it stays in the DVR tab. The group is created only when there is a recording to keep and removed again once empty. Must differ from the Target group name above (if they match, preservation is disabled and channels with recordings are kept instead of reaped)."
+    },
+    {
       "id": "virtual_channel_base",
       "type": "number",
       "label": "Starting channel number (0 = auto)",

--- a/plugin.py
+++ b/plugin.py
@@ -202,6 +202,134 @@ def _owned_tvg_id_q(field_prefix: str = ""):
         | Q(**{f"{field_prefix}tvg_id__in": _OWNED_TVG_ID_LEGACY_MARKERS})
     )
 
+
+# ---------- DVR recording preservation (#146) ----------
+#
+# A completed DVR recording is FK'd to the matchups game channel it was made on
+# (apps/channels/models.py: Recording.channel, on_delete=CASCADE). Every apply
+# reaps stale (past-game) virtual channels, so without intervention deleting the
+# game channel CASCADE-deletes the recording row, orphaning the .mkv on disk and
+# making it vanish from the DVR tab. To preserve recordings we re-home them onto
+# a persistent archive channel (in a separate, user-named group) BEFORE reaping
+# the game channel, and never reap a channel whose recording is still active.
+
+# Default name for the archive group; overridable via the recordings_group_name
+# setting. The group is created lazily (only when a recording needs preserving)
+# and removed again once it holds no recordings.
+DEFAULT_RECORDINGS_GROUP = "Matchups Recordings"
+
+# Stable tvg_id for the single archive channel. Lives under TVG_ID_PREFIX so it
+# reads as "ours" and is therefore excluded from the matcher (it must never be
+# matched to a game) and from the highest-real-channel scan. It is NOT a game
+# marker, so it is never in seen_markers and is scoped out of existing_virtuals
+# (which is filtered to the live target_group, not the recordings group).
+ARCHIVE_TVG_ID = TVG_ID_PREFIX + "recordings_archive"
+
+# The in-progress value Dispatcharr writes to Recording.custom_properties["status"]
+# while a recording is capturing (apps/channels/tasks.py sets it to "recording"
+# at start and "completed"/"stopped" at end). We only ever need to recognize the
+# in-progress state, to avoid reaping a channel mid-recording. Named here so the
+# external contract is documented in one place rather than as a bare literal.
+_DVR_STATUS_RECORDING = "recording"
+
+
+def _recording_is_active(rec, now) -> bool:
+    """True when a recording must NOT be stranded by reaping its channel: it is
+    in progress, or scheduled/running with an end_time still in the future.
+
+    Pure: `rec` only needs `.custom_properties` (dict or None) and `.end_time`
+    (aware datetime or None). Kept ORM-free so it is unit-testable without a
+    Django DB (mirrors the offline-policy pattern used elsewhere in this plugin).
+    """
+    cp = getattr(rec, "custom_properties", None) or {}
+    if cp.get("status") == _DVR_STATUS_RECORDING:
+        return True
+    end = getattr(rec, "end_time", None)
+    return end is not None and end > now
+
+
+def _partition_stale_for_recordings(stale, recs_by_channel, now, archive_enabled):
+    """Decide, for stale (past-game) channels, which are safe to reap and which
+    recordings to re-home first. Pure policy, no ORM.
+
+    stale: iterable of channel-likes with `.id`.
+    recs_by_channel: {channel_id: [recording-likes]} (see _recording_is_active).
+    now: aware datetime.
+    archive_enabled: whether re-homing is available (False when the archive
+        group name clashes with the live group, so recordings cannot be moved).
+
+    Returns (reapable, kept, rehome_rec_ids):
+      reapable        channels safe to delete (no recordings, or all done and
+                      re-homable).
+      kept            channels to leave in place this cycle (active recording,
+                      or recordings present but archive disabled so reaping
+                      would destroy them). Reconciles next cycle.
+      rehome_rec_ids  recording ids on reapable channels to move to the archive.
+    """
+    reapable, kept, rehome_rec_ids = [], [], []
+    for ch in stale:
+        recs = recs_by_channel.get(ch.id, [])
+        if not recs:
+            reapable.append(ch)
+            continue
+        if any(_recording_is_active(r, now) for r in recs):
+            kept.append(ch)
+            continue
+        if not archive_enabled:
+            # No place to preserve them: keep the channel rather than CASCADE
+            # the recordings away.
+            kept.append(ch)
+            continue
+        rehome_rec_ids.extend(r.id for r in recs)
+        reapable.append(ch)
+    return reapable, kept, rehome_rec_ids
+
+
+def _ensure_archive_channel(recordings_group_name):
+    """Get-or-create the persistent recordings group and its single archive
+    channel. The archive channel is stream-less (a recording container only),
+    has no channel_number (stays out of the highest-real-channel scan), and is
+    keyed by ARCHIVE_TVG_ID so it is found again on the next apply."""
+    from apps.channels.models import Channel, ChannelGroup
+    grp, _ = ChannelGroup.objects.get_or_create(name=recordings_group_name)
+    arch = Channel.objects.filter(
+        channel_group=grp, tvg_id=ARCHIVE_TVG_ID,
+    ).first()
+    if arch is None:
+        arch = Channel.objects.create(
+            name=recordings_group_name,
+            channel_group=grp,
+            tvg_id=ARCHIVE_TVG_ID,
+            channel_number=None,
+            auto_created=False,
+        )
+        logger.info(
+            "[ranked_matchups] created recordings archive channel id=%s in group %r",
+            arch.id, recordings_group_name,
+        )
+    return arch
+
+
+def _cleanup_empty_archive(recordings_group_name) -> bool:
+    """Remove the archive channel (and then the group) once no recordings remain
+    under it, so the group exists only while it holds recordings. Returns True if
+    anything was removed. Safe: the archive channel is deleted only when it has
+    zero Recording rows, so the CASCADE takes nothing with it."""
+    from apps.channels.models import Channel, ChannelGroup, Recording
+    grp = ChannelGroup.objects.filter(name=recordings_group_name).first()
+    if grp is None:
+        return False
+    removed = False
+    arch = Channel.objects.filter(channel_group=grp, tvg_id=ARCHIVE_TVG_ID).first()
+    if arch is not None and not Recording.objects.filter(channel_id=arch.id).exists():
+        arch.delete()
+        removed = True
+    if Channel.objects.filter(channel_group=grp).count() == 0:
+        grp.delete()
+        removed = True
+    return removed
+
+
 # Default starting channel number when the user hasn't configured one. Sentinel
 # 0 means "auto": pick the first channel number after the highest existing
 # non-virtual channel, so we slot in cleanly without colliding with real
@@ -2218,7 +2346,7 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     Source channels are never touched. Stale virtual channels (game no longer
     in cache) are deleted along with their EPG entries.
     """
-    from apps.channels.models import Channel, ChannelGroup, ChannelStream, Stream
+    from apps.channels.models import Channel, ChannelGroup, ChannelStream, Recording, Stream
     from apps.epg.models import EPGSource, EPGData, ProgramData
     from django.db import transaction
 
@@ -2230,6 +2358,23 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         return {"status": "ok", "message": "Cache empty; run refresh first."}
 
     group_name = settings.get("channel_profile_name", "Top Matchups")
+    # Archive group for preserved DVR recordings (#146). Blank falls back to the
+    # default. It MUST differ from the live group: if they collide the archive
+    # channel would land in the reaped group and defeat the feature, so we
+    # disable preservation (and keep recordings safe by not reaping channels
+    # that have them) until the user sets a distinct name.
+    recordings_group_name = (
+        str(settings.get("recordings_group_name", "") or "").strip()
+        or DEFAULT_RECORDINGS_GROUP
+    )
+    archive_enabled = recordings_group_name.lower() != str(group_name).strip().lower()
+    if not archive_enabled:
+        logger.warning(
+            "[ranked_matchups] recordings_group_name (%r) matches the live group; "
+            "recording preservation disabled until a distinct name is set. "
+            "Channels with recordings will be kept rather than reaped.",
+            recordings_group_name,
+        )
     dry_run = bool(settings.get("dry_run", True))
     # #111: when the widen pool is on, order each channel's pooled streams
     # English+quality first, then non-English. Same toggle as the matcher-side
@@ -2265,13 +2410,18 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     # Find any other groups containing channels we own. Helper covers both the
     # current TVG_ID_PREFIX scheme and any legacy markers from earlier plugin
     # versions (a prefix-only check would miss leftovers on rename).
+    # Exclude the recordings archive group/source (#146) from the rename-cleanup
+    # sweep: the archive channel is intentionally "ours" (so the matcher skips
+    # it), which would otherwise make this sweep migrate it into the live group
+    # and delete the archive group out from under preserved recordings.
+    _protected_group_names = [group_name, recordings_group_name]
     foreign_owned_groups = list(
-        ChannelGroup.objects.exclude(name=group_name)
+        ChannelGroup.objects.exclude(name__in=_protected_group_names)
         .filter(_owned_tvg_id_q("channels__"))
         .distinct()
     )
     foreign_epg_sources = list(
-        EPGSource.objects.exclude(name=group_name)
+        EPGSource.objects.exclude(name__in=_protected_group_names)
         .filter(_owned_tvg_id_q("epgs__"))
         .distinct()
     )
@@ -2411,6 +2561,8 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
     updated = 0
     deleted_stale = 0
     skipped_unmatched = 0
+    rehomed_recordings = 0      # #146: recordings moved to the archive this run
+    kept_for_recording_n = 0    # #146: stale channels kept (active recording)
     seen_markers = set()
 
     placeholder_threshold = float(settings.get("placeholder_min_score", 5.0))
@@ -2719,6 +2871,12 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
         # range so we can renumber based on cache order without colliding with
         # the unique (channel_group, channel_number) constraint. park_base is
         # guaranteed to be past every target number we're about to write.
+        # Capture pre-park numbers so a channel we end up KEEPING (active
+        # recording, #146) can be restored to its real number instead of being
+        # stranded at a ~park_base value: only "seen" games get renumbered in
+        # the loop below, so without this a kept stale channel would sit at the
+        # parking number until the next cycle reaps it.
+        prepark_numbers = {ch.id: ch.channel_number for ch in existing_virtuals.values()}
         if not dry_run and existing_virtuals:
             parked = list(existing_virtuals.values())
             for i, ch in enumerate(parked):
@@ -2889,18 +3047,62 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                     tvg_id=marker,
                 )
 
-        # 5. Delete stale virtual channels (not seen this refresh)
+        # 5. Reap stale virtual channels (not seen this refresh), preserving any
+        # DVR recordings first (#146). Recording.channel is on_delete=CASCADE, so
+        # a bare Channel.delete() would take the user's recordings with it. We
+        # re-home completed recordings onto a persistent archive channel and skip
+        # reaping any channel whose recording is still active (it reconciles next
+        # cycle once the recording finishes).
         stale = [ch for marker, ch in existing_virtuals.items() if marker not in seen_markers]
-        if stale:
-            if not dry_run:
-                stale_ids = [c.id for c in stale]
-                stale_markers = [c.tvg_id for c in stale]
-                ChannelStream.objects.filter(channel_id__in=stale_ids).delete()
-                Channel.objects.filter(id__in=stale_ids).delete()
+        if stale and not dry_run:
+            now_reap = datetime.now(timezone.utc)
+            stale_ids_all = [c.id for c in stale]
+            recs_by_channel: Dict[int, list] = {}
+            for r in Recording.objects.filter(channel_id__in=stale_ids_all):
+                recs_by_channel.setdefault(r.channel_id, []).append(r)
+            reapable, kept_for_recording, rehome_rec_ids = _partition_stale_for_recordings(
+                stale, recs_by_channel, now_reap, archive_enabled,
+            )
+            if rehome_rec_ids:
+                archive_ch = _ensure_archive_channel(recordings_group_name)
+                # .update() on the Recording queryset: re-point the FK without
+                # invoking per-row save hooks. Recording carries no destructive
+                # post_save signal (unlike Channel.epg_data), so this is a plain
+                # bulk re-home.
+                rehomed_recordings = Recording.objects.filter(
+                    id__in=rehome_rec_ids,
+                ).update(channel_id=archive_ch.id)
+                logger.info(
+                    "[ranked_matchups] re-homed %d recording(s) to archive %r before reaping",
+                    rehomed_recordings, recordings_group_name,
+                )
+            reap_ids = [c.id for c in reapable]
+            reap_markers = [c.tvg_id for c in reapable]
+            if reap_ids:
+                ChannelStream.objects.filter(channel_id__in=reap_ids).delete()
+                Channel.objects.filter(id__in=reap_ids).delete()
                 if epg_source is not None:
                     EPGData.objects.filter(
-                        epg_source=epg_source, tvg_id__in=stale_markers,
+                        epg_source=epg_source, tvg_id__in=reap_markers,
                     ).delete()
+            # Restore kept channels (active recording) to their pre-park number
+            # so they don't linger at a ~park_base value. Only restore numbers
+            # not claimed by a current game this run (assigned set), so the
+            # unique (channel_group, channel_number) constraint can't be hit;
+            # any (rare) collision leaves that channel parked, still safe.
+            if kept_for_recording:
+                assigned_now = set(chnum_by_marker.values())
+                restore = []
+                for ch in kept_for_recording:
+                    orig = prepark_numbers.get(ch.id)
+                    if orig is not None and orig not in assigned_now:
+                        ch.channel_number = orig
+                        restore.append(ch)
+                if restore:
+                    Channel.objects.bulk_update(restore, ["channel_number"])
+            deleted_stale = len(reap_ids)
+            kept_for_recording_n = len(kept_for_recording)
+        elif stale and dry_run:
             deleted_stale = len(stale)
 
         # 6. Defensive: clean up orphan EPGData entries on our source whose
@@ -2917,6 +3119,12 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
                 _owned_tvg_id_q(), epg_source=epg_source,
             ).exclude(tvg_id__in=kept_markers)
             orphan_epg_deleted, _ = orphans.delete()
+
+        # 7. Archive hygiene (#146): the recordings group/channel exists only
+        # while it holds recordings. Drop the archive channel and its group once
+        # empty (e.g. after the user deletes the last preserved recording).
+        if not dry_run and archive_enabled:
+            _cleanup_empty_archive(recordings_group_name)
 
     # Persist the LLM-description cache (prune entries whose marker is no
     # longer in this refresh; keep file bounded to live games). Save outside
@@ -2959,12 +3167,18 @@ def _action_apply(settings: Dict[str, Any]) -> Dict[str, Any]:
             f"{matchup_logos_fallback} fell back to source-channel logo, "
             f"{stale_logo_files_swept} stale file(s) swept."
         )
+    rec_msg = ""
+    if rehomed_recordings or kept_for_recording_n:
+        rec_msg = (
+            f" Recordings: {rehomed_recordings} re-homed to {recordings_group_name!r}, "
+            f"{kept_for_recording_n} channel(s) kept (active recording)."
+        )
     msg = (
         f"{prefix}Group {group_name!r}: created={created}, updated={updated} "
         f"(placeholders={placeholder_channels_created} included), "
         f"stale_deleted={deleted_stale}, "
         f"orphan_epg_deleted={orphan_epg_deleted if 'orphan_epg_deleted' in locals() else 0}, "
-        f"unmatched_skipped={skipped_unmatched}.{rename_msg}{llm_msg}{logo_msg} "
+        f"unmatched_skipped={skipped_unmatched}.{rename_msg}{rec_msg}{llm_msg}{logo_msg} "
         f"WHY descriptions written to EPG source."
     )
     return {"status": "ok", "message": msg}

--- a/tests/test_recording_preservation.py
+++ b/tests/test_recording_preservation.py
@@ -1,0 +1,217 @@
+"""Tests for the DVR-recording preservation policy (#146).
+
+`Recording.channel` is `on_delete=CASCADE`, so reaping a stale matchups game
+channel would CASCADE-delete any recording made on it. `_action_apply` avoids
+that by re-homing completed recordings onto a persistent archive channel and by
+NOT reaping a channel whose recording is still active. The decision is isolated
+in two pure (ORM-free) helpers so it can be tested without a Django DB, mirroring
+`test_plugin_helpers.py`. The ORM wiring (`_ensure_archive_channel`,
+`_cleanup_empty_archive`, and the apply integration) is exercised live against
+the running container in the PR's live-verification section.
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+PLUGIN_PY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "plugin.py"))
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PKG_NAME = os.path.basename(REPO_ROOT)
+
+
+def _load_plugin_module():
+    """Load plugin.py without exec-ing the package __init__ (which would start
+    the scheduler thread and import Django). plugin.py does its Django imports
+    lazily inside functions, so a top-level load is safe."""
+    if f"{PKG_NAME}.plugin" in sys.modules:
+        return sys.modules[f"{PKG_NAME}.plugin"]
+    util_spec = importlib.util.spec_from_file_location(
+        f"{PKG_NAME}._util", os.path.join(REPO_ROOT, "_util.py")
+    )
+    util_mod = importlib.util.module_from_spec(util_spec)
+    sys.modules[f"{PKG_NAME}._util"] = util_mod
+    util_spec.loader.exec_module(util_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PKG_NAME}.plugin", os.path.join(REPO_ROOT, "plugin.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{PKG_NAME}.plugin"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def plugin():
+    return _load_plugin_module()
+
+
+NOW = datetime(2026, 6, 28, 18, 0, tzinfo=timezone.utc)
+
+
+def _rec(rec_id, status=None, end_offset_hours=None):
+    """A recording-like with the only two attrs the policy reads."""
+    end = None if end_offset_hours is None else NOW + timedelta(hours=end_offset_hours)
+    cp = {"status": status} if status is not None else {}
+    return SimpleNamespace(id=rec_id, custom_properties=cp, end_time=end)
+
+
+def _chan(chan_id):
+    return SimpleNamespace(id=chan_id)
+
+
+class TestRecordingIsActive:
+    def test_in_progress_is_active(self, plugin):
+        # status=recording means active regardless of end_time.
+        assert plugin._recording_is_active(_rec(1, status="recording", end_offset_hours=-2), NOW)
+        assert plugin._recording_is_active(_rec(1, status="recording", end_offset_hours=None), NOW)
+
+    def test_completed_in_past_is_inactive(self, plugin):
+        assert not plugin._recording_is_active(_rec(1, status="completed", end_offset_hours=-1), NOW)
+
+    def test_stopped_in_past_is_inactive(self, plugin):
+        assert not plugin._recording_is_active(_rec(1, status="stopped", end_offset_hours=-3), NOW)
+
+    def test_scheduled_future_is_active(self, plugin):
+        # No status yet (scheduled, not started) but end_time still ahead.
+        assert plugin._recording_is_active(_rec(1, status=None, end_offset_hours=+2), NOW)
+
+    def test_no_status_no_end_is_inactive(self, plugin):
+        assert not plugin._recording_is_active(_rec(1, status=None, end_offset_hours=None), NOW)
+
+    def test_none_custom_properties_is_handled(self, plugin):
+        r = SimpleNamespace(id=1, custom_properties=None, end_time=NOW - timedelta(hours=1))
+        assert not plugin._recording_is_active(r, NOW)
+
+
+class TestPartitionStaleForRecordings:
+    def test_channel_without_recordings_is_reapable(self, plugin):
+        ch = _chan(10)
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], {}, NOW, archive_enabled=True
+        )
+        assert reapable == [ch]
+        assert kept == []
+        assert rehome == []
+
+    def test_completed_recording_rehomed_then_reapable(self, plugin):
+        ch = _chan(10)
+        recs = {10: [_rec(100, status="completed", end_offset_hours=-1)]}
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], recs, NOW, archive_enabled=True
+        )
+        assert reapable == [ch]
+        assert kept == []
+        assert rehome == [100]
+
+    def test_active_recording_keeps_channel(self, plugin):
+        ch = _chan(10)
+        recs = {10: [_rec(100, status="recording", end_offset_hours=+1)]}
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], recs, NOW, archive_enabled=True
+        )
+        assert reapable == []
+        assert kept == [ch]
+        assert rehome == []
+
+    def test_mixed_active_and_done_keeps_channel_and_rehomes_nothing(self, plugin):
+        # An active recording on the channel pins the whole channel; we do not
+        # re-home its siblings mid-cycle (they reconcile once everything is done).
+        ch = _chan(10)
+        recs = {10: [
+            _rec(100, status="completed", end_offset_hours=-2),
+            _rec(101, status="recording", end_offset_hours=+1),
+        ]}
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], recs, NOW, archive_enabled=True
+        )
+        assert reapable == []
+        assert kept == [ch]
+        assert rehome == []
+
+    def test_archive_disabled_keeps_channel_with_recordings(self, plugin):
+        # With no archive to move them to, a channel with recordings must be
+        # kept rather than reaped (reaping would CASCADE the recordings away).
+        ch = _chan(10)
+        recs = {10: [_rec(100, status="completed", end_offset_hours=-1)]}
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], recs, NOW, archive_enabled=False
+        )
+        assert reapable == []
+        assert kept == [ch]
+        assert rehome == []
+
+    def test_archive_disabled_still_reaps_channels_without_recordings(self, plugin):
+        ch = _chan(10)
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [ch], {}, NOW, archive_enabled=False
+        )
+        assert reapable == [ch]
+        assert kept == []
+        assert rehome == []
+
+    def test_multiple_channels_partition_independently(self, plugin):
+        empty = _chan(1)                      # reap, nothing to move
+        done = _chan(2)                       # reap, re-home its recordings
+        active = _chan(3)                      # keep
+        recs = {
+            2: [_rec(200, status="completed", end_offset_hours=-1),
+                _rec(201, status="stopped", end_offset_hours=-2)],
+            3: [_rec(300, status="recording", end_offset_hours=+1)],
+        }
+        reapable, kept, rehome = plugin._partition_stale_for_recordings(
+            [empty, done, active], recs, NOW, archive_enabled=True
+        )
+        assert reapable == [empty, done]
+        assert kept == [active]
+        assert sorted(rehome) == [200, 201]
+
+
+class TestApplyPreservationWiring:
+    """Static contract that `_action_apply` actually wires the preservation
+    policy in: the unit tests above prove the pure helpers, but a future
+    refactor could drop the call site and leave the bare CASCADE delete back in
+    while every unit test stays green. This guards the integration the way
+    test_apply_no_network_in_transaction.py guards call ordering."""
+
+    @staticmethod
+    def _apply_source():
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        lines = open(PLUGIN_PY, encoding="utf-8").read().splitlines()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_action_apply":
+                return "\n".join(lines[node.lineno - 1: node.end_lineno])
+        raise AssertionError("_action_apply not found")
+
+    def test_apply_invokes_preservation_helpers(self):
+        src = self._apply_source()
+        assert "_partition_stale_for_recordings(" in src
+        assert "_ensure_archive_channel(" in src
+        assert "_cleanup_empty_archive(" in src
+
+    def test_preservation_precedes_channel_delete(self):
+        # Recordings must be partitioned/re-homed BEFORE the stale channels are
+        # deleted, or the CASCADE takes them first. Assert ordering by source
+        # position within the reap block.
+        src = self._apply_source()
+        i_partition = src.index("_partition_stale_for_recordings(")
+        i_delete = src.index("Channel.objects.filter(id__in=reap_ids).delete()")
+        assert i_partition < i_delete, "partition/re-home must run before the reap delete"
+
+    def test_no_unguarded_stale_delete(self):
+        # The pre-fix code deleted every stale channel directly via
+        # `Channel.objects.filter(id__in=stale_ids).delete()`. That exact path
+        # must be gone: channel deletes now key off `reap_ids` (post-partition).
+        # (Matching the full Channel-delete pattern, not a bare `stale_ids`
+        # substring, so the legitimate Recording query on `stale_ids_all` that
+        # gathers recordings across all stale channels doesn't false-trip this.)
+        src = self._apply_source()
+        assert "Channel.objects.filter(id__in=stale_ids)" not in src, (
+            "unguarded all-stale channel delete must not return"
+        )


### PR DESCRIPTION
## Problem

`Recording.channel` is `on_delete=CASCADE` (`apps/channels/models.py`). The apply step reaps stale (past-game) virtual channels every cycle, so deleting a game channel CASCADE-deleted any DVR recording made on it: the `.mkv` was orphaned on disk and vanished from the DVR tab. Hit live: a 7.7 GB Norway/France recording lost its DB row when its channel was reaped (the file was on disk with no record).

## Change

Apply preserves recordings before reaping (all in the existing reconcile transaction):

- **Never reap mid-recording.** A channel with an active recording (status `recording`, or `end_time` still in the future) is kept this cycle and reconciles next cycle once the recording finishes.
- **Re-home completed recordings** onto a persistent archive channel in a separate, user-named group, via a queryset `.update()` (no destructive save hooks on `Recording`). Then the game channel is reaped as before.
- **Configurable group name** (`recordings_group_name`, default `Matchups Recordings`). Created lazily only when a recording needs preserving, and removed again once it holds no recordings, so the group exists only while it has recordings.
- **Safe on name collision.** If the archive name matches the live group, preservation is disabled and channels with recordings are kept (never destroyed) until a distinct name is set.
- **Kept channels keep their real number** instead of lingering at a parking value (regression I caught in review).

Policy is isolated in pure helpers (`_recording_is_active`, `_partition_stale_for_recordings`); the archive group/channel get-or-create and empty-cleanup are small ORM helpers.

## Tests

- 13 unit tests on the pure policy (empty / done / active / mixed / archive-disabled / multi-channel).
- 3 static contract tests guarding the apply wiring (helpers invoked, re-home precedes the delete, the old unguarded all-stale delete cannot return).
- Full suite: **3291 passed**.

## Live verification (real Dispatcharr container, isolated `ZZ146` namespace, rolled back, zero residue)

```
[live146] BUG check  -> recording survives bare channel delete? False (expect False)
[live146] partition  -> reapable [212971] kept [] rehome [21]
[live146] archive    -> channel 212972 group ZZ146_recordings_test tvg ranked_matchups:recordings_archive chnum None
[live146] re-home    -> moved 1 | recording survived reap? True (expect True)
[live146] re-home    -> recording now on archive channel? True (expect True)
[live146] re-home    -> game channel gone? True (expect True)
[live146] cleanup    -> removed? True | archive channel gone? True | archive group gone? True
[live146] residue check -> channels: 0 groups: 0 (expect 0 0)
```

Separately verified: while a recording remains, `_cleanup_empty_archive` retains the archive (removed=False).

## Follow-up (not in this PR)

The underlying CASCADE is a Dispatcharr-core sharp edge; `Recording.channel` should arguably be `on_delete=SET_NULL` upstream so a completed recording never dies with any channel. That's a core migration to file against Dispatcharr, complementary to this plugin-side fix.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
