### PR TITLE
Boxing source + World Cup knockout premium + archive-channel fix (sync main to prod)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-10
+
+### Added
+- **Boxing source** (`enable_boxing`). Professional boxing cards surface as
+  one field-event entry per card (same shape as UFC), sourced from the Boxing
+  Data API (RapidAPI) via a new `boxing_data_api_key` setting. ESPN has no
+  boxing feed, so boxing requires this key; enabled-but-unkeyed is a logged
+  no-op. Cards default to "Event" tier; explicit world-title cards get "Major".
+  Cancelled cards are dropped. The free tier looks ahead about 7 days, so the
+  boxing lookahead is clamped to 7. Boxing gets a widened EPG match window
+  because the feed's start times are unreliable (date-only placeholders + naive
+  datetimes); name specificity, not the clock, drives matching. Covers boxing
+  only: UFC/MMA remains the separate `enable_ufc` toggle, and kickboxing /
+  bare-knuckle have no free feed.
+
 ## [1.10.0] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ the **Test naming convention** action to preview a template before applying it.
 | MLS (regular + Cup playoffs) | [site.api.espn.com](https://site.api.espn.com/) for schedule + [The Odds API](https://the-odds-api.com/) (`soccer_usa_mls`) for closeness | Yes (Odds API free tier; ESPN no key) |
 | NCAA Baseball (D1 regular season) | [site.api.espn.com](https://site.api.espn.com/) (unofficial) + D1Baseball.com poll | Yes (no key required) |
 | NCAA Soccer — Men's + Women's (D1 regular season) | [site.api.espn.com](https://site.api.espn.com/) (unofficial) + United Soccer Coaches Top 25 | Yes (no key required) |
+| Field events — Formula 1 / NASCAR / PGA Golf / ATP + WTA Tennis / UFC | [site.api.espn.com](https://site.api.espn.com/) (unofficial) | Yes (no key required) |
+| Boxing | [Boxing Data API](https://rapidapi.com/bengroves1993/api/boxing-data-api) (RapidAPI — ESPN has no boxing feed) | Yes (free RapidAPI tier; ~7-day lookahead) |
 | Spreads (any sport above) | [The Odds API](https://the-odds-api.com/) | Yes (500 req/mo) |
 
 Adding a sport is a new file in `sources/` implementing the `SportSource`
@@ -144,6 +146,7 @@ form will collect everything needed to scope it.
      echo "<CFBD key>"          > /data/plugins/dispatcharr_ranked_matchups/cfbd_api_key
      echo "<Football-Data key>" > /data/plugins/dispatcharr_ranked_matchups/football_data_api_key
      echo "<Odds API key>"      > /data/plugins/dispatcharr_ranked_matchups/odds_api_key
+     echo "<Boxing Data key>"   > /data/plugins/dispatcharr_ranked_matchups/boxing_data_api_key
      echo "<Anthropic key>"     > /data/plugins/dispatcharr_ranked_matchups/anthropic_api_key
      chmod 600 /data/plugins/dispatcharr_ranked_matchups/*_api_key
    '

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/_util.py
+++ b/_util.py
@@ -193,6 +193,34 @@ def is_field_event(away: Optional[str], extra: Optional[Dict[str, Any]] = None) 
     return away == FIELD_AWAY_SENTINEL
 
 
+def field_event_extra(
+    fd_competition_code: str,
+    stage: str,
+    short_name: str,
+    **extra: Any,
+) -> Dict[str, Any]:
+    """Build the `GameRow.extra` dict shared by EVERY field-event source
+    (racing, golf, tennis, UFC, boxing). Single source of truth for the
+    field-event contract so the consumers (scoring's tournament_stage band via
+    extra["stage"], is_field_event() routing via extra["is_field_event"],
+    league-context lookup via extra["fd_competition_code"]) read the same keys
+    regardless of which source produced the row. DO NOT hand-build this dict in
+    a source and DO NOT let the key set drift; source-specific metadata goes in
+    **extra (e.g. espn_event_id, boxing_event_id, venue). See is_field_event()
+    above and sources/field_event.py.
+
+    `stage` is "MAJOR" (marquee: golf majors, tennis Slams, UFC PPVs, world-
+    title boxing) or "EVENT" (regular tour stop / fight night).
+    """
+    return {
+        "is_field_event": True,
+        "fd_competition_code": fd_competition_code,
+        "stage": stage,
+        "short_name": short_name,
+        **extra,
+    }
+
+
 # ---------- playoff-series rendering ----------
 #
 # The sport-agnostic `extra["series"]` schema that best-of-N sources populate

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",
@@ -216,6 +216,13 @@
       "help_text": "Each UFC fight card surfaces as one entry in the guide (the card title carries the headliner, e.g., 'UFC 309: Jones vs. Miocic'). Numbered PPVs get a higher tier ('Major') than Fight Nights and ESPN cards ('Event'). No API key required — ESPN unofficial."
     },
     {
+      "id": "enable_boxing",
+      "type": "boolean",
+      "label": "Boxing",
+      "default": false,
+      "help_text": "Each professional boxing card surfaces as one 'Event'-tier entry (the card title carries the headliner, e.g., 'Gassiev vs. Kadiru: IBA Pro 19'); explicit world-title cards get 'Major'. REQUIRES the Boxing Data API key below — ESPN has no boxing feed. Free tier looks ahead about 7 days. Note: covers boxing only; UFC/MMA is the separate 'UFC' toggle, and kickboxing/bare-knuckle have no free feed."
+    },
+    {
       "id": "enable_atp",
       "type": "boolean",
       "label": "ATP Tour (men's tennis)",
@@ -292,6 +299,14 @@
       "label": "Football-Data.org API key",
       "default": "",
       "help_text": "Register: https://www.football-data.org/client/register (free, 10 req/min). Free tier covers EPL, EFL Championship, UCL, Bundesliga, La Liga, Serie A, Ligue 1, and 5 more competitions."
+    },
+    {
+      "id": "boxing_data_api_key",
+      "type": "string",
+      "input_type": "password",
+      "label": "Boxing Data API key (RapidAPI)",
+      "default": "",
+      "help_text": "Register: https://rapidapi.com/bengroves1993/api/boxing-data-api (free tier, no credit card). Powers the 'Boxing' source. Free tier looks ahead about 7 days per refresh."
     },
     {
       "id": "odds_api_key",

--- a/plugin.py
+++ b/plugin.py
@@ -225,6 +225,22 @@ DEFAULT_RECORDINGS_GROUP = "Matchups Recordings"
 # (which is filtered to the live target_group, not the recordings group).
 ARCHIVE_TVG_ID = TVG_ID_PREFIX + "recordings_archive"
 
+# Starting channel number for the single archive channel. It MUST be non-None:
+# Dispatcharr's Xtream Codes EPG/stream-list generator (apps/output/epg.py) does
+# an unconditional channel_num_map[channel.id] for XC clients, and that map only
+# contains channels whose effective_channel_number is not None. A null-numbered
+# channel therefore raises KeyError mid-stream and TRUNCATES the entire XC feed
+# (every televizo/XC client sees "no playlist"/"update failed"), not just this one
+# channel. DO NOT set the archive channel's number back to None.
+#
+# The exact value is arbitrary: _ensure_archive_channel takes the first free
+# number at/above this within the recordings group (via _first_free_number), so it
+# never trips the unique (channel_group, channel_number) constraint even if the
+# user points recordings_group_name at an already-populated group. Staying out of
+# the highest-real-channel scan is handled by the ranked_matchups: tvg_id prefix
+# via _owned_tvg_id_q (see _resolve_virtual_base), NOT by the number.
+_ARCHIVE_CHANNEL_NUMBER = 9999
+
 # The in-progress value Dispatcharr writes to Recording.custom_properties["status"]
 # while a recording is capturing (apps/channels/tasks.py sets it to "recording"
 # at start and "completed"/"stopped" at end). We only ever need to recognize the
@@ -285,27 +301,65 @@ def _partition_stale_for_recordings(stale, recs_by_channel, now, archive_enabled
     return reapable, kept, rehome_rec_ids
 
 
+def _first_free_number(used, start: int) -> int:
+    """Smallest integer >= ``start`` that is not in ``used`` (any collection of
+    numbers). Pure and ORM-free so it is unit-testable without a Django DB
+    (mirrors the offline-policy pattern used elsewhere in this plugin). Shared by
+    _assign_channel_numbers (resolving same-minute game collisions) and
+    _ensure_archive_channel (placing the archive channel collision-free)."""
+    num = int(start)
+    while num in used:
+        num += 1
+    return num
+
+
 def _ensure_archive_channel(recordings_group_name):
     """Get-or-create the persistent recordings group and its single archive
     channel. The archive channel is stream-less (a recording container only),
-    has no channel_number (stays out of the highest-real-channel scan), and is
-    keyed by ARCHIVE_TVG_ID so it is found again on the next apply."""
+    carries a non-null channel_number (a null number truncates the whole Xtream
+    Codes feed, see _ARCHIVE_CHANNEL_NUMBER), and is keyed by ARCHIVE_TVG_ID so it
+    is found again on the next apply. Scan-exclusion comes from the owned tvg_id,
+    not the number."""
     from apps.channels.models import Channel, ChannelGroup
     grp, _ = ChannelGroup.objects.get_or_create(name=recordings_group_name)
     arch = Channel.objects.filter(
         channel_group=grp, tvg_id=ARCHIVE_TVG_ID,
     ).first()
+    if arch is not None and arch.channel_number is not None:
+        return arch
+
+    # Either a fresh create, or a self-heal of an install whose archive channel
+    # was created before _ARCHIVE_CHANNEL_NUMBER existed (null number, silently
+    # breaking the XC feed). Take the first free number at/above the constant
+    # within the group so the unique (channel_group, channel_number) constraint
+    # can't fire even if recordings_group_name points at a populated group.
+    used = set(
+        Channel.objects.filter(channel_group=grp)
+        .exclude(tvg_id=ARCHIVE_TVG_ID)
+        .exclude(channel_number__isnull=True)
+        .values_list("channel_number", flat=True)
+    )
+    number = _first_free_number(used, _ARCHIVE_CHANNEL_NUMBER)
+
     if arch is None:
         arch = Channel.objects.create(
             name=recordings_group_name,
             channel_group=grp,
             tvg_id=ARCHIVE_TVG_ID,
-            channel_number=None,
+            channel_number=number,
             auto_created=False,
         )
         logger.info(
-            "[ranked_matchups] created recordings archive channel id=%s in group %r",
-            arch.id, recordings_group_name,
+            "[ranked_matchups] created recordings archive channel id=%s number=%s in group %r",
+            arch.id, number, recordings_group_name,
+        )
+    else:
+        # update() bypasses the post_save signal chain (the epg_data-wipe trap).
+        Channel.objects.filter(pk=arch.pk).update(channel_number=number)
+        arch.channel_number = number
+        logger.info(
+            "[ranked_matchups] backfilled archive channel id=%s number=%s (was None)",
+            arch.id, number,
         )
     return arch
 
@@ -1919,11 +1973,10 @@ def _assign_channel_numbers(
     used: set = set()
     collisions = 0
     for marker, number in pairs:
-        while number in used:
-            number += 1
-            collisions += 1
-        used.add(number)
-        assigned[marker] = number
+        free = _first_free_number(used, number)
+        collisions += free - number  # == number of +1 nudges taken
+        used.add(free)
+        assigned[marker] = free
     if collisions:
         logger.warning(
             "[ranked_matchups] resolved %d channel-number collision(s) by +1 nudge; "

--- a/plugin.py
+++ b/plugin.py
@@ -1491,7 +1491,7 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
     #     outcomes out of contention.
     from .scoring import (
         match_favorites, LEAGUE_CONTEXTS, build_impact_narratives,
-        compute_match_importance,
+        compute_match_importance, wc_knockout_importance,
     )
     n_importance_sims = int(settings.get("n_importance_sims", 500))
     scored: List[Tuple[Any, GameSignals, Any]] = []
@@ -1557,6 +1557,19 @@ def _action_refresh(settings: Dict[str, Any]) -> Dict[str, Any]:
                     "[ranked_matchups] importance failed for %s vs %s: %s",
                     g.home, g.away, e,
                 )
+
+        # World Cup knockout premium. A knockout tie is win-or-go-home, but the
+        # Monte Carlo above scores it 0 (binary outcome, no standings leverage to
+        # simulate), so a marquee Round-of-32 game would otherwise rank at the
+        # bottom and fall under placeholder_min_score. Override with a round-
+        # scaled importance premium; the gate (WC competition + knockout stage)
+        # lives in the pure, unit-tested wc_knockout_importance so WC group games
+        # keep their simulated importance and no other competition is affected.
+        _ko_premium = wc_knockout_importance(comp_code, extra.get("stage"))
+        if _ko_premium is not None:
+            importance_pts = _ko_premium
+            importance_notes = ["World Cup knockout: win or go home"]
+            importance_thresholds_hit = []
 
         # Rivalry detection: source-set is_rivalry takes precedence (no adapter
         # currently does this, but the door is open); otherwise we consult the

--- a/plugin.py
+++ b/plugin.py
@@ -20,6 +20,7 @@ Files:
   - cfbd_api_key:         CFBD/CBB-Data bearer token (chmod 600)
   - football_data_api_key: Football-Data.org token (chmod 600)
   - odds_api_key:         The Odds API token (chmod 600)
+  - boxing_data_api_key:  Boxing Data API / RapidAPI key (chmod 600)
   - anthropic_api_key:    Claude key (chmod 600), needed for LLM EPG
                           matching, the optional narrative signal, OR the
                           optional LLM-rewritten EPG descriptions.
@@ -129,6 +130,7 @@ CFBD_KEY_PATH = os.path.join(PLUGIN_DIR, "cfbd_api_key")
 FD_KEY_PATH = os.path.join(PLUGIN_DIR, "football_data_api_key")
 ODDS_KEY_PATH = os.path.join(PLUGIN_DIR, "odds_api_key")
 ANTHROPIC_KEY_PATH = os.path.join(PLUGIN_DIR, "anthropic_api_key")
+BOXING_KEY_PATH = os.path.join(PLUGIN_DIR, "boxing_data_api_key")
 SPORTSDB_KEY_PATH = os.path.join(PLUGIN_DIR, "sportsdb_api_key")
 # Free public test tier. Patreon keys unlock higher rate limits per
 # https://www.thesportsdb.com/api.php.
@@ -161,6 +163,16 @@ _SOCCER_PREFIXES = frozenset({
 })
 _MATCH_WINDOW_OVERRIDE_PRE_MIN: Dict[str, int] = {p: 5 for p in _SOCCER_PREFIXES}
 _MATCH_WINDOW_OVERRIDE_POST_HOURS: Dict[str, float] = {p: 2.5 for p in _SOCCER_PREFIXES}
+
+# Boxing (BOX) gets a WIDE window, the opposite of soccer's tight one. The
+# Boxing Data API's start times are unreliable: some cards are date-only and
+# come back as T00:00:00, and the feed's datetimes are naive (no offset, so
+# parse_iso_utc assumes UTC), which can place a card up to a day off the actual
+# broadcast slot. A boxing card is a rare, name-unique field event, so the
+# event-name keyword filter (not the clock) is the real discriminator; a wide
+# +/- ~1 day window absorbs the time error without inviting false positives.
+_MATCH_WINDOW_OVERRIDE_PRE_MIN["BOX"] = 12 * 60   # 12h before
+_MATCH_WINDOW_OVERRIDE_POST_HOURS["BOX"] = 24.0   # 24h after
 
 
 def _epg_match_window(sport_prefix: Optional[str]) -> Tuple[int, float]:
@@ -1025,6 +1037,7 @@ def _build_sources(settings: Dict[str, Any]):
         NhlPlayoffSource, NhlRegularSource, SoccerSource,
         F1Source, NascarSource, GolfSource, UfcSource,
         AtpSource, WtaSource,
+        BoxingSource,
         InternationalFriendliesSource,
     )
     from .sources.soccer import COMPETITIONS
@@ -1256,6 +1269,17 @@ def _build_sources(settings: Dict[str, Any]):
     # (numbered UFC events) get MAJOR tier, Fight Nights get EVENT.
     if settings.get("enable_ufc", False):
         sources.append(UfcSource())
+
+    # Boxing. Same field-event shape as UFC (one row per fight card), but a
+    # DIFFERENT upstream: ESPN has no boxing feed (verified 2026-07-10), so
+    # boxing pulls from the Boxing Data API (RapidAPI) and REQUIRES a key.
+    # Enabled-but-unkeyed is a no-op with a warning, matching the CFBD/FD gate.
+    if settings.get("enable_boxing", False):
+        boxing_key = _resolve_key(settings, "boxing_data_api_key", BOXING_KEY_PATH)
+        if boxing_key:
+            sources.append(BoxingSource(api_key=boxing_key))
+        else:
+            logger.warning("[boxing] enabled but no Boxing Data API key configured")
 
     # Tennis. ESPN's tennis scoreboard returns whole
     # tournaments (one entry per active event), not individual
@@ -3951,7 +3975,7 @@ class Plugin:
     # Single source of truth for the displayed version: the loader uses this
     # class attr over plugin.json's "version". Keep all three in sync
     # (this attr, plugin.json, __init__.py __version__).
-    version = "1.10.0"
+    version = "1.11.0"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/scoring.py
+++ b/scoring.py
@@ -267,6 +267,67 @@ _WC_KNOCKOUT_THRESHOLDS: List[Tuple[str, str, float]] = [
 ]
 
 
+# FIFA World Cup knockout importance premium (pre-weight importance_points),
+# keyed by the UPPER-cased tournament stage. A knockout game is win-or-go-home:
+# maximal stakes. But compute_match_importance returns 0 for it (there is no
+# standings distribution to Monte-Carlo: the outcome is binary), so without this
+# a marquee Round-of-32 tie (e.g. France vs Sweden) scored only its tournament-
+# stage band (raw 1.5 -> ~0.95/10) and ranked BELOW a random regular-season game
+# AND below placeholder_min_score, so it never even got a placeholder channel.
+#
+# DO NOT move this into the shared `stage_score` tournament ladder in score_game:
+# that ladder caps at a FINAL (5.0 x tournament weight 1.5 = 7.5 raw -> 4.37/10,
+# still under the 5.0 placeholder bar), inverting it (R32 > FINAL) would be
+# nonsensical, and its QF/SF/FINAL keys are shared with NHL/NBA so a bump there
+# would silently boost those sports too. The importance channel is the design's
+# top-priority signal (see the ScoringWeights docstring: "importance > rank >
+# favorites > tournament"), is uncapped, and is applied per-competition in
+# plugin.py's scoring loop scoped to fd_competition_code == "WC", so only the
+# World Cup is affected.
+#
+# Values chosen so that, at the default weight_importance (3.0) plus each stage's
+# tournament band, the displayed 0-10 score escalates R32~5.5 -> R16~6.5 ->
+# QF~7.6 -> SF~8.3 -> FINAL~9.2, all clearing placeholder_min_score's 5.0 default.
+# THIRD_PLACE has no tournament band, so its premium is set to still clear 5.0.
+# If weight_importance is retuned, these displayed targets shift proportionally,
+# which is the intended, coherent behavior of an importance weight.
+_WC_KNOCKOUT_IMPORTANCE: Dict[str, float] = {
+    "LAST_32":        2.8,
+    "LAST_16":        3.4,
+    "QUARTER_FINALS": 4.0,
+    "SEMI_FINALS":    4.6,
+    "FINAL":          6.0,
+    "THIRD_PLACE":    3.4,
+}
+
+# FD.org competition code for the FIFA World Cup. Matches the fd_code on the WC
+# SoccerCompetitionConfig and the LEAGUE_CONTEXTS key; named here so the scoring
+# gate below and any future WC-scoped logic compare against one symbol instead
+# of a bare "WC" literal scattered across modules.
+WC_COMPETITION_CODE = "WC"
+
+
+def wc_knockout_importance(
+    comp_code: Optional[str], stage: Optional[str]
+) -> Optional[float]:
+    """Importance-points premium for a FIFA World Cup knockout game, or None.
+
+    Pure gate for the WC knockout premium so plugin.py's `_action_refresh`
+    scoring loop stays a thin caller and this runtime string match (competition
+    code + stage label) is unit-testable in isolation — a silent drift in the
+    `fd_competition_code` value or the stage casing would otherwise regress WC
+    games back to their bare ~0.9 tournament-band score with no test to catch it.
+
+    Returns None for anything that is NOT a World Cup knockout game (a different
+    competition, or a WC group-stage game, whose importance is left to the Monte
+    Carlo simulation). See _WC_KNOCKOUT_IMPORTANCE for the why and the calibrated
+    displayed-score targets.
+    """
+    if comp_code != WC_COMPETITION_CODE:
+        return None
+    return _WC_KNOCKOUT_IMPORTANCE.get((stage or "").upper())
+
+
 LEAGUE_CONTEXTS: Dict[str, LeagueContext] = {
     "PL": LeagueContext(
         code="PL", matchdays_total=38,

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -10,6 +10,7 @@ from .field_event import (
     F1Source, NascarSource, GolfSource, UfcSource,
     AtpSource, WtaSource, FieldEventSource,
 )
+from .boxing import BoxingSource
 from .friendlies import InternationalFriendliesSource
 from .nba import NbaPlayoffSource, NbaRegularSource
 from .wnba import WnbaPlayoffSource, WnbaRegularSource
@@ -46,6 +47,7 @@ __all__ = [
     "NwslSource", "LigaMxSource",
     "FieldEventSource", "F1Source", "NascarSource", "GolfSource", "UfcSource",
     "AtpSource", "WtaSource",
+    "BoxingSource",
     "InternationalFriendliesSource",
     "NbaRegularSource", "NbaPlayoffSource",
     "WnbaRegularSource", "WnbaPlayoffSource",

--- a/sources/boxing.py
+++ b/sources/boxing.py
@@ -1,0 +1,219 @@
+"""Boxing source: professional boxing fight cards via the Boxing Data API.
+
+Boxing is the same PRODUCT shape as UFC (see field_event.py's UfcSource):
+one broadcast unit per fight card, no two-team head-to-head, surface-if-
+toggled with no per-bout importance ranking. So it emits the SAME GameRow
+contract every field event uses:
+
+  - `home` = the card title ("Gassiev vs. Kadiru: IBA Pro 19")
+  - `away` = FIELD_AWAY_SENTINEL ("Field"), which flips is_field_event and
+    routes matching to the name-only, single-sided path (#127).
+  - `extra["is_field_event"] = True`, `extra["stage"]` in {"MAJOR","EVENT"}
+    (consumed by scoring's tournament_stage band exactly like golf/UFC),
+    `extra["fd_competition_code"] = "BOXING"`.
+
+DO NOT subclass FieldEventSource. That base hardcodes the ESPN site API
+(ESPN_SLUG + scoreboard range query), and ESPN exposes NO boxing feed
+(verified 2026-07-10: site + core APIs both 404 for boxing, while mma/ufc
+works). Boxing's upstream is a DIFFERENT API (RapidAPI Boxing Data API),
+so this is a standalone SportSource that reuses the field-event OUTPUT
+contract, not the ESPN FETCH plumbing. The output contract itself is
+single-sourced in _util.field_event_extra (shared with field_event.py), so
+downstream scoring/matching treats every field event identically.
+
+Free-tier constraints (verified live 2026-07-10 against the Boxing Data API):
+  - The subscription caps the queryable date range: `days=7` returns data,
+    `days>=14` returns {"error": {"code": "DateOutOfRange"}}. So we clamp
+    the lookahead to _FREE_TIER_MAX_DAYS. The plugin's lookahead_days
+    defaults to 7 anyway; a user who raises it just gets boxing capped.
+  - Some events carry a real time; others are date-only and come back as
+    T00:00:00 (no time). Combined with the feed's naive (no-offset) datetimes,
+    the effective start_time can sit up to a day off the actual broadcast, so
+    boxing gets a WIDENED EPG match window in plugin.py (name specificity,
+    not the clock, is the real discriminator for a rare, name-unique event).
+  - Cancelled cards keep "(Cancelled)" in the title; we drop them.
+
+The feed has no title-fight / championship flag, so like F1/NASCAR every
+card is EVENT tier by default; a conservative regex promotes the obvious
+championship cards to MAJOR.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, Optional, Pattern
+
+import requests
+
+from .base import GameRow, SportSource
+from .._util import FIELD_AWAY_SENTINEL, field_event_extra, parse_iso_utc
+
+logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.boxing")
+
+# RapidAPI gateway for the Boxing Data API (boxing-data.com). The key is a
+# RapidAPI key; the host header selects this API on the shared gateway.
+_RAPIDAPI_HOST = "boxing-data-api.p.rapidapi.com"
+_SCHEDULE_URL = f"https://{_RAPIDAPI_HOST}/v2/events/schedule"
+
+# Free-tier date-range cap. days>=14 returns DateOutOfRange (verified live
+# 2026-07-10). Raise this only after confirming a paid tier lifts the cap.
+_FREE_TIER_MAX_DAYS = 7
+
+# Conservative MAJOR detection. The feed exposes no championship flag, so we
+# read the card title: an explicit belt (WBC/WBA/IBF/WBO/IBO/The Ring) or an
+# "undisputed / world title / championship / vacant title" framing marks a
+# marquee card. Everything else stays EVENT, mirroring F1/NASCAR where every
+# entry is EVENT-tier. Kept deliberately tight to avoid false MAJORs: most
+# card titles are just "A vs. B: Promo Name" and correctly stay EVENT.
+_BOXING_MAJOR_RE: Pattern[str] = re.compile(
+    r"\b(?:undisputed|world\s+title|world\s+championship|"
+    r"unified|vacant\b.*\btitle|w\.?b\.?c\.?|w\.?b\.?a\.?|"
+    r"i\.?b\.?f\.?|w\.?b\.?o\.?|i\.?b\.?o\.?|the\s+ring)\b",
+    re.IGNORECASE,
+)
+
+# Cancelled cards carry this marker in the title (verified live 2026-07-10:
+# "Olascuaga vs. Dominguez (Cancelled): History in the Making").
+_CANCELLED_RE: Pattern[str] = re.compile(r"\(\s*cancell?ed\s*\)", re.IGNORECASE)
+
+# "A vs. B" head detector. The feed's titles are "Fighter vs. Fighter: Card
+# Name"; the fighters are the headliner.
+_VS_RE: Pattern[str] = re.compile(r"\bvs?\.?\b", re.IGNORECASE)
+
+
+def _match_name(title: str) -> str:
+    """The name the EPG matcher keys off. DO NOT return the full card title:
+    the matcher derives keyword variants (including a bare last-word fallback)
+    from this string, and a card title's promo suffix is generic. "... IBA
+    Pro 19" reduces to the keyword "19", "... Boxing 26" to "26", which
+    substring-match channel names and numbers wholesale (offline replay:
+    one such card matched 4388 channels, 2026-07-10). The Boxing Data API
+    formats every card as "Fighter vs. Fighter: Card Name", so when the pre-
+    colon head names the fighters we match on THAT alone (distinctive
+    surnames); only a title with no "vs." head falls back to the full string.
+    The full title is still used for MAJOR-tier detection and kept in extra."""
+    head = title.split(":", 1)[0].strip()
+    # Strip a trailing "(Cancelled)"-style parenthetical from the head so a
+    # non-cancelled parenthetical (e.g. "(II)") doesn't leak into keywords.
+    head = re.sub(r"\s*\([^)]*\)\s*$", "", head).strip()
+    if head and _VS_RE.search(head):
+        return head
+    return title
+
+
+class BoxingSource(SportSource):
+    """Professional boxing cards from the Boxing Data API (RapidAPI).
+
+    Requires an API key (RapidAPI key). Emits one GameRow per scheduled,
+    non-cancelled card using the shared field-event contract.
+    """
+
+    # supports_importance stays False (SportSource default): a boxing card is
+    # a field event, surfaced by the tournament_stage band alone, exactly like
+    # golf / UFC / racing. No Monte Carlo importance.
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    @property
+    def sport_prefix(self) -> str:
+        return "BOX"
+
+    @property
+    def sport_label(self) -> str:
+        return "Boxing"
+
+    def _headers(self) -> dict:
+        return {
+            "x-rapidapi-key": self.api_key,
+            "x-rapidapi-host": _RAPIDAPI_HOST,
+        }
+
+    def fetch_upcoming(self, days_ahead: int = 7) -> List[GameRow]:
+        """Pull upcoming boxing cards in the next `days_ahead` days (clamped to
+        the free-tier cap). Empty list on any error or when nothing is
+        scheduled; the caller does not filter by date."""
+        if not self.api_key:
+            logger.warning("[boxing] no Boxing Data API key; skipping")
+            return []
+        days = max(1, min(days_ahead, _FREE_TIER_MAX_DAYS))
+        params = {"days": days, "date_sort": "ASC", "page_size": 25}
+        data = self._http_get(_SCHEDULE_URL, params=params)
+        if not isinstance(data, dict):
+            return []
+        err = data.get("error")
+        if err:
+            # DateOutOfRange (or any subscription error) comes back in-band with
+            # HTTP 200 and an empty data list. Log and yield nothing rather than
+            # raising: a source that can't fetch should be a no-op, not a crash.
+            logger.warning("[boxing] API error: %s", err)
+            return []
+        events = data.get("data") or []
+        out: List[GameRow] = []
+        for ev in events:
+            row = self._to_row(ev)
+            if row is not None:
+                out.append(row)
+        logger.info("[boxing] %d card(s) in next %dd", len(out), days)
+        return out
+
+    def _to_row(self, ev: Any) -> Optional[GameRow]:
+        if not isinstance(ev, dict):
+            return None
+        title = (ev.get("title") or "").strip()
+        if not title:
+            return None
+        # Drop cancelled cards: surfacing a cancelled fight as a live channel
+        # is worse than omitting it.
+        if _CANCELLED_RE.search(title):
+            return None
+        start = parse_iso_utc(ev.get("date"))
+        if start is None:
+            return None
+        # MAJOR detection reads the FULL title: belt / "undisputed" framing
+        # usually lives in the promo suffix ("... Undisputed Super Middleweight").
+        stage = "MAJOR" if _BOXING_MAJOR_RE.search(title) else "EVENT"
+        # Matching keys off the fighters, not the promo suffix (see _match_name).
+        home = _match_name(title)
+        # US broadcasters, when present, are a useful debugging hint for which
+        # channel should carry the card; matching itself is name-driven.
+        broadcasters: List[str] = []
+        for b in ev.get("broadcast") or []:
+            if isinstance(b, dict) and (b.get("country") or "").upper() in ("US", "USA"):
+                broadcasters = [str(x) for x in (b.get("broadcasters") or [])]
+                break
+        return GameRow(
+            sport_prefix=self.sport_prefix,
+            sport_label=self.sport_label,
+            home=home,
+            away=FIELD_AWAY_SENTINEL,
+            rank_home=None,
+            rank_away=None,
+            start_time=start,
+            # Shared field-event contract via field_event_extra (single source
+            # of truth in _util); boxing-specific metadata rides in **extra and
+            # is informational only (not used for matching).
+            extra=field_event_extra(
+                "BOXING",
+                stage,
+                title,
+                full_title=title,
+                boxing_event_id=ev.get("id"),
+                venue=ev.get("venue"),
+                location=ev.get("location"),
+                us_broadcasters=broadcasters,
+                poster_image_url=ev.get("poster_image_url"),
+            ),
+        )
+
+    def _http_get(self, url: str, params: dict, timeout: float = 15.0) -> Optional[Any]:
+        try:
+            r = requests.get(url, params=params, headers=self._headers(), timeout=timeout)
+            if r.status_code >= 400:
+                logger.warning("[boxing] %s -> %d", url, r.status_code)
+                return None
+            return r.json()
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning("[boxing] %s failed: %s", url, exc)
+            return None

--- a/sources/field_event.py
+++ b/sources/field_event.py
@@ -36,7 +36,7 @@ from typing import Any, List, Optional, Pattern
 import requests
 
 from .base import GameRow, SportSource
-from .._util import FIELD_AWAY_SENTINEL, parse_iso_utc
+from .._util import FIELD_AWAY_SENTINEL, field_event_extra, parse_iso_utc
 
 logger = logging.getLogger("plugins.dispatcharr_ranked_matchups.field_event")
 
@@ -119,13 +119,12 @@ class FieldEventSource(SportSource):
                 rank_home=None,
                 rank_away=None,
                 start_time=start,
-                extra={
-                    "espn_event_id": eid,
-                    "fd_competition_code": self.FD_COMPETITION_CODE,
-                    "is_field_event": True,
-                    "stage": stage,
-                    "short_name": short_name,
-                },
+                extra=field_event_extra(
+                    self.FD_COMPETITION_CODE,
+                    stage,
+                    short_name,
+                    espn_event_id=eid,
+                ),
             ))
         return out
 

--- a/tests/test_boxing.py
+++ b/tests/test_boxing.py
@@ -1,0 +1,170 @@
+"""Tests for the Boxing source (sources/boxing.py).
+
+Network is never called: we monkeypatch `boxing.requests.get` with a fake
+response. The schedule payload below is a real capture from the Boxing Data
+API (2026-07-10), trimmed to the fields the parser reads, so the test pins the
+actual wire shape (naive datetimes, the '(Cancelled)' marker, the broadcast
+country array) rather than an invented one.
+"""
+
+import pytest
+
+from dispatcharr_ranked_matchups.sources import BoxingSource
+from dispatcharr_ranked_matchups.sources.base import SportSource
+from dispatcharr_ranked_matchups.sources import boxing as boxing_mod
+from dispatcharr_ranked_matchups._util import FIELD_AWAY_SENTINEL
+
+
+class FakeResp:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._p = payload
+
+    def json(self):
+        return self._p
+
+
+# Real capture (2026-07-10), trimmed. Note: naive datetimes (no offset), a
+# date-only card at T00:00:00, and a cancelled card carrying "(Cancelled)".
+_SCHEDULE_PAYLOAD = {
+    "metadata": {"timestamp": "2026-07-10T18:51:08+00:00"},
+    "pagination": {"page": 1, "items": 3, "total_pages": 1, "total_items": 3},
+    "error": None,
+    "data": [
+        {
+            "id": "6a11cfa967a83631b538dd83",
+            "title": "Gassiev vs. Kadiru: IBA Pro 19",
+            "date": "2026-07-11T15:00:00",
+            "venue": "VTB Arena",
+            "location": "Moscow, Russia",
+            "broadcast": [
+                {"country": "US", "broadcasters": ["DAZN"]},
+                {"country": "United Kingdom", "broadcasters": ["DAZN Global"]},
+            ],
+            "poster_image_url": "https://assets.boxing-data.com/x.jpg",
+        },
+        {
+            "id": "69fbd6dfe91967a315c29309",
+            "title": "Olascuaga vs. Dominguez (Cancelled): History in the Making",
+            "date": "2026-07-12T00:00:00",
+            "venue": "Civic Center",
+            "location": "San Francisco, California",
+            "broadcast": [{"country": "US", "broadcasters": ["ProBox TV US"]}],
+            "poster_image_url": None,
+        },
+        {
+            "id": "abc123",
+            "title": "Alvarez vs. Crawford: Undisputed Super Middleweight",
+            "date": "2026-07-13T02:00:00",
+            "venue": "Allegiant Stadium",
+            "location": "Las Vegas, Nevada",
+            "broadcast": [{"country": "US", "broadcasters": ["Netflix"]}],
+            "poster_image_url": None,
+        },
+    ],
+}
+
+
+class TestBoxingConstants:
+    def test_implements_interface(self):
+        assert issubclass(BoxingSource, SportSource)
+
+    def test_constants(self):
+        src = BoxingSource(api_key="x")
+        assert src.sport_prefix == "BOX"
+        assert src.sport_label == "Boxing"
+
+    def test_not_importance(self):
+        assert BoxingSource(api_key="x").supports_importance is False
+
+    def test_no_key_returns_empty(self):
+        assert BoxingSource(api_key="").fetch_upcoming() == []
+
+
+class TestBoxingParse:
+    def test_parses_and_drops_cancelled(self, monkeypatch):
+        monkeypatch.setattr(
+            boxing_mod.requests, "get", lambda *a, **kw: FakeResp(_SCHEDULE_PAYLOAD)
+        )
+        rows = BoxingSource(api_key="x").fetch_upcoming()
+        # 3 in the payload, the cancelled one dropped -> 2 rows.
+        assert len(rows) == 2
+        # home is the fighters portion (matcher keys off distinctive surnames,
+        # not the generic promo suffix); the full title is kept in extra.
+        homes = [r.home for r in rows]
+        assert "Gassiev vs. Kadiru" in homes
+        assert "Gassiev vs. Kadiru: IBA Pro 19" not in homes
+        full = [r.extra["full_title"] for r in rows]
+        assert "Gassiev vs. Kadiru: IBA Pro 19" in full
+        assert all("Cancelled" not in t for t in full)
+
+    def test_field_event_contract(self, monkeypatch):
+        monkeypatch.setattr(
+            boxing_mod.requests, "get", lambda *a, **kw: FakeResp(_SCHEDULE_PAYLOAD)
+        )
+        row = BoxingSource(api_key="x").fetch_upcoming()[0]
+        assert row.away == FIELD_AWAY_SENTINEL
+        assert row.rank_home is None and row.rank_away is None
+        assert row.extra["is_field_event"] is True
+        assert row.extra["fd_competition_code"] == "BOXING"
+        assert row.start_time.tzinfo is not None  # naive -> UTC-aware
+        assert row.extra["us_broadcasters"] == ["DAZN"]
+
+    def test_major_vs_event_tier(self, monkeypatch):
+        monkeypatch.setattr(
+            boxing_mod.requests, "get", lambda *a, **kw: FakeResp(_SCHEDULE_PAYLOAD)
+        )
+        rows = BoxingSource(api_key="x").fetch_upcoming()
+        by_full = {r.extra["full_title"]: r.extra["stage"] for r in rows}
+        # Plain promo card -> EVENT; explicit title/undisputed card -> MAJOR
+        # (MAJOR is detected on the full title, where the belt framing lives).
+        assert by_full["Gassiev vs. Kadiru: IBA Pro 19"] == "EVENT"
+        assert by_full["Alvarez vs. Crawford: Undisputed Super Middleweight"] == "MAJOR"
+
+    def test_error_envelope_returns_empty(self, monkeypatch):
+        payload = {"data": [], "error": {"code": "DateOutOfRange", "message": "x"}}
+        monkeypatch.setattr(
+            boxing_mod.requests, "get", lambda *a, **kw: FakeResp(payload)
+        )
+        assert BoxingSource(api_key="x").fetch_upcoming() == []
+
+    def test_lookahead_clamped_to_free_tier(self, monkeypatch):
+        captured = {}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            captured["params"] = params
+            captured["headers"] = headers
+            return FakeResp({"data": [], "error": None})
+
+        monkeypatch.setattr(boxing_mod.requests, "get", fake_get)
+        BoxingSource(api_key="x").fetch_upcoming(days_ahead=30)
+        # Free tier caps the queryable range; 30 must be clamped to 7.
+        assert captured["params"]["days"] == boxing_mod._FREE_TIER_MAX_DAYS
+        # And the RapidAPI auth headers must be sent.
+        assert captured["headers"]["x-rapidapi-key"] == "x"
+        assert captured["headers"]["x-rapidapi-host"] == boxing_mod._RAPIDAPI_HOST
+
+    def test_match_name_strips_promo_suffix(self):
+        # "Fighter vs. Fighter: Promo" -> fighters only (distinctive surnames);
+        # a generic promo suffix like "IBA Pro 19" must not leak into keywords.
+        assert boxing_mod._match_name("Gassiev vs. Kadiru: IBA Pro 19") == "Gassiev vs. Kadiru"
+        assert boxing_mod._match_name("Alvarez vs. Crawford: Undisputed") == "Alvarez vs. Crawford"
+
+    def test_match_name_falls_back_when_no_vs(self):
+        # A promo-only title (no "vs." head) has no fighters to isolate: keep
+        # the full title rather than inventing a name.
+        assert boxing_mod._match_name("Night of Champions XII") == "Night of Champions XII"
+
+    def test_match_name_ignores_trailing_parenthetical_in_head(self):
+        assert boxing_mod._match_name("Olascuaga vs. Dominguez (Cancelled): x") == "Olascuaga vs. Dominguez"
+
+    def test_http_error_status_returns_empty(self, monkeypatch):
+        class ErrResp:
+            status_code = 429
+
+            def json(self):
+                raise AssertionError("json() must not be read on a >=400 status")
+
+        monkeypatch.setattr(boxing_mod.requests, "get", lambda *a, **kw: ErrResp())
+        assert BoxingSource(api_key="x").fetch_upcoming() == []

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1558,6 +1558,35 @@ class TestComputePastSlotEnd:
         assert past_end.utcoffset().total_seconds() == 0
 
 
+class TestBuildSourcesBoxingGate:
+    """_build_sources wires the boxing source: gated on enable_boxing AND a
+    resolved Boxing Data API key (ESPN has no boxing feed, so unlike the ESPN
+    field events boxing REQUIRES a key). Enabled-without-key must be a no-op,
+    not a crash, mirroring the CFBD/FD-keyed sources."""
+
+    def _boxing(self, plugin, settings):
+        from dispatcharr_ranked_matchups.sources.boxing import BoxingSource
+        return [s for s in plugin._build_sources(settings) if isinstance(s, BoxingSource)]
+
+    def test_enabled_with_key_adds_source(self, plugin):
+        srcs = self._boxing(plugin, {
+            "enable_boxing": True,
+            "boxing_data_api_key": "test-key",
+        })
+        assert len(srcs) == 1
+        assert srcs[0].api_key == "test-key"
+
+    def test_enabled_without_key_is_noop(self, plugin):
+        # No key -> no source (and a warning), never a crash.
+        assert self._boxing(plugin, {"enable_boxing": True}) == []
+
+    def test_disabled_adds_nothing(self, plugin):
+        assert self._boxing(plugin, {
+            "enable_boxing": False,
+            "boxing_data_api_key": "test-key",
+        }) == []
+
+
 class TestEpgMatchWindow:
     """#4: per-sport match-window override. Soccer uses (5, 2.5) to avoid
     false-positives on pre-game preview programs; NCAAF / NFL keep
@@ -1585,6 +1614,15 @@ class TestEpgMatchWindow:
         pre, post = plugin._epg_match_window("CFB")
         assert pre == 30
         assert post == 4
+
+    def test_boxing_wide_window(self, plugin):
+        # Boxing (BOX) uses a WIDE window: the Boxing Data API's start times are
+        # unreliable (date-only T00:00:00 placeholders + naive datetimes), so a
+        # +/- ~1 day window absorbs the offset; the event-name keyword filter,
+        # not the clock, is the discriminator for a rare, name-unique card.
+        pre, post = plugin._epg_match_window("BOX")
+        assert pre == 12 * 60
+        assert post == 24.0
 
 
 class TestCurationPresets:

--- a/tests/test_recording_preservation.py
+++ b/tests/test_recording_preservation.py
@@ -215,3 +215,79 @@ class TestApplyPreservationWiring:
         assert "Channel.objects.filter(id__in=stale_ids)" not in src, (
             "unguarded all-stale channel delete must not return"
         )
+
+
+class TestArchiveChannelHasNumber:
+    """The archive channel MUST carry a non-null channel_number. A null number
+    makes Dispatcharr's XC EPG/stream-list generator raise KeyError mid-stream
+    (channel_num_map[channel.id]) and truncate the entire feed, so every Xtream
+    client sees an empty/failed playlist. This guards against regressing the
+    archive channel back to channel_number=None."""
+
+    @staticmethod
+    def _archive_source():
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        lines = open(PLUGIN_PY, encoding="utf-8").read().splitlines()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_ensure_archive_channel":
+                return "\n".join(lines[node.lineno - 1: node.end_lineno])
+        raise AssertionError("_ensure_archive_channel not found")
+
+    def test_create_assigns_a_number_not_none(self):
+        src = self._archive_source()
+        assert "channel_number=number" in src, (
+            "archive channel must be created with the resolved non-null number"
+        )
+        assert "channel_number=None" not in src, (
+            "archive channel must never be created with a null channel_number"
+        )
+        assert "_first_free_number(" in src and "_ARCHIVE_CHANNEL_NUMBER" in src, (
+            "number must come from _first_free_number seeded by _ARCHIVE_CHANNEL_NUMBER"
+        )
+
+    def test_constant_is_a_positive_int(self):
+        # Read the literal via AST without importing the Django-dependent module.
+        tree = ast.parse(open(PLUGIN_PY, encoding="utf-8").read(), filename=PLUGIN_PY)
+        value = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "_ARCHIVE_CHANNEL_NUMBER"
+                for t in node.targets
+            ):
+                value = ast.literal_eval(node.value)
+        assert isinstance(value, int) and value > 0, (
+            "_ARCHIVE_CHANNEL_NUMBER must be a positive int so the XC map is populated"
+        )
+
+    def test_self_heals_existing_null_archive(self):
+        src = self._archive_source()
+        # Existing installs already have a null-numbered archive channel; the
+        # function must repair it (via a signal-bypassing update), not only fix
+        # fresh creates.
+        assert "arch.channel_number is not None" in src, (
+            "must detect and pass through an already-numbered archive channel"
+        )
+        assert ".update(channel_number=number)" in src, (
+            "must backfill a pre-existing null-numbered archive channel via update()"
+        )
+
+
+class TestFirstFreeNumber:
+    """The shared collision-resolver used by both _assign_channel_numbers and
+    _ensure_archive_channel. Pure, so tested directly."""
+
+    def test_returns_start_when_free(self, plugin):
+        assert plugin._first_free_number(set(), 9999) == 9999
+        assert plugin._first_free_number({1, 2, 3}, 9999) == 9999
+
+    def test_bumps_past_a_run_of_taken_numbers(self, plugin):
+        assert plugin._first_free_number({9999}, 9999) == 10000
+        assert plugin._first_free_number({9999, 10000, 10001}, 9999) == 10002
+
+    def test_matches_float_used_values(self, plugin):
+        # Channel.channel_number is a float column, so the DB hands back floats;
+        # an int seed must still detect the clash (9999 == 9999.0).
+        assert plugin._first_free_number({9999.0}, 9999) == 10000
+
+    def test_returns_int(self, plugin):
+        assert isinstance(plugin._first_free_number({9999.0}, 9999), int)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -8,6 +8,8 @@ from dispatcharr_ranked_matchups.scoring import (
     TEAM_QUALIFIER_TOKENS,
     TEAM_SUFFIX_TOKENS,
     _compress_to_10,
+    _WC_KNOCKOUT_IMPORTANCE,
+    wc_knockout_importance,
     build_impact_narratives,
     compute_match_importance,
     format_channel_name,
@@ -955,3 +957,92 @@ class TestAdaptiveCompress:
         in_order = [i for _, i in pairs_in]
         out_order = [i for _, i in pairs_out]
         assert in_order == out_order
+
+
+class TestWorldCupKnockoutPremium:
+    """The WC knockout importance premium (_WC_KNOCKOUT_IMPORTANCE) is the
+    lever that makes a marquee Round-of-32 tie (France vs Sweden) rank as
+    premium content instead of scoring ~0.9 and never getting a placeholder
+    channel. plugin.py's scoring loop applies these values as importance_points
+    for WC knockout games; these tests pin the resulting displayed scores so a
+    silent change to the premium, the importance weight default, or the tanh
+    knee can't quietly re-break the World Cup guide.
+
+    The default placeholder_min_score is 5.0: EVERY knockout round must clear it
+    so an unmatched WC game still surfaces as a 'match pending' channel.
+    """
+
+    PLACEHOLDER_MIN = 5.0
+
+    def _final(self, stage):
+        sig = GameSignals(
+            team_a="A", team_b="B",
+            tournament_stage=stage,
+            importance_points=_WC_KNOCKOUT_IMPORTANCE[stage],
+            importance_notes=["World Cup knockout: win or go home"],
+        )
+        return score_game(sig, Weights()).final
+
+    # --- the pure gate (wc_knockout_importance), the runtime string match that
+    # decides WHEN the premium applies. Untested, a drift in the fd_competition_
+    # code value or stage casing silently no-ops and WC games regress. ---
+
+    def test_gate_returns_premium_for_each_wc_knockout_stage(self):
+        for stage, pts in _WC_KNOCKOUT_IMPORTANCE.items():
+            assert wc_knockout_importance("WC", stage) == pts
+
+    def test_gate_is_case_insensitive_on_stage(self):
+        # The source emits UPPER stages today, but the gate upper-cases so a
+        # lower/mixed-case label still resolves.
+        assert wc_knockout_importance("WC", "last_32") == _WC_KNOCKOUT_IMPORTANCE["LAST_32"]
+        assert wc_knockout_importance("WC", "Quarter_Finals") == _WC_KNOCKOUT_IMPORTANCE["QUARTER_FINALS"]
+
+    def test_gate_none_for_non_wc_competition(self):
+        # A UEFA / domestic-cup knockout emits the same stage labels but must
+        # NOT get the WC premium (Jake's ask is World Cup only).
+        assert wc_knockout_importance("CL", "QUARTER_FINALS") is None
+        assert wc_knockout_importance("PL", "LAST_16") is None
+
+    def test_gate_none_for_wc_group_stage(self):
+        # WC group games keep their Monte Carlo advancement importance; the
+        # premium must not clobber it.
+        assert wc_knockout_importance("WC", "GROUP_STAGE") is None
+
+    def test_gate_none_for_missing_or_unknown_stage(self):
+        assert wc_knockout_importance("WC", None) is None
+        assert wc_knockout_importance("WC", "") is None
+        assert wc_knockout_importance("WC", "REPLAY") is None
+        assert wc_knockout_importance(None, "LAST_32") is None
+
+    def test_every_knockout_stage_clears_placeholder_bar(self):
+        for stage in _WC_KNOCKOUT_IMPORTANCE:
+            assert self._final(stage) >= self.PLACEHOLDER_MIN, (
+                f"{stage} scored {self._final(stage)} < placeholder bar "
+                f"{self.PLACEHOLDER_MIN}; it would be skipped when unmatched"
+            )
+
+    def test_rounds_escalate_by_depth(self):
+        # Deeper rounds must outrank earlier ones (a Final beats a R32).
+        order = ["LAST_32", "LAST_16", "QUARTER_FINALS", "SEMI_FINALS", "FINAL"]
+        finals = [self._final(s) for s in order]
+        assert finals == sorted(finals), f"stages not monotonic: {finals}"
+
+    def test_displayed_targets_pinned(self):
+        # The calibrated targets at the default weights (importance=3.0,
+        # tournament=1.5). If these drift the guide ordering shifts.
+        assert round(self._final("LAST_32"), 1) == 5.5
+        assert round(self._final("LAST_16"), 1) == 6.5
+        assert round(self._final("QUARTER_FINALS"), 1) == 7.5
+        assert round(self._final("SEMI_FINALS"), 1) == 8.3
+        assert round(self._final("FINAL"), 1) == 9.2
+
+    def test_premium_dwarfs_pre_fix_bare_stage_score(self):
+        # Regression guard: pre-fix a LAST_32 with no importance scored the bare
+        # tournament band (~0.9). The premium must be a large, deliberate jump.
+        bare = score_game(
+            GameSignals(team_a="A", team_b="B", tournament_stage="LAST_32",
+                        importance_points=0.0),
+            Weights(),
+        ).final
+        assert bare < 1.0
+        assert self._final("LAST_32") - bare > 4.0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ from dispatcharr_ranked_matchups._util import (
     CHANNEL_NUMBER_TIEBREAK_SLOTS,
     FIELD_AWAY_SENTINEL,
     extract_game_number_after_marker,
+    field_event_extra,
     group_advance_text,
     group_phase_text,
     group_results_lines,
@@ -43,6 +44,32 @@ class TestIsFieldEvent:
         assert is_field_event("Field", {}) is True
         assert is_field_event("Field", {"is_field_event": False}) is True
         assert is_field_event("Arsenal", {"is_field_event": False}) is False
+
+
+class TestFieldEventExtra:
+    """Single source of truth for the field-event GameRow.extra contract,
+    shared by field_event.py (ESPN) and boxing.py (RapidAPI)."""
+
+    def test_core_contract_keys(self):
+        e = field_event_extra("PGA", "MAJOR", "The Masters")
+        assert e["is_field_event"] is True
+        assert e["fd_competition_code"] == "PGA"
+        assert e["stage"] == "MAJOR"
+        assert e["short_name"] == "The Masters"
+
+    def test_source_specific_extra_merged(self):
+        e = field_event_extra("BOXING", "EVENT", "A vs. B", boxing_event_id="x1", venue="Arena")
+        assert e["boxing_event_id"] == "x1"
+        assert e["venue"] == "Arena"
+        # Core keys still present alongside the source-specific ones.
+        assert e["is_field_event"] is True
+        assert e["fd_competition_code"] == "BOXING"
+
+    def test_the_two_field_event_sources_agree_on_core_keys(self):
+        espn = field_event_extra("UFC", "MAJOR", "UFC 309", espn_event_id="e1")
+        box = field_event_extra("BOXING", "EVENT", "A vs. B", boxing_event_id="b1")
+        core = {"is_field_event", "fd_competition_code", "stage", "short_name"}
+        assert core <= set(espn) and core <= set(box)
 
 
 class TestParseIsoUtc:


### PR DESCRIPTION
Brings `main` fully in line with what's running in prod. Three logical commits:

1. **Archive-channel null-number fix** (550f92b) — was deployed but never merged; a null channel number truncates the entire Xtream Codes feed. Merging closes the prod/main gap.
2. **World Cup knockout importance premium** — round-scaled importance for WC knockout ties (the Monte Carlo sim scores a binary win-or-go-home tie at 0, so a marquee R32 would fall under the placeholder bar). Gated to WC + knockout stage in the pure, unit-tested `wc_knockout_importance`.
3. **Boxing source** (Boxing Data API / RapidAPI) as a field event — new `Boxing` toggle + `Boxing Data API key` setting; ESPN has no boxing feed. Matches on the fighters portion (not the generic promo suffix, which false-matched 4388 channels in offline replay); widened EPG window for the feed's unreliable start times; cancelled cards dropped; conservative belt/undisputed → MAJOR. Field-event `extra` contract extracted to `_util.field_event_extra`.

## Status
- Deployed to prod (v1.11.0); this branch's `plugin.py` is byte-identical to the deployed file.
- Boxing is **disabled** in the owner's config by request (code present, off).
- 3327 tests pass. Live API + offline-EPG-snapshot verified for boxing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)