### PR TITLE
Fix: archive channel null number truncates entire Xtream Codes feed

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -225,6 +225,22 @@ DEFAULT_RECORDINGS_GROUP = "Matchups Recordings"
 # (which is filtered to the live target_group, not the recordings group).
 ARCHIVE_TVG_ID = TVG_ID_PREFIX + "recordings_archive"
 
+# Starting channel number for the single archive channel. It MUST be non-None:
+# Dispatcharr's Xtream Codes EPG/stream-list generator (apps/output/epg.py) does
+# an unconditional channel_num_map[channel.id] for XC clients, and that map only
+# contains channels whose effective_channel_number is not None. A null-numbered
+# channel therefore raises KeyError mid-stream and TRUNCATES the entire XC feed
+# (every televizo/XC client sees "no playlist"/"update failed"), not just this one
+# channel. DO NOT set the archive channel's number back to None.
+#
+# The exact value is arbitrary: _ensure_archive_channel takes the first free
+# number at/above this within the recordings group (via _first_free_number), so it
+# never trips the unique (channel_group, channel_number) constraint even if the
+# user points recordings_group_name at an already-populated group. Staying out of
+# the highest-real-channel scan is handled by the ranked_matchups: tvg_id prefix
+# via _owned_tvg_id_q (see _resolve_virtual_base), NOT by the number.
+_ARCHIVE_CHANNEL_NUMBER = 9999
+
 # The in-progress value Dispatcharr writes to Recording.custom_properties["status"]
 # while a recording is capturing (apps/channels/tasks.py sets it to "recording"
 # at start and "completed"/"stopped" at end). We only ever need to recognize the
@@ -285,27 +301,65 @@ def _partition_stale_for_recordings(stale, recs_by_channel, now, archive_enabled
     return reapable, kept, rehome_rec_ids
 
 
+def _first_free_number(used, start: int) -> int:
+    """Smallest integer >= ``start`` that is not in ``used`` (any collection of
+    numbers). Pure and ORM-free so it is unit-testable without a Django DB
+    (mirrors the offline-policy pattern used elsewhere in this plugin). Shared by
+    _assign_channel_numbers (resolving same-minute game collisions) and
+    _ensure_archive_channel (placing the archive channel collision-free)."""
+    num = int(start)
+    while num in used:
+        num += 1
+    return num
+
+
 def _ensure_archive_channel(recordings_group_name):
     """Get-or-create the persistent recordings group and its single archive
     channel. The archive channel is stream-less (a recording container only),
-    has no channel_number (stays out of the highest-real-channel scan), and is
-    keyed by ARCHIVE_TVG_ID so it is found again on the next apply."""
+    carries a non-null channel_number (a null number truncates the whole Xtream
+    Codes feed, see _ARCHIVE_CHANNEL_NUMBER), and is keyed by ARCHIVE_TVG_ID so it
+    is found again on the next apply. Scan-exclusion comes from the owned tvg_id,
+    not the number."""
     from apps.channels.models import Channel, ChannelGroup
     grp, _ = ChannelGroup.objects.get_or_create(name=recordings_group_name)
     arch = Channel.objects.filter(
         channel_group=grp, tvg_id=ARCHIVE_TVG_ID,
     ).first()
+    if arch is not None and arch.channel_number is not None:
+        return arch
+
+    # Either a fresh create, or a self-heal of an install whose archive channel
+    # was created before _ARCHIVE_CHANNEL_NUMBER existed (null number, silently
+    # breaking the XC feed). Take the first free number at/above the constant
+    # within the group so the unique (channel_group, channel_number) constraint
+    # can't fire even if recordings_group_name points at a populated group.
+    used = set(
+        Channel.objects.filter(channel_group=grp)
+        .exclude(tvg_id=ARCHIVE_TVG_ID)
+        .exclude(channel_number__isnull=True)
+        .values_list("channel_number", flat=True)
+    )
+    number = _first_free_number(used, _ARCHIVE_CHANNEL_NUMBER)
+
     if arch is None:
         arch = Channel.objects.create(
             name=recordings_group_name,
             channel_group=grp,
             tvg_id=ARCHIVE_TVG_ID,
-            channel_number=None,
+            channel_number=number,
             auto_created=False,
         )
         logger.info(
-            "[ranked_matchups] created recordings archive channel id=%s in group %r",
-            arch.id, recordings_group_name,
+            "[ranked_matchups] created recordings archive channel id=%s number=%s in group %r",
+            arch.id, number, recordings_group_name,
+        )
+    else:
+        # update() bypasses the post_save signal chain (the epg_data-wipe trap).
+        Channel.objects.filter(pk=arch.pk).update(channel_number=number)
+        arch.channel_number = number
+        logger.info(
+            "[ranked_matchups] backfilled archive channel id=%s number=%s (was None)",
+            arch.id, number,
         )
     return arch
 
@@ -1919,11 +1973,10 @@ def _assign_channel_numbers(
     used: set = set()
     collisions = 0
     for marker, number in pairs:
-        while number in used:
-            number += 1
-            collisions += 1
-        used.add(number)
-        assigned[marker] = number
+        free = _first_free_number(used, number)
+        collisions += free - number  # == number of +1 nudges taken
+        used.add(free)
+        assigned[marker] = free
     if collisions:
         logger.warning(
             "[ranked_matchups] resolved %d channel-number collision(s) by +1 nudge; "

--- a/tests/test_recording_preservation.py
+++ b/tests/test_recording_preservation.py
@@ -215,3 +215,79 @@ class TestApplyPreservationWiring:
         assert "Channel.objects.filter(id__in=stale_ids)" not in src, (
             "unguarded all-stale channel delete must not return"
         )
+
+
+class TestArchiveChannelHasNumber:
+    """The archive channel MUST carry a non-null channel_number. A null number
+    makes Dispatcharr's XC EPG/stream-list generator raise KeyError mid-stream
+    (channel_num_map[channel.id]) and truncate the entire feed, so every Xtream
+    client sees an empty/failed playlist. This guards against regressing the
+    archive channel back to channel_number=None."""
+
+    @staticmethod
+    def _archive_source():
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        lines = open(PLUGIN_PY, encoding="utf-8").read().splitlines()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_ensure_archive_channel":
+                return "\n".join(lines[node.lineno - 1: node.end_lineno])
+        raise AssertionError("_ensure_archive_channel not found")
+
+    def test_create_assigns_a_number_not_none(self):
+        src = self._archive_source()
+        assert "channel_number=number" in src, (
+            "archive channel must be created with the resolved non-null number"
+        )
+        assert "channel_number=None" not in src, (
+            "archive channel must never be created with a null channel_number"
+        )
+        assert "_first_free_number(" in src and "_ARCHIVE_CHANNEL_NUMBER" in src, (
+            "number must come from _first_free_number seeded by _ARCHIVE_CHANNEL_NUMBER"
+        )
+
+    def test_constant_is_a_positive_int(self):
+        # Read the literal via AST without importing the Django-dependent module.
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        value = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "_ARCHIVE_CHANNEL_NUMBER"
+                for t in node.targets
+            ):
+                value = ast.literal_eval(node.value)
+        assert isinstance(value, int) and value > 0, (
+            "_ARCHIVE_CHANNEL_NUMBER must be a positive int so the XC map is populated"
+        )
+
+    def test_self_heals_existing_null_archive(self):
+        src = self._archive_source()
+        # Existing installs already have a null-numbered archive channel; the
+        # function must repair it (via a signal-bypassing update), not only fix
+        # fresh creates.
+        assert "arch.channel_number is not None" in src, (
+            "must detect and pass through an already-numbered archive channel"
+        )
+        assert ".update(channel_number=number)" in src, (
+            "must backfill a pre-existing null-numbered archive channel via update()"
+        )
+
+
+class TestFirstFreeNumber:
+    """The shared collision-resolver used by both _assign_channel_numbers and
+    _ensure_archive_channel. Pure, so tested directly."""
+
+    def test_returns_start_when_free(self, plugin):
+        assert plugin._first_free_number(set(), 9999) == 9999
+        assert plugin._first_free_number({1, 2, 3}, 9999) == 9999
+
+    def test_bumps_past_a_run_of_taken_numbers(self, plugin):
+        assert plugin._first_free_number({9999}, 9999) == 10000
+        assert plugin._first_free_number({9999, 10000, 10001}, 9999) == 10002
+
+    def test_matches_float_used_values(self, plugin):
+        # Channel.channel_number is a float column, so the DB hands back floats;
+        # an int seed must still detect the clash (9999 == 9999.0).
+        assert plugin._first_free_number({9999.0}, 9999) == 10000
+
+    def test_returns_int(self, plugin):
+        assert isinstance(plugin._first_free_number({9999.0}, 9999), int)


### PR DESCRIPTION
## Problem

The DVR recordings archive channel (#146, \"Matchups Recordings\") was created with \`channel_number=None\`. Dispatcharr's Xtream Codes EPG/stream-list generator (\`apps/output/epg.py\`) does an **unconditional** \`channel_num_map[channel.id]\` for XC clients, and that map only contains channels with a non-null number. The null-numbered archive channel raised \`KeyError\` mid-stream and **truncated the whole feed** — every Xtream client (televizo, etc.) got \"no playlist available\" / \"update failed\", and the EPG was cut off before any \`<programme>\` data (~1 MB instead of ~14 MB).

The null number was believed to keep the channel out of the highest-real-channel scan, but that exclusion actually comes from the \`ranked_matchups:\` tvg_id prefix via \`_owned_tvg_id_q\` (independent of the number). The null bought nothing and silently broke XC.

## Fix

- Add \`_ARCHIVE_CHANNEL_NUMBER\` and assign the archive channel the first free number at/above it within its group — collision-safe even if \`recordings_group_name\` points at a populated group.
- **Self-heal** existing installs whose archive channel already has a null number (signal-bypassing queryset \`.update()\`).
- Extract the shared \`_first_free_number\` collision-resolver and reuse it in \`_assign_channel_numbers\` (was a duplicated while-bump loop).
- Tests: pure coverage for \`_first_free_number\` + static guards that the archive channel is never created/left null.

## Live verification (running 0.27.1 container, via tv.jacoblasky.com)

| Endpoint | Before | After |
|---|---|---|
| \`get_live_streams\` | invalid/truncated JSON | **valid JSON, 6204 entries** |
| \`xmltv\` | ~1 MB, no \`</tv>\` | **~14 MB, closes \`</tv>\`** |
| KeyError in logs | repeating \`KeyError: 213247\` | **zero** |

Full suite: **3298 passed**. Deployed to the live container and the live archive channel reconciled to the code-predicted number.

> Note: the underlying defect is also a Dispatcharr core bug — the XC branch in \`epg.py\` should fall back like the non-XC branch instead of \`KeyError\`-ing on any null-numbered channel. Worth a separate upstream issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)