### PR TITLE
Fix: sync Plugin.version class attr to 1.11.1 + version-consistency test

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -3972,10 +3972,15 @@ _ACTION_HANDLERS = {
 
 class Plugin:
     name = "Ranked Matchups (Top Games)"
-    # Single source of truth for the displayed version: the loader uses this
-    # class attr over plugin.json's "version". Keep all three in sync
-    # (this attr, plugin.json, __init__.py __version__).
-    version = "1.11.0"
+    # The version the loader DISPLAYS: it prefers this class attr over
+    # plugin.json's "version" (manifest only fills gaps). The version lives in
+    # three places that must stay in sync (this attr, plugin.json,
+    # __init__.py __version__) because plugin.json must be a static literal the
+    # loader can read WITHOUT executing code, and __init__ imports plugin before
+    # it defines __version__ (so this attr can't source it without a circular
+    # import). tests/test_version_consistency.py enforces the three-way match;
+    # if you bump one, bump all three or that test fails.
+    version = "1.11.1"
 
     def __init__(self):
         # The scheduler reads settings live from the DB on each tick rather than

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,58 @@
+"""The plugin version lives in three places that must never drift.
+
+- plugin.json "version": must be a static literal (the loader reads the
+  manifest WITHOUT executing plugin code).
+- __init__.py __version__: the package version.
+- plugin.py `Plugin.version`: the class attr the loader DISPLAYS (it wins over
+  the manifest).
+
+They can't be collapsed to one Python source: __init__ imports plugin before it
+defines __version__ (circular import), and plugin.json has to stay literal. So
+this text-only test (no imports, runs without Django) is the backstop. It exists
+because a bump that touched plugin.json + __init__ but not the class attr shipped
+a plugin that displayed the wrong version (1.11.1 release, caught in prod deploy).
+"""
+import json
+import os
+import re
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(name):
+    with open(os.path.join(_ROOT, name), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _manifest_version():
+    return json.loads(_read("plugin.json"))["version"]
+
+
+def _init_version():
+    m = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', _read("__init__.py"), re.M)
+    assert m, "__version__ not found in __init__.py"
+    return m.group(1)
+
+
+def _class_version():
+    # First `version = "..."` inside plugin.py is the Plugin class attr.
+    m = re.search(r'^\s{4}version\s*=\s*["\']([^"\']+)["\']', _read("plugin.py"), re.M)
+    assert m, "Plugin.version class attr not found in plugin.py"
+    return m.group(1)
+
+
+def test_all_three_versions_match():
+    manifest = _manifest_version()
+    init = _init_version()
+    klass = _class_version()
+    assert manifest == init == klass, (
+        f"version drift: plugin.json={manifest!r}, __init__={init!r}, "
+        f"Plugin.version={klass!r} - bump all three together"
+    )
+
+
+def test_version_is_semver():
+    assert re.fullmatch(r"\d+\.\d+\.\d+", _manifest_version()), (
+        "plugin.json version must be strict X.Y.Z semver (the official-repo "
+        "validator rejects a 'v' prefix or non-semver)"
+    )


### PR DESCRIPTION
The loader displays `Plugin.version` over `plugin.json`; the 1.11.1 bump missed the class attr (caught during the prod deploy — the API reported 1.11.0). Bumps it and adds a text-only `test_version_consistency.py` enforcing the three-way match so this can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)