### PR TITLE
Fix: field-event title ending in a number matched every stream (UFC 329)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__/
 .idea/
 *.swp
 .DS_Store
+dg_snapshot.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ follows [Keep a Changelog](https://keepachangelog.com/) with semver.
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-11
+
+### Fixed
+- **Field-event titles ending in a number no longer match every stream.** The
+  EPG keyword pre-filter relaxes a name down to its last word so abbreviated
+  titles still hit, but a bare number is a substring of a huge fraction of
+  channel names and numbers. A UFC rematch card, `UFC 329: McGregor vs.
+  Holloway 2`, reduced to the keyword `2` and matched 8214 unrelated streams
+  (NASCAR, BMX, MLB feeds, `TVA Sports 2`, `Dota 2`, ...). The last-word
+  fallback now skips weak tokens (a bare number, or a 1-2 char token such as a
+  Roman-numeral rematch marker), so the card matches only genuine `UFC 329`
+  feeds and the broadcasters actually airing it. This is a shared-matcher
+  backstop, so every field-event source is protected, not just the boxing
+  source that sanitised its own titles. Not gated on `enable_boxing`; the bug
+  affected UFC (and any field event) independently.
+
 ## [1.11.0] - 2026-07-10
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -3,4 +3,4 @@
 from .plugin import Plugin
 
 __all__ = ["Plugin"]
-__version__ = "1.11.0"
+__version__ = "1.11.1"

--- a/matcher.py
+++ b/matcher.py
@@ -81,6 +81,27 @@ _GENERIC_LAST_WORDS = frozenset(
 )
 
 
+def _is_weak_last_word(token: str) -> bool:
+    """Whether a last-word fallback keyword would substring-match wholesale.
+
+    The last-word fallback in _team_keywords() relaxes a name down to its final
+    token so abbreviated EPG titles still hit. But a bare NUMBER or a 1-2 char
+    token is not a discriminator: it appears inside a huge fraction of channel
+    names and numbers, so as a case-insensitive substring it matches almost
+    everything. DO NOT emit it as a standalone keyword. This is exactly how a
+    field-event card whose title ends in a rematch number reduced to a wildcard:
+    'UFC 329: McGregor vs. Holloway 2' -> last word '2' -> 10593 tier-1 matches
+    (NASCAR/BMX/MLB feeds, 'TVA Sports 2', 'Dota 2', ...). Same shape the boxing
+    source pre-empts at the source ('... IBA Pro 19' -> '19'); this is the
+    shared-matcher backstop so EVERY source (UFC, and any future field event) is
+    protected, not just the ones that remembered to sanitise their own title.
+    The full-name and first-two-words keywords remain the real discriminators,
+    so dropping this bonus token only removes false positives, never the match.
+    """
+    t = token.strip().strip(".:,-")
+    return t.isdigit() or len(t) < 3
+
+
 @dataclass
 class ChannelCandidate:
     channel_id: int
@@ -133,7 +154,9 @@ def _team_keywords(team_name: str) -> List[str]:
     Returns ordered list of progressively-relaxed keywords. Always deduped.
     Drops the last-word fallback for generic-suffix names so 'Manchester
     United' never reduces to just 'United' (which would false-match
-    'Brentford v West Ham United').
+    'Brentford v West Ham United'), and for weak tokens (a bare number or a
+    1-2 char token) so a field-event title ending in a rematch number never
+    reduces to a wildcard like '2' (see _is_weak_last_word).
 
     Pulls broadcaster aliases from team_aliases.json: "Manchester United"
     expands to include "Man United" / "Man Utd" / "Man U" / "MUFC" so
@@ -154,7 +177,11 @@ def _team_keywords(team_name: str) -> List[str]:
         # Re-derive parts so subsequent rules see the canonical form.
         parts = stripped.split()
 
-    if len(parts) > 1 and parts[-1].lower() not in _GENERIC_LAST_WORDS:
+    if (
+        len(parts) > 1
+        and parts[-1].lower() not in _GENERIC_LAST_WORDS
+        and not _is_weak_last_word(parts[-1])
+    ):
         keywords.append(parts[-1])
     if len(parts) >= 2:
         # First two words (only meaningful for 3+ word names; for 2-word names

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jake (with Claude)",
   "license": "MIT",

--- a/sources/boxing.py
+++ b/sources/boxing.py
@@ -92,7 +92,14 @@ def _match_name(title: str) -> str:
     formats every card as "Fighter vs. Fighter: Card Name", so when the pre-
     colon head names the fighters we match on THAT alone (distinctive
     surnames); only a title with no "vs." head falls back to the full string.
-    The full title is still used for MAJOR-tier detection and kept in extra."""
+    The full title is still used for MAJOR-tier detection and kept in extra.
+
+    Layered with, NOT replaced by, matcher._is_weak_last_word: that shared
+    backstop drops a bare-number/1-2-char last word so ANY field event (UFC
+    included) is protected even without source-side cleaning. Keep BOTH: this
+    also yields a cleaner display/home and a fighter-surname keyword the
+    backstop alone cannot recover from a generic promo suffix. DO NOT delete
+    one as redundant."""
     head = title.split(":", 1)[0].strip()
     # Strip a trailing "(Cancelled)"-style parenthetical from the head so a
     # non-cancelled parenthetical (e.g. "(II)") doesn't leak into keywords.

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -37,6 +37,28 @@ class TestTeamKeywords:
         kws = _team_keywords("Boston College")
         assert "College" not in kws
 
+    def test_numeric_rematch_last_word_skipped(self):
+        # Regression (UFC 329 wildcard): a field-event title ending in a rematch
+        # number must NOT reduce to the bare number as a keyword. '2' is a
+        # substring of a huge fraction of channel names/numbers, so it dragged
+        # 'UFC 329: McGregor vs. Holloway 2' onto 8214 unrelated streams.
+        kws = _team_keywords("UFC 329: McGregor vs. Holloway 2")
+        assert "2" not in kws
+        # The real discriminators survive.
+        assert "UFC 329: McGregor vs. Holloway 2" in kws
+        assert "UFC 329:" in kws
+
+    def test_boxing_promo_number_last_word_skipped(self):
+        # Same shape from the boxing feed: '... IBA Pro 19' -> '19'.
+        kws = _team_keywords("Gassiev vs. Kadiru: IBA Pro 19")
+        assert "19" not in kws
+
+    def test_short_last_word_skipped(self):
+        # A 1-2 char last-word token (e.g. a Roman-numeral rematch marker) is
+        # also a wildcard and must not be emitted as a standalone keyword.
+        kws = _team_keywords("Ali vs. Frazier II")
+        assert "II" not in kws
+
     def test_first_two_words_added(self):
         kws = _team_keywords("North Carolina State")
         assert "North Carolina" in kws


### PR DESCRIPTION
## Problem

A user reported the plugin assigning "all these unrelated streams for the UFC tomorrow." Confirmed on my own instance (with `enable_boxing` OFF, `enable_ufc` ON): today's cache had `UFC 329: McGregor vs. Holloway 2` matched to **8214 streams / 2610 channels**, primary match a NASCAR multiview channel.

## Root cause

`matcher._team_keywords` relaxes an event name down to its **last word** so abbreviated EPG titles still hit. For a rematch card the last word is a bare number (`2`), which is a case-insensitive substring of a huge fraction of channel names/numbers, so it wildcard-matched everything (NASCAR, BMX, MLB, `TVA Sports 2`, `Dota 2`, ...).

This is **not** the boxing change: the boxing source already sanitises its own titles via `_match_name` (its docstring documents the identical `"... IBA Pro 19"` → `"19"` trap), but UFC and any other field event feed their raw title straight through the shared matcher. The bug affects UFC independently of `enable_boxing`.

## Fix

Add `_is_weak_last_word` and skip the last-word fallback for weak tokens (a bare number, or a 1-2 char token such as a Roman-numeral rematch marker). A shared-matcher backstop, so every field-event source is protected — not just the one that remembered to clean its titles. Display strings are untouched; the full-title and first-two-words keywords remain as the real discriminators.

## Live verification (offline replay against a fresh read-only snapshot of real data)

| | Before | After |
|---|---|---|
| UFC 329 candidates in window | 10,841 | 61 |
| tier-1 matches | 10,593 | 44 (every one names "UFC 329") |
| final assignment | 2610 chans / 8214 streams | 25 chans / 36 streams |
| primary | NASCAR multiview | DAZN UFC 329 feed |

Genuine broadcasters airing it (e.g. `TVA Sports 2`, EPG `"UFC 329: McGregor c. Holloway 2"`) still match via program title. Full-cache replay: **no other game regressed** (WC, F1, UFC Fight Night unchanged).

## Tests

3 new tests in `test_matcher.py`, **confirmed failing on the pre-fix matcher** with the exact symptom (`'2'`/`'19'`/`'II'` present in keywords) and green after. Full suite passes.

Version bumped to 1.11.1; CHANGELOG updated. Strengthened the boxing `_match_name` docstring to document the now-layered defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)